### PR TITLE
fix: chain multi-spawn game components to prevent stale entity ID

### DIFF
--- a/.changeset/fix-auto-iteration-stale-entity.md
+++ b/.changeset/fix-auto-iteration-stale-entity.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge-web": patch
+"web": patch
 ---
 
 Fix stale selectedEntityId when AI auto-iteration spawns multiple game-component entities in one batch

--- a/.changeset/fix-auto-iteration-stale-entity.md
+++ b/.changeset/fix-auto-iteration-stale-entity.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": patch
+---
+
+Fix stale selectedEntityId when AI auto-iteration spawns multiple game-component entities in one batch

--- a/web/src/lib/ai/__tests__/autoIteration.test.ts
+++ b/web/src/lib/ai/__tests__/autoIteration.test.ts
@@ -583,6 +583,76 @@ describe('applyFixes', () => {
     vi.useRealTimers();
   });
 
+  it('chains multi-spawn game components sequentially to prevent stale selectedEntityId (regression: #8311)', () => {
+    vi.useFakeTimers();
+    const dispatch = vi.fn();
+    // Return different entity IDs on successive calls
+    const getSelectedEntityId = vi.fn()
+      .mockReturnValueOnce('entity-checkpoint')
+      .mockReturnValueOnce('entity-collectible');
+    const fixes: IssueFix[] = [
+      {
+        issueId: 'issue-multi',
+        description: 'Add checkpoint and collectible',
+        changes: [
+          {
+            component: 'checkpoint',
+            property: 'autoSave',
+            oldValue: undefined,
+            newValue: true,
+            command: 'spawn_entity',
+          },
+          {
+            component: 'collectible',
+            property: 'value',
+            oldValue: undefined,
+            newValue: 10,
+            command: 'spawn_entity',
+          },
+        ],
+        confidence: 0.7,
+        estimatedImpact: 'Multiple spawns',
+      },
+    ];
+
+    applyFixes(fixes, dispatch, 1, getSelectedEntityId);
+
+    // First spawn dispatched immediately by processNext()
+    expect(dispatch).toHaveBeenCalledWith('spawn_entity', {
+      entityType: 'cube',
+      name: 'checkpoint',
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    // First frame: attach game component to first entity, then spawn second
+    vi.advanceTimersByTime(16);
+    expect(dispatch).toHaveBeenCalledWith('add_game_component', {
+      entityId: 'entity-checkpoint',
+      componentType: 'Checkpoint',
+      properties: { autoSave: true },
+    });
+
+    // Second frame: second spawn_entity
+    vi.advanceTimersByTime(16);
+    expect(dispatch).toHaveBeenCalledWith('spawn_entity', {
+      entityType: 'cube',
+      name: 'collectible',
+    });
+
+    // Third frame: attach second game component to second entity
+    vi.advanceTimersByTime(16);
+    expect(dispatch).toHaveBeenCalledWith('add_game_component', {
+      entityId: 'entity-collectible',
+      componentType: 'Collectible',
+      properties: { value: 10 },
+    });
+
+    // Each getSelectedEntityId call returned a DIFFERENT entity
+    expect(getSelectedEntityId).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
   it('does not schedule add_game_component for non-game-component spawns (e.g. light)', () => {
     vi.useFakeTimers();
     const dispatch = vi.fn();

--- a/web/src/lib/ai/autoIteration.ts
+++ b/web/src/lib/ai/autoIteration.ts
@@ -558,8 +558,10 @@ export function applyFixes(
             properties: { [item.property]: item.value },
           });
         }
-        // Process next spawn on the following frame
-        requestAnimationFrame(processNext);
+        // Process next spawn on the following frame (only if items remain)
+        if (idx < spawnQueue.length) {
+          requestAnimationFrame(processNext);
+        }
       });
     }
     processNext();

--- a/web/src/lib/ai/autoIteration.ts
+++ b/web/src/lib/ai/autoIteration.ts
@@ -479,9 +479,10 @@ const SPAWN_GAME_COMPONENTS: Record<string, string> = {
  * Returns an iteration report documenting what was changed.
  *
  * For spawn_entity changes with a game component type (checkpoint, collectible,
- * triggerZone), a follow-up add_game_component dispatch is scheduled on the
- * next animation frame so the engine has time to process the spawn and update
- * the selected entity ID.
+ * triggerZone), spawns are chained sequentially — each spawn waits one frame
+ * for the engine to update the selected entity ID, then attaches the component,
+ * then processes the next spawn. This prevents all components from attaching
+ * to the last spawned entity (bug #8311).
  */
 export function applyFixes(
   fixes: IssueFix[],
@@ -490,22 +491,35 @@ export function applyFixes(
   getSelectedEntityId?: () => string | null,
 ): IterationReport {
   const appliedFixes: IssueFix[] = [];
-  const pendingGameComponents: Array<{ component: string; property: string; value: unknown }> = [];
+  // Collect spawn commands that need game component attachment.
+  // These are dispatched sequentially (one per frame) so each
+  // getSelectedEntityId() call returns the correct entity.
+  const spawnQueue: Array<{
+    entityType: string;
+    name: string;
+    gameComponent: string;
+    property: string;
+    value: unknown;
+  }> = [];
 
   for (const fix of fixes) {
     for (const change of fix.changes) {
       if (change.command === 'spawn_entity') {
-        dispatch(change.command, {
-          entityType: SPAWN_ENTITY_TYPE_MAP[change.component] ?? 'cube',
-          name: change.component,
-        });
-        // Queue game component attachment for the next frame
         const gameComponentType = SPAWN_GAME_COMPONENTS[change.component];
-        if (gameComponentType) {
-          pendingGameComponents.push({
-            component: gameComponentType,
+        if (gameComponentType && getSelectedEntityId) {
+          // Queue for sequential dispatch
+          spawnQueue.push({
+            entityType: SPAWN_ENTITY_TYPE_MAP[change.component] ?? 'cube',
+            name: change.component,
+            gameComponent: gameComponentType,
             property: change.property,
             value: change.newValue,
+          });
+        } else {
+          // No game component needed — dispatch immediately
+          dispatch(change.command, {
+            entityType: SPAWN_ENTITY_TYPE_MAP[change.component] ?? 'cube',
+            name: change.component,
           });
         }
       } else if (change.command === 'update_ambient_light') {
@@ -523,20 +537,32 @@ export function applyFixes(
     appliedFixes.push(fix);
   }
 
-  // Attach game components after the engine processes the spawns
-  if (pendingGameComponents.length > 0 && getSelectedEntityId) {
-    requestAnimationFrame(() => {
-      for (const pending of pendingGameComponents) {
-        const entityId = getSelectedEntityId();
+  // Process spawn queue sequentially: spawn entity, wait a frame for the
+  // engine to update selectedEntityId, then attach the game component.
+  // Chains RAFs so each spawn-attach pair gets its own frame.
+  if (spawnQueue.length > 0 && getSelectedEntityId) {
+    let idx = 0;
+    function processNext() {
+      if (idx >= spawnQueue.length) return;
+      const item = spawnQueue[idx++];
+      dispatch('spawn_entity', {
+        entityType: item.entityType,
+        name: item.name,
+      });
+      requestAnimationFrame(() => {
+        const entityId = getSelectedEntityId!();
         if (entityId) {
           dispatch('add_game_component', {
             entityId,
-            componentType: pending.component,
-            properties: { [pending.property]: pending.value },
+            componentType: item.gameComponent,
+            properties: { [item.property]: item.value },
           });
         }
-      }
-    });
+        // Process next spawn on the following frame
+        requestAnimationFrame(processNext);
+      });
+    }
+    processNext();
   }
 
   const totalChanges = appliedFixes.reduce((sum, f) => sum + f.changes.length, 0);


### PR DESCRIPTION
## Summary
- When AI auto-iteration spawned multiple game-component entities in one batch, all `add_game_component` calls received the same (last) entity ID due to a shared `requestAnimationFrame`
- Fix: sequential RAF chaining via `processNext()` — each spawn waits for its attach to complete before spawning the next entity
- Regression test verifies `getSelectedEntityId` is called once per entity with distinct values

Closes #8311

## Test plan
- [x] `npx vitest run src/lib/ai/__tests__/autoIteration.test.ts` — 46/46 pass
- [x] ESLint zero warnings
- [x] TypeScript compiles clean