### PR TITLE
feat(engine): keyboard orbit_camera command + arrow-key viewport nav

### DIFF
--- a/.changeset/orbit-camera-keyboard.md
+++ b/.changeset/orbit-camera-keyboard.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add `orbit_camera` engine command and Arrow-key / `=` / `-` viewport navigation. Keyboard-only users can now orbit and zoom the editor camera without a mouse.

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -70,4 +70,22 @@ cp pkg-webgpu/*          "$WEB_PUBLIC/engine-pkg-webgpu/"
 cp pkg-webgl2-runtime/*  "$WEB_PUBLIC/engine-pkg-webgl2-runtime/"
 cp pkg-webgpu-runtime/*  "$WEB_PUBLIC/engine-pkg-webgpu-runtime/"
 
+# --- Generate content-hash manifests for cache-busting ---
+# useEngine.ts reads wasm-manifest.json to append ?v=<hash> to WASM URLs,
+# preventing browsers from serving stale binaries after a deployment.
+echo "=== Generating WASM content-hash manifests ==="
+for variant in engine-pkg-webgl2 engine-pkg-webgpu engine-pkg-webgl2-runtime engine-pkg-webgpu-runtime; do
+    dest_dir="$WEB_PUBLIC/$variant"
+    wasm_path="$dest_dir/forge_engine_bg.wasm"
+    if [ -f "$wasm_path" ]; then
+        # First 16 hex chars of SHA-256 (64 bits — sufficient for cache-busting)
+        short_hash=$(shasum -a 256 "$wasm_path" | awk '{print substr($1, 1, 16)}')
+        printf '{"wasmFile":"forge_engine_bg.wasm","jsFile":"forge_engine.js","hash":"%s"}' "$short_hash" \
+            > "$dest_dir/wasm-manifest.json"
+        echo "  $variant hash: $short_hash"
+    else
+        echo "  WARNING: $wasm_path not found, skipping manifest"
+    fi
+done
+
 echo "=== All WASM variants built successfully (editor + runtime) ==="

--- a/engine/src/core/camera.rs
+++ b/engine/src/core/camera.rs
@@ -20,6 +20,7 @@ impl Plugin for CameraControlPlugin {
             .init_resource::<CameraViewState>()
             .add_systems(Update, (
                 apply_pending_camera_focus,
+                apply_pending_camera_orbit,
                 focus_on_selection_system,
                 camera_presets::camera_preset_keyboard_system,
                 camera_presets::apply_camera_preset_system,
@@ -49,6 +50,43 @@ fn apply_pending_camera_focus(
             if let Ok(mut camera) = camera_query.single_mut() {
                 camera.target_focus = transform.translation;
             }
+        }
+    }
+}
+
+/// System that applies pending camera orbit requests (keyboard-driven deltas).
+///
+/// Adjusts `target_yaw`, `target_pitch`, `target_radius` on the editor camera
+/// so `bevy_panorbit_camera`'s built-in smoothing handles the transition.
+/// Pitch is clamped to avoid flipping past the poles; radius is clamped to
+/// a sensible floor so the camera can't zoom through the focus point.
+fn apply_pending_camera_orbit(
+    mut pending: ResMut<PendingCommands>,
+    mut camera_query: Query<&mut PanOrbitCamera, With<EditorCamera>>,
+) {
+    if pending.camera_orbit_requests.is_empty() {
+        return;
+    }
+
+    let Ok(mut camera) = camera_query.single_mut() else {
+        pending.camera_orbit_requests.clear();
+        return;
+    };
+
+    // Pitch clamp: ~89° each side. Past this, the orbit basis flips.
+    const PITCH_LIMIT: f32 = 1.55; // ~88.8°
+    // Radius floor — must be > 0 to avoid degenerate projection.
+    const MIN_RADIUS: f32 = 0.1;
+
+    for request in pending.camera_orbit_requests.drain(..) {
+        if let Some(dy) = request.delta_yaw {
+            camera.target_yaw += dy;
+        }
+        if let Some(dp) = request.delta_pitch {
+            camera.target_pitch = (camera.target_pitch + dp).clamp(-PITCH_LIMIT, PITCH_LIMIT);
+        }
+        if let Some(dr) = request.delta_radius {
+            camera.target_radius = (camera.target_radius + dr).max(MIN_RADIUS);
         }
     }
 }

--- a/engine/src/core/commands/mod.rs
+++ b/engine/src/core/commands/mod.rs
@@ -75,7 +75,7 @@ fn route_domain(command: &str) -> u8 {
         | "update_transform" | "set_camera" | "select_entity" | "select_entities"
         | "clear_selection" | "set_visibility" | "set_gizmo_mode"
         | "set_coordinate_mode" | "rename_entity" | "reparent_entity"
-        | "focus_camera" | "delete_entities" | "duplicate_entity"
+        | "focus_camera" | "orbit_camera" | "delete_entities" | "duplicate_entity"
         | "undo" | "redo" | "set_snap_settings" | "toggle_grid"
         | "set_camera_preset" | "set_input_binding" | "remove_input_binding"
         | "set_input_preset" | "get_input_bindings" | "get_input_state" => 0,

--- a/engine/src/core/commands/transform.rs
+++ b/engine/src/core/commands/transform.rs
@@ -8,12 +8,13 @@ use crate::core::{
     input::{ActionDef, ActionType, InputPreset, InputSource},
     pending_commands::{
         queue_transform_update_from_bridge, queue_rename_from_bridge, queue_camera_focus_from_bridge,
+        queue_camera_orbit_from_bridge,
         queue_spawn_from_bridge, queue_delete_from_bridge, queue_duplicate_from_bridge,
         queue_reparent_from_bridge, queue_snap_settings_update_from_bridge, queue_grid_toggle_from_bridge,
         queue_camera_preset_from_bridge, queue_coordinate_mode_update_from_bridge,
         queue_input_binding_update_from_bridge, queue_input_preset_from_bridge,
         queue_input_binding_removal_from_bridge,
-        TransformUpdate, RenameRequest, CameraFocusRequest, SpawnRequest, DeleteRequest, DuplicateRequest,
+        TransformUpdate, RenameRequest, CameraFocusRequest, CameraOrbitRequest, SpawnRequest, DeleteRequest, DuplicateRequest,
         ReparentRequest, SnapSettingsUpdate, CameraPresetRequest, EntityType,
         InputBindingUpdate, InputPresetRequest, InputBindingRemoval,
         QueryRequest, SelectionRequest, SelectionMode, queue_selection_from_bridge,
@@ -46,6 +47,7 @@ pub fn dispatch(command: &str, payload: &serde_json::Value) -> Option<CommandRes
         "rename_entity" => handle_rename_entity(payload.clone()),
         "reparent_entity" => handle_reparent_entity(payload.clone()),
         "focus_camera" => handle_focus_camera(payload.clone()),
+        "orbit_camera" => handle_orbit_camera(payload.clone()),
         "delete_entities" => handle_delete_entities(payload.clone()),
         "duplicate_entity" => handle_duplicate_entity(payload.clone()),
         "undo" => handle_undo(payload.clone()),
@@ -400,6 +402,52 @@ fn handle_focus_camera(payload: serde_json::Value) -> CommandResult {
 
     if queue_camera_focus_from_bridge(request) {
         tracing::info!("Queued camera focus on entity: {}", data.entity_id);
+        Ok(())
+    } else {
+        Err("PendingCommands resource not initialized".to_string())
+    }
+}
+
+/// Payload for orbit_camera command.
+/// All fields optional — apply whichever deltas are present.
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct OrbitCameraPayload {
+    delta_yaw: Option<f32>,
+    delta_pitch: Option<f32>,
+    delta_radius: Option<f32>,
+}
+
+/// Orbit the editor camera by delta yaw/pitch/radius (keyboard-driven).
+/// Payload: { deltaYaw?: number, deltaPitch?: number, deltaRadius?: number }
+fn handle_orbit_camera(payload: serde_json::Value) -> CommandResult {
+    let data: OrbitCameraPayload = serde_json::from_value(payload)
+        .map_err(|e| format!("Invalid orbit_camera payload: {}", e))?;
+
+    if data.delta_yaw.is_none() && data.delta_pitch.is_none() && data.delta_radius.is_none() {
+        return Err("orbit_camera requires at least one of deltaYaw, deltaPitch, deltaRadius".to_string());
+    }
+
+    // Reject non-finite values to prevent NaN/Infinity leaking into camera state.
+    for (name, v) in [
+        ("deltaYaw", data.delta_yaw),
+        ("deltaPitch", data.delta_pitch),
+        ("deltaRadius", data.delta_radius),
+    ] {
+        if let Some(n) = v {
+            if !n.is_finite() {
+                return Err(format!("{} must be finite", name));
+            }
+        }
+    }
+
+    let request = CameraOrbitRequest {
+        delta_yaw: data.delta_yaw,
+        delta_pitch: data.delta_pitch,
+        delta_radius: data.delta_radius,
+    };
+
+    if queue_camera_orbit_from_bridge(request) {
         Ok(())
     } else {
         Err("PendingCommands resource not initialized".to_string())
@@ -1014,6 +1062,38 @@ mod tests {
             err
         );
     }
+
+    // === orbit_camera ===
+
+    #[test]
+    fn orbit_camera_accepts_yaw_delta() {
+        let result = run("orbit_camera", json!({"deltaYaw": 0.1}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not initialized"));
+    }
+
+    #[test]
+    fn orbit_camera_accepts_radius_delta() {
+        let result = run("orbit_camera", json!({"deltaRadius": -1.0}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not initialized"));
+    }
+
+    #[test]
+    fn orbit_camera_rejects_empty_payload() {
+        let result = run("orbit_camera", json!({}));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("at least one"),
+            "Expected 'at least one' error, got: {}",
+            err
+        );
+    }
+
+    // Note: JSON can't represent NaN/Infinity, so the is_finite() guard in
+    // handle_orbit_camera protects against construction paths that don't go
+    // through serde_json (currently none, but cheap insurance).
 
     // === undo/redo ===
     // undo/redo use PENDING_HISTORY which is always initialized (thread-local with default value),

--- a/engine/src/core/pending/mod.rs
+++ b/engine/src/core/pending/mod.rs
@@ -126,6 +126,7 @@ pub struct PendingCommands {
     pub transform_updates: Vec<TransformUpdate>,
     pub rename_requests: Vec<RenameRequest>,
     pub camera_focus_requests: Vec<CameraFocusRequest>,
+    pub camera_orbit_requests: Vec<CameraOrbitRequest>,
     pub spawn_requests: Vec<SpawnRequest>,
     pub delete_requests: Vec<DeleteRequest>,
     pub duplicate_requests: Vec<DuplicateRequest>,

--- a/engine/src/core/pending/transform.rs
+++ b/engine/src/core/pending/transform.rs
@@ -27,6 +27,13 @@ pub struct CameraFocusRequest {
     pub entity_id: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct CameraOrbitRequest {
+    pub delta_yaw: Option<f32>,
+    pub delta_pitch: Option<f32>,
+    pub delta_radius: Option<f32>,
+}
+
 #[derive(Debug, Clone)]
 pub struct SpawnRequest {
     pub entity_type: super::EntityType,
@@ -105,6 +112,10 @@ impl PendingCommands {
         self.camera_focus_requests.push(request);
     }
 
+    pub fn queue_camera_orbit(&mut self, request: CameraOrbitRequest) {
+        self.camera_orbit_requests.push(request);
+    }
+
     pub fn queue_spawn(&mut self, request: SpawnRequest) {
         self.spawn_requests.push(request);
     }
@@ -170,6 +181,10 @@ pub fn queue_rename_from_bridge(request: RenameRequest) -> bool {
 
 pub fn queue_camera_focus_from_bridge(request: CameraFocusRequest) -> bool {
     super::with_pending(|pc| pc.queue_camera_focus(request)).is_some()
+}
+
+pub fn queue_camera_orbit_from_bridge(request: CameraOrbitRequest) -> bool {
+    super::with_pending(|pc| pc.queue_camera_orbit(request)).is_some()
 }
 
 pub fn queue_spawn_from_bridge(request: SpawnRequest) -> bool {

--- a/web/src/components/editor/CanvasArea.tsx
+++ b/web/src/components/editor/CanvasArea.tsx
@@ -15,6 +15,12 @@ import { UIRuntimeRenderer } from './ui-builder/UIRuntimeRenderer';
 
 const CANVAS_ID = 'game-canvas';
 
+// Keyboard orbit step sizes — kept small enough that held-key repeat feels
+// smooth, large enough that a single tap is perceptible.
+const ORBIT_YAW_STEP = 0.1;    // radians (~5.7°)
+const ORBIT_PITCH_STEP = 0.08; // radians (~4.6°)
+const ZOOM_STEP = 0.5;         // radius units
+
 /** Map keybinding action names to WASM engine commands. */
 const ACTION_COMMANDS: Record<string, (wasm: ReturnType<typeof getWasmModule>) => void> = {
   translate: (w) => w?.handle_command('set_gizmo_mode', { mode: 'translate' }),
@@ -26,6 +32,12 @@ const ACTION_COMMANDS: Record<string, (wasm: ReturnType<typeof getWasmModule>) =
   redo: (w) => w?.handle_command('redo', {}),
   focus: (w) => { const id = useEditorStore.getState().primaryId; if (id) w?.handle_command('focus_camera', { entityId: id }); },
   deselect: (w) => w?.handle_command('clear_selection', {}),
+  'orbit-left': (w) => w?.handle_command('orbit_camera', { deltaYaw: -ORBIT_YAW_STEP }),
+  'orbit-right': (w) => w?.handle_command('orbit_camera', { deltaYaw: ORBIT_YAW_STEP }),
+  'orbit-up': (w) => w?.handle_command('orbit_camera', { deltaPitch: ORBIT_PITCH_STEP }),
+  'orbit-down': (w) => w?.handle_command('orbit_camera', { deltaPitch: -ORBIT_PITCH_STEP }),
+  'zoom-in': (w) => w?.handle_command('orbit_camera', { deltaRadius: -ZOOM_STEP }),
+  'zoom-out': (w) => w?.handle_command('orbit_camera', { deltaRadius: ZOOM_STEP }),
 };
 
 export function CanvasArea() {

--- a/web/src/components/editor/CanvasArea.tsx
+++ b/web/src/components/editor/CanvasArea.tsx
@@ -34,8 +34,13 @@ const ACTION_COMMANDS: Record<string, (wasm: ReturnType<typeof getWasmModule>) =
   deselect: (w) => w?.handle_command('clear_selection', {}),
   'orbit-left': (w) => w?.handle_command('orbit_camera', { deltaYaw: -ORBIT_YAW_STEP }),
   'orbit-right': (w) => w?.handle_command('orbit_camera', { deltaYaw: ORBIT_YAW_STEP }),
-  'orbit-up': (w) => w?.handle_command('orbit_camera', { deltaPitch: ORBIT_PITCH_STEP }),
-  'orbit-down': (w) => w?.handle_command('orbit_camera', { deltaPitch: -ORBIT_PITCH_STEP }),
+  // Arrow Up/Down match mouse-drag convention: dragging up (negative screen-Y)
+  // tilts the view upward, which corresponds to a NEGATIVE pitch delta in
+  // bevy_panorbit_camera (positive pitch raises the camera above the target so
+  // the view tilts down to track it). Keeping arrows and mouse drag consistent
+  // avoids the "inverted controls" surprise flagged in #8338 review.
+  'orbit-up': (w) => w?.handle_command('orbit_camera', { deltaPitch: -ORBIT_PITCH_STEP }),
+  'orbit-down': (w) => w?.handle_command('orbit_camera', { deltaPitch: ORBIT_PITCH_STEP }),
   'zoom-in': (w) => w?.handle_command('orbit_camera', { deltaRadius: -ZOOM_STEP }),
   'zoom-out': (w) => w?.handle_command('orbit_camera', { deltaRadius: ZOOM_STEP }),
 };

--- a/web/src/components/editor/__tests__/CanvasArea.test.tsx
+++ b/web/src/components/editor/__tests__/CanvasArea.test.tsx
@@ -247,6 +247,32 @@ describe('CanvasArea', () => {
     expect(mockHandleCommand).not.toHaveBeenCalledWith('focus_camera', expect.anything());
   });
 
+  // Regression: Sentry #8338 — Arrow Up/Down pitch signs were inverted relative
+  // to mouse-drag convention in bevy_panorbit_camera. Mouse drag up (screen-Y
+  // negative) tilts the view up, corresponding to a NEGATIVE pitch delta.
+  // Arrow Up must match mouse drag up → negative pitch.
+  it('ArrowUp dispatches orbit_camera with NEGATIVE deltaPitch (tilts view up)', () => {
+    mockEditorStore();
+    const { container } = render(<CanvasArea />);
+    const canvas = container.querySelector('canvas')!;
+    fireEvent.keyDown(canvas, { key: 'ArrowUp' });
+    const call = mockHandleCommand.mock.calls.find(([cmd]) => cmd === 'orbit_camera');
+    expect(call).toBeDefined();
+    const payload = call![1] as { deltaPitch: number };
+    expect(payload.deltaPitch).toBeLessThan(0);
+  });
+
+  it('ArrowDown dispatches orbit_camera with POSITIVE deltaPitch (tilts view down)', () => {
+    mockEditorStore();
+    const { container } = render(<CanvasArea />);
+    const canvas = container.querySelector('canvas')!;
+    fireEvent.keyDown(canvas, { key: 'ArrowDown' });
+    const call = mockHandleCommand.mock.calls.find(([cmd]) => cmd === 'orbit_camera');
+    expect(call).toBeDefined();
+    const payload = call![1] as { deltaPitch: number };
+    expect(payload.deltaPitch).toBeGreaterThan(0);
+  });
+
   it('Escape in paused mode dispatches stop', () => {
     mockEditorStore({ engineMode: 'paused' });
     const { container } = render(<CanvasArea />);

--- a/web/src/lib/workspace/keybindings.ts
+++ b/web/src/lib/workspace/keybindings.ts
@@ -43,6 +43,14 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
   { action: 'delete', label: 'Delete selected', category: 'Scene', defaultKey: 'Delete', customKey: null, context: 'canvas' },
   { action: 'focus', label: 'Focus on selected', category: 'Scene', defaultKey: 'F', customKey: null, context: 'canvas' },
 
+  // Camera orbit (keyboard navigation of 3D viewport)
+  { action: 'orbit-left', label: 'Orbit camera left', category: 'Camera', defaultKey: 'ArrowLeft', customKey: null, context: 'canvas' },
+  { action: 'orbit-right', label: 'Orbit camera right', category: 'Camera', defaultKey: 'ArrowRight', customKey: null, context: 'canvas' },
+  { action: 'orbit-up', label: 'Orbit camera up', category: 'Camera', defaultKey: 'ArrowUp', customKey: null, context: 'canvas' },
+  { action: 'orbit-down', label: 'Orbit camera down', category: 'Camera', defaultKey: 'ArrowDown', customKey: null, context: 'canvas' },
+  { action: 'zoom-in', label: 'Zoom camera in', category: 'Camera', defaultKey: '=', customKey: null, context: 'canvas' },
+  { action: 'zoom-out', label: 'Zoom camera out', category: 'Camera', defaultKey: '-', customKey: null, context: 'canvas' },
+
   // View
   { action: 'view-top', label: 'Top view', category: 'View', defaultKey: '1', customKey: null },
   { action: 'view-front', label: 'Front view', category: 'View', defaultKey: '2', customKey: null },


### PR DESCRIPTION
## Summary

Implements the `orbit_camera` engine command (Rust/WASM) and wires Arrow keys / `=` / `-` to dispatch it from the canvas, giving keyboard-only users viewport navigation parity with mouse orbit.

- `CameraOrbitRequest` pending queue entry with `deltaYaw` / `deltaPitch` / `deltaRadius`
- `apply_pending_camera_orbit` Bevy system applies deltas to `PanOrbitCamera.target_yaw/pitch/radius` with pitch clamped to ±1.55 rad and radius ≥ 0.1
- Command-layer handler with NaN/Infinity guards + 3 unit tests
- `keybindings.ts` Camera category: `ArrowLeft/Right/Up/Down` = orbit, `=`/`-` = zoom
- `CanvasArea.tsx` dispatches via new `ACTION_COMMANDS` entries
- `build_wasm.sh` now generates `wasm-manifest.json` (parity with `build_wasm.ps1`) so local bash builds don't 404 on the cache-bust hash
- All 4 WASM variants (webgl2 / webgpu / webgl2-runtime / webgpu-runtime) rebuilt, wasm-opt'd, and deployed to R2 CDN under hash `51611a6fad38cddd`

Closes #8255

## Test plan

- [x] `cargo test -p forge-engine --target wasm32-unknown-unknown` — 3 new orbit_camera tests pass
- [x] WASM build successful (47 MB → 22 MB after wasm-opt)
- [x] All 4 variants uploaded to R2, `engine.spawnforge.ai` returns HTTP 200 for each
- [x] Manifest hash served correctly at each variant URL
- [ ] Smoke test Arrow keys + `=`/`-` in editor canvas (needs deploy)
- [ ] CI quality gate passes