### PR TITLE
feat(infra): automate monthly Neon PITR verification (#8212)

### DIFF
--- a/.github/workflows/pitr-verify.yml
+++ b/.github/workflows/pitr-verify.yml
@@ -1,0 +1,85 @@
+name: PITR Verification
+
+on:
+  schedule:
+    # 08:00 UTC on the 1st of each month
+    - cron: '0 8 1 * *'
+  workflow_dispatch:
+    inputs:
+      hours_ago:
+        description: 'How far back to recover from (hours)'
+        required: false
+        default: '24'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  verify:
+    name: Verify Neon PITR
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+      NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+      HOURS_AGO: ${{ github.event.inputs.hours_ago || '24' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install psql
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Run unit tests for driver
+        run: node --test scripts/pitr-verify.test.mjs
+
+      - name: Run PITR verification
+        id: verify
+        run: node scripts/pitr-verify.mjs
+
+      - name: Summary
+        if: always()
+        env:
+          OUTCOME: ${{ steps.verify.outcome }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          {
+            echo "# PITR Verification"
+            echo ""
+            echo "- Result: **${OUTCOME}**"
+            echo "- Recovered from: ${HOURS_AGO}h ago"
+            echo "- Run: ${RUN_ID}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        env:
+          HOURS_AGO: ${{ env.HOURS_AGO }}
+        with:
+          script: |
+            const title = `PITR verification failed (${new Date().toISOString().slice(0, 10)})`;
+            const body = [
+              `Scheduled PITR verification failed.`,
+              ``,
+              `**Run:** https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              `**Hours ago:** ${process.env.HOURS_AGO}`,
+              ``,
+              `See \`docs/database-backup-restore.md\` for the manual recovery procedure.`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['priority-p0', 'area-infra', 'disaster-recovery'],
+            });

--- a/docs/database-backup-restore.md
+++ b/docs/database-backup-restore.md
@@ -181,9 +181,25 @@ If any check fails, review the detailed output, adjust the PITR timestamp, and r
 
 ---
 
-## 5. Backup Verification Checklist (Monthly)
+## 5. Backup Verification
 
-Run this checklist on the first Monday of each month. Estimated time: 15 minutes.
+### Automated (monthly)
+
+A scheduled GitHub Actions workflow exercises PITR end-to-end on the 1st of each month:
+
+- **Workflow:** `.github/workflows/pitr-verify.yml`
+- **Driver:** `scripts/pitr-verify.mjs`
+- **Script:** `scripts/verify-db-backup.sh` (runs against the recovery branch)
+- **Trigger:** `schedule: '0 8 1 * *'` or `workflow_dispatch` with optional `hours_ago` input
+- **Required secrets:** `NEON_API_KEY`, `NEON_PROJECT_ID` (both configured in repo settings)
+
+The driver creates a read-only Neon branch from `(now - HOURS_AGO)`, waits for the branch operations to finish, runs `verify-db-backup.sh` against the recovery branch's connection URI, and deletes the branch in a `finally` block regardless of outcome. On scheduled failures the workflow opens a P0 issue tagged `priority-p0, area-infra, disaster-recovery`.
+
+Run it manually at any time from the Actions tab → **PITR Verification** → **Run workflow**.
+
+### Manual Checklist (optional backstop)
+
+Run this checklist on the first Monday of each month if the automated workflow has been disabled. Estimated time: 15 minutes.
 
 ```
 [ ] 1. Confirm Neon project exists and main branch is healthy

--- a/scripts/pitr-verify.mjs
+++ b/scripts/pitr-verify.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * pitr-verify.mjs
+ *
+ * Drives a full Neon Point-in-Time-Recovery verification end-to-end:
+ *
+ *   1. Creates a read-only Neon branch from (now - HOURS_AGO hours).
+ *   2. Waits for the branch's create_branch operation to finish.
+ *   3. Runs scripts/verify-db-backup.sh against the branch connection URI.
+ *   4. Deletes the branch in a finally block — always, even on failure.
+ *
+ * Usage:
+ *   NEON_API_KEY=napi_xxx \
+ *   NEON_PROJECT_ID=fragrant-moon-12345 \
+ *   HOURS_AGO=24 \
+ *     node scripts/pitr-verify.mjs
+ *
+ * Exit codes:
+ *   0  all checks passed
+ *   1  verification script reported failures
+ *   2  missing required env var
+ *   3  Neon API error (create/poll/delete)
+ *   4  operation timed out
+ *
+ * Ticket: #8212 — PITR never tested.
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const NEON_API_BASE = 'https://console.neon.tech/api/v2';
+const POLL_INTERVAL_MS = 2000;
+const POLL_TIMEOUT_MS = 120000;
+
+export class PitrError extends Error {
+  constructor(message, exitCode) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+}
+
+export function formatBranchName(date) {
+  const iso = date.toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `pitr-verify-${iso}`;
+}
+
+export function computeParentTimestamp(now, hoursAgo) {
+  const offset = Number(hoursAgo);
+  if (!Number.isFinite(offset) || offset <= 0) {
+    throw new PitrError(`HOURS_AGO must be a positive number, got: ${hoursAgo}`, 2);
+  }
+  const ts = new Date(now.getTime() - offset * 60 * 60 * 1000);
+  return ts.toISOString();
+}
+
+export function buildBranchPayload({ parentTimestamp, branchName }) {
+  return {
+    branch: {
+      parent_timestamp: parentTimestamp,
+      name: branchName,
+    },
+    endpoints: [{ type: 'read_only' }],
+  };
+}
+
+export function parseCreateResponse(json) {
+  const branchId = json?.branch?.id;
+  const connectionUri = json?.connection_uris?.[0]?.connection_uri;
+  const operations = Array.isArray(json?.operations) ? json.operations : [];
+  const operationIds = operations.map(op => op?.id).filter(Boolean);
+
+  if (!branchId) {
+    throw new PitrError('Neon response missing branch.id', 3);
+  }
+  if (!connectionUri) {
+    throw new PitrError('Neon response missing connection_uris[0].connection_uri', 3);
+  }
+  return { branchId, connectionUri, operationIds };
+}
+
+export function isOperationDone(json) {
+  const status = json?.operation?.status;
+  if (status === 'finished') return { done: true, ok: true };
+  if (status === 'failed' || status === 'error' || status === 'cancelled') {
+    return { done: true, ok: false, status };
+  }
+  return { done: false };
+}
+
+async function neonFetch(fetchFn, { method, path: urlPath, apiKey, body }) {
+  const url = `${NEON_API_BASE}${urlPath}`;
+  const res = await fetchFn(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new PitrError(
+      `Neon API ${method} ${urlPath} failed: ${res.status} ${res.statusText} — ${text.slice(0, 400)}`,
+      3,
+    );
+  }
+  try {
+    return text.length ? JSON.parse(text) : {};
+  } catch {
+    throw new PitrError(`Neon API returned non-JSON body: ${text.slice(0, 200)}`, 3);
+  }
+}
+
+export async function waitForOperation({ fetchFn, projectId, apiKey, operationId, sleepFn, now }) {
+  const deadline = now() + POLL_TIMEOUT_MS;
+  while (now() < deadline) {
+    const json = await neonFetch(fetchFn, {
+      method: 'GET',
+      path: `/projects/${projectId}/operations/${operationId}`,
+      apiKey,
+    });
+    const status = isOperationDone(json);
+    if (status.done) {
+      if (!status.ok) {
+        throw new PitrError(`Operation ${operationId} ended with status=${status.status}`, 3);
+      }
+      return;
+    }
+    await sleepFn(POLL_INTERVAL_MS);
+  }
+  throw new PitrError(`Operation ${operationId} did not finish within ${POLL_TIMEOUT_MS}ms`, 4);
+}
+
+export function runVerifyScript({ connectionUri, scriptPath, spawnFn }) {
+  return new Promise((resolve, reject) => {
+    const child = spawnFn('bash', [scriptPath], {
+      env: { ...process.env, NEON_VERIFY_DB_URL: connectionUri },
+      stdio: 'inherit',
+    });
+    child.on('error', reject);
+    child.on('exit', code => resolve(code ?? 1));
+  });
+}
+
+export async function main({ env, fetchFn, spawnFn, sleepFn, now, log, scriptPath }) {
+  const apiKey = env.NEON_API_KEY;
+  const projectId = env.NEON_PROJECT_ID;
+  const hoursAgo = env.HOURS_AGO ?? '24';
+
+  if (!apiKey) throw new PitrError('NEON_API_KEY is required', 2);
+  if (!projectId) throw new PitrError('NEON_PROJECT_ID is required', 2);
+
+  const parentTimestamp = computeParentTimestamp(new Date(now()), hoursAgo);
+  const branchName = formatBranchName(new Date(now()));
+  log(`Creating recovery branch "${branchName}" from ${parentTimestamp}`);
+
+  const createJson = await neonFetch(fetchFn, {
+    method: 'POST',
+    path: `/projects/${projectId}/branches`,
+    apiKey,
+    body: buildBranchPayload({ parentTimestamp, branchName }),
+  });
+
+  const { branchId, connectionUri, operationIds } = parseCreateResponse(createJson);
+  log(`Branch created: ${branchId} (${operationIds.length} operations pending)`);
+
+  let verifyExitCode = 1;
+  try {
+    for (const opId of operationIds) {
+      log(`Waiting for operation ${opId}...`);
+      await waitForOperation({ fetchFn, projectId, apiKey, operationId: opId, sleepFn, now });
+    }
+    log('Branch ready. Running verification script...');
+    verifyExitCode = await runVerifyScript({ connectionUri, scriptPath, spawnFn });
+    log(`Verification script exited with code ${verifyExitCode}`);
+  } finally {
+    log(`Deleting branch ${branchId}...`);
+    try {
+      await neonFetch(fetchFn, {
+        method: 'DELETE',
+        path: `/projects/${projectId}/branches/${branchId}`,
+        apiKey,
+      });
+      log('Branch deleted.');
+    } catch (err) {
+      log(`WARN: failed to delete branch ${branchId}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  return verifyExitCode === 0 ? 0 : 1;
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMain) {
+  const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'verify-db-backup.sh');
+  main({
+    env: process.env,
+    fetchFn: globalThis.fetch,
+    spawnFn: spawn,
+    sleepFn: ms => new Promise(r => setTimeout(r, ms)),
+    now: () => Date.now(),
+    log: msg => console.log(`[pitr-verify] ${msg}`),
+    scriptPath,
+  })
+    .then(code => process.exit(code))
+    .catch(err => {
+      if (err instanceof PitrError) {
+        console.error(`[pitr-verify] FATAL: ${err.message}`);
+        process.exit(err.exitCode);
+      }
+      console.error('[pitr-verify] FATAL:', err);
+      process.exit(1);
+    });
+}

--- a/scripts/pitr-verify.mjs
+++ b/scripts/pitr-verify.mjs
@@ -163,11 +163,11 @@ export async function main({ env, fetchFn, spawnFn, sleepFn, now, log, scriptPat
     body: buildBranchPayload({ parentTimestamp, branchName }),
   });
 
-  const { branchId, connectionUri, operationIds } = parseCreateResponse(createJson);
-  log(`Branch created: ${branchId} (${operationIds.length} operations pending)`);
-
+  const branchId = createJson?.branch?.id;
   let verifyExitCode = 1;
   try {
+    const { connectionUri, operationIds } = parseCreateResponse(createJson);
+    log(`Branch created: ${branchId} (${operationIds.length} operations pending)`);
     for (const opId of operationIds) {
       log(`Waiting for operation ${opId}...`);
       await waitForOperation({ fetchFn, projectId, apiKey, operationId: opId, sleepFn, now });
@@ -176,16 +176,18 @@ export async function main({ env, fetchFn, spawnFn, sleepFn, now, log, scriptPat
     verifyExitCode = await runVerifyScript({ connectionUri, scriptPath, spawnFn });
     log(`Verification script exited with code ${verifyExitCode}`);
   } finally {
-    log(`Deleting branch ${branchId}...`);
-    try {
-      await neonFetch(fetchFn, {
-        method: 'DELETE',
-        path: `/projects/${projectId}/branches/${branchId}`,
-        apiKey,
-      });
-      log('Branch deleted.');
-    } catch (err) {
-      log(`WARN: failed to delete branch ${branchId}: ${err instanceof Error ? err.message : err}`);
+    if (branchId) {
+      log(`Deleting branch ${branchId}...`);
+      try {
+        await neonFetch(fetchFn, {
+          method: 'DELETE',
+          path: `/projects/${projectId}/branches/${branchId}`,
+          apiKey,
+        });
+        log('Branch deleted.');
+      } catch (err) {
+        log(`WARN: failed to delete branch ${branchId}: ${err instanceof Error ? err.message : err}`);
+      }
     }
   }
 

--- a/scripts/pitr-verify.test.mjs
+++ b/scripts/pitr-verify.test.mjs
@@ -1,0 +1,566 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PitrError,
+  formatBranchName,
+  computeParentTimestamp,
+  buildBranchPayload,
+  parseCreateResponse,
+  isOperationDone,
+  waitForOperation,
+  runVerifyScript,
+  main,
+} from './pitr-verify.mjs';
+
+describe('formatBranchName', () => {
+  test('produces filesystem-safe branch name from Date', () => {
+    const d = new Date('2026-04-11T19:04:38.123Z');
+    assert.equal(formatBranchName(d), 'pitr-verify-2026-04-11T19-04-38');
+  });
+});
+
+describe('computeParentTimestamp', () => {
+  test('subtracts the given hours from now', () => {
+    const now = new Date('2026-04-11T12:00:00Z');
+    assert.equal(computeParentTimestamp(now, 24), '2026-04-10T12:00:00.000Z');
+  });
+
+  test('accepts numeric string', () => {
+    const now = new Date('2026-04-11T12:00:00Z');
+    assert.equal(computeParentTimestamp(now, '6'), '2026-04-11T06:00:00.000Z');
+  });
+
+  test('rejects zero', () => {
+    assert.throws(() => computeParentTimestamp(new Date(), 0), PitrError);
+  });
+
+  test('rejects negative', () => {
+    assert.throws(() => computeParentTimestamp(new Date(), -1), PitrError);
+  });
+
+  test('rejects non-numeric', () => {
+    assert.throws(() => computeParentTimestamp(new Date(), 'abc'), PitrError);
+  });
+
+  test('error carries exit code 2', () => {
+    try {
+      computeParentTimestamp(new Date(), 0);
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.equal(e.exitCode, 2);
+    }
+  });
+});
+
+describe('buildBranchPayload', () => {
+  test('shapes the Neon branch-create request body', () => {
+    const body = buildBranchPayload({
+      parentTimestamp: '2026-04-10T12:00:00.000Z',
+      branchName: 'pitr-verify-2026-04-11T12-00-00',
+    });
+    assert.deepEqual(body, {
+      branch: {
+        parent_timestamp: '2026-04-10T12:00:00.000Z',
+        name: 'pitr-verify-2026-04-11T12-00-00',
+      },
+      endpoints: [{ type: 'read_only' }],
+    });
+  });
+});
+
+describe('parseCreateResponse', () => {
+  test('extracts branch id, connection uri, and operation ids', () => {
+    const json = {
+      branch: { id: 'br_abc' },
+      connection_uris: [{ connection_uri: 'postgres://user:pw@host/db' }],
+      operations: [{ id: 'op_1' }, { id: 'op_2' }],
+    };
+    assert.deepEqual(parseCreateResponse(json), {
+      branchId: 'br_abc',
+      connectionUri: 'postgres://user:pw@host/db',
+      operationIds: ['op_1', 'op_2'],
+    });
+  });
+
+  test('handles missing operations array', () => {
+    const json = {
+      branch: { id: 'br_abc' },
+      connection_uris: [{ connection_uri: 'postgres://host/db' }],
+    };
+    assert.deepEqual(parseCreateResponse(json).operationIds, []);
+  });
+
+  test('throws if branch.id is missing', () => {
+    assert.throws(
+      () => parseCreateResponse({ connection_uris: [{ connection_uri: 'x' }] }),
+      PitrError,
+    );
+  });
+
+  test('throws if connection_uri is missing', () => {
+    assert.throws(() => parseCreateResponse({ branch: { id: 'br_abc' } }), PitrError);
+  });
+
+  test('filters falsy operation ids', () => {
+    const json = {
+      branch: { id: 'br_abc' },
+      connection_uris: [{ connection_uri: 'x' }],
+      operations: [{ id: 'op_1' }, { id: null }, {}],
+    };
+    assert.deepEqual(parseCreateResponse(json).operationIds, ['op_1']);
+  });
+});
+
+describe('isOperationDone', () => {
+  test('finished → done + ok', () => {
+    assert.deepEqual(isOperationDone({ operation: { status: 'finished' } }), {
+      done: true,
+      ok: true,
+    });
+  });
+
+  test('failed → done + not ok', () => {
+    const r = isOperationDone({ operation: { status: 'failed' } });
+    assert.equal(r.done, true);
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 'failed');
+  });
+
+  test('error → done + not ok', () => {
+    assert.equal(isOperationDone({ operation: { status: 'error' } }).ok, false);
+  });
+
+  test('cancelled → done + not ok', () => {
+    assert.equal(isOperationDone({ operation: { status: 'cancelled' } }).ok, false);
+  });
+
+  test('running → not done', () => {
+    assert.deepEqual(isOperationDone({ operation: { status: 'running' } }), { done: false });
+  });
+
+  test('missing status → not done', () => {
+    assert.deepEqual(isOperationDone({}), { done: false });
+  });
+});
+
+function makeFetch(responses) {
+  const calls = [];
+  const fetchFn = async (url, init) => {
+    calls.push({ url, init });
+    const next = responses.shift();
+    if (!next) throw new Error(`no more mocked responses for ${url}`);
+    return {
+      ok: next.ok,
+      status: next.status ?? (next.ok ? 200 : 500),
+      statusText: next.statusText ?? '',
+      text: async () => next.body ?? '',
+    };
+  };
+  return { fetchFn, calls };
+}
+
+describe('waitForOperation', () => {
+  test('resolves when first poll returns finished', async () => {
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: JSON.stringify({ operation: { status: 'finished' } }) },
+    ]);
+    const sleeps = [];
+    await waitForOperation({
+      fetchFn,
+      projectId: 'proj_1',
+      apiKey: 'napi_xxx',
+      operationId: 'op_1',
+      sleepFn: async (ms) => sleeps.push(ms),
+      now: () => 1000,
+    });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /\/projects\/proj_1\/operations\/op_1$/);
+    assert.equal(calls[0].init.headers.Authorization, 'Bearer napi_xxx');
+    assert.equal(sleeps.length, 0);
+  });
+
+  test('polls until finished', async () => {
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: JSON.stringify({ operation: { status: 'running' } }) },
+      { ok: true, body: JSON.stringify({ operation: { status: 'running' } }) },
+      { ok: true, body: JSON.stringify({ operation: { status: 'finished' } }) },
+    ]);
+    let t = 0;
+    const sleeps = [];
+    await waitForOperation({
+      fetchFn,
+      projectId: 'p',
+      apiKey: 'k',
+      operationId: 'o',
+      sleepFn: async (ms) => {
+        sleeps.push(ms);
+        t += ms;
+      },
+      now: () => t,
+    });
+    assert.equal(calls.length, 3);
+    assert.deepEqual(sleeps, [2000, 2000]);
+  });
+
+  test('throws PitrError with exitCode 3 when operation fails', async () => {
+    const { fetchFn } = makeFetch([
+      { ok: true, body: JSON.stringify({ operation: { status: 'failed' } }) },
+    ]);
+    try {
+      await waitForOperation({
+        fetchFn,
+        projectId: 'p',
+        apiKey: 'k',
+        operationId: 'op_bad',
+        sleepFn: async () => {},
+        now: () => 0,
+      });
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e instanceof PitrError);
+      assert.equal(e.exitCode, 3);
+      assert.match(e.message, /op_bad/);
+    }
+  });
+
+  test('throws PitrError with exitCode 4 on timeout', async () => {
+    const { fetchFn } = makeFetch([
+      { ok: true, body: JSON.stringify({ operation: { status: 'running' } }) },
+    ]);
+    let t = 0;
+    try {
+      await waitForOperation({
+        fetchFn,
+        projectId: 'p',
+        apiKey: 'k',
+        operationId: 'op_slow',
+        sleepFn: async (ms) => {
+          t += ms + 200_000;
+        },
+        now: () => t,
+      });
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e instanceof PitrError);
+      assert.equal(e.exitCode, 4);
+    }
+  });
+
+  test('throws PitrError with exitCode 3 on non-2xx', async () => {
+    const { fetchFn } = makeFetch([
+      { ok: false, status: 401, statusText: 'Unauthorized', body: 'bad key' },
+    ]);
+    try {
+      await waitForOperation({
+        fetchFn,
+        projectId: 'p',
+        apiKey: 'k',
+        operationId: 'o',
+        sleepFn: async () => {},
+        now: () => 0,
+      });
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e instanceof PitrError);
+      assert.equal(e.exitCode, 3);
+      assert.match(e.message, /401/);
+    }
+  });
+});
+
+describe('runVerifyScript', () => {
+  test('resolves with child exit code and sets NEON_VERIFY_DB_URL env', async () => {
+    const spawned = [];
+    const spawnFn = (cmd, args, opts) => {
+      spawned.push({ cmd, args, opts });
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(0));
+      return child;
+    };
+    const code = await runVerifyScript({
+      connectionUri: 'postgres://host/db',
+      scriptPath: '/tmp/verify.sh',
+      spawnFn,
+    });
+    assert.equal(code, 0);
+    assert.equal(spawned[0].cmd, 'bash');
+    assert.deepEqual(spawned[0].args, ['/tmp/verify.sh']);
+    assert.equal(spawned[0].opts.env.NEON_VERIFY_DB_URL, 'postgres://host/db');
+    assert.equal(spawned[0].opts.stdio, 'inherit');
+  });
+
+  test('rejects on child error', async () => {
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.error?.(new Error('spawn failed')));
+      return child;
+    };
+    await assert.rejects(
+      runVerifyScript({ connectionUri: 'x', scriptPath: '/tmp/x.sh', spawnFn }),
+      /spawn failed/,
+    );
+  });
+
+  test('treats null exit code as failure (1)', async () => {
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(null));
+      return child;
+    };
+    const code = await runVerifyScript({
+      connectionUri: 'x',
+      scriptPath: '/tmp/x.sh',
+      spawnFn,
+    });
+    assert.equal(code, 1);
+  });
+});
+
+function makeEnv(overrides = {}) {
+  return {
+    NEON_API_KEY: 'napi_test',
+    NEON_PROJECT_ID: 'proj_test',
+    HOURS_AGO: '24',
+    ...overrides,
+  };
+}
+
+describe('main', () => {
+  test('creates branch, waits for ops, runs verify, deletes branch, returns 0', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_new' },
+      connection_uris: [{ connection_uri: 'postgres://host/db' }],
+      operations: [{ id: 'op_1' }],
+    });
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: true, body: JSON.stringify({ operation: { status: 'finished' } }) },
+      { ok: true, body: '{}' },
+    ]);
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(0));
+      return child;
+    };
+    const logs = [];
+    const code = await main({
+      env: makeEnv(),
+      fetchFn,
+      spawnFn,
+      sleepFn: async () => {},
+      now: () => Date.parse('2026-04-11T12:00:00Z'),
+      log: (m) => logs.push(m),
+      scriptPath: '/tmp/verify.sh',
+    });
+    assert.equal(code, 0);
+    assert.equal(calls.length, 3);
+    assert.equal(calls[0].init.method, 'POST');
+    assert.match(calls[0].url, /\/projects\/proj_test\/branches$/);
+    assert.equal(calls[2].init.method, 'DELETE');
+    assert.match(calls[2].url, /\/projects\/proj_test\/branches\/br_new$/);
+    assert.ok(logs.some((l) => l.includes('Branch deleted')));
+  });
+
+  test('deletes branch even when verify script fails, returns 1', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_new' },
+      connection_uris: [{ connection_uri: 'postgres://host/db' }],
+      operations: [{ id: 'op_1' }],
+    });
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: true, body: JSON.stringify({ operation: { status: 'finished' } }) },
+      { ok: true, body: '{}' },
+    ]);
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(2));
+      return child;
+    };
+    const code = await main({
+      env: makeEnv(),
+      fetchFn,
+      spawnFn,
+      sleepFn: async () => {},
+      now: () => Date.parse('2026-04-11T12:00:00Z'),
+      log: () => {},
+      scriptPath: '/tmp/verify.sh',
+    });
+    assert.equal(code, 1);
+    assert.equal(calls[2].init.method, 'DELETE');
+  });
+
+  test('deletes branch even when operation polling throws', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_new' },
+      connection_uris: [{ connection_uri: 'postgres://host/db' }],
+      operations: [{ id: 'op_1' }],
+    });
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: true, body: JSON.stringify({ operation: { status: 'failed' } }) },
+      { ok: true, body: '{}' },
+    ]);
+    await assert.rejects(
+      main({
+        env: makeEnv(),
+        fetchFn,
+        spawnFn: () => {
+          throw new Error('should not spawn');
+        },
+        sleepFn: async () => {},
+        now: () => Date.parse('2026-04-11T12:00:00Z'),
+        log: () => {},
+        scriptPath: '/tmp/verify.sh',
+      }),
+      PitrError,
+    );
+    assert.equal(calls[2].init.method, 'DELETE');
+  });
+
+  test('swallows delete failure with warning', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_new' },
+      connection_uris: [{ connection_uri: 'postgres://host/db' }],
+      operations: [],
+    });
+    const { fetchFn } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: false, status: 500, statusText: 'Server Error', body: 'boom' },
+    ]);
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(0));
+      return child;
+    };
+    const logs = [];
+    const code = await main({
+      env: makeEnv(),
+      fetchFn,
+      spawnFn,
+      sleepFn: async () => {},
+      now: () => Date.parse('2026-04-11T12:00:00Z'),
+      log: (m) => logs.push(m),
+      scriptPath: '/tmp/verify.sh',
+    });
+    assert.equal(code, 0);
+    assert.ok(logs.some((l) => l.startsWith('WARN: failed to delete branch')));
+  });
+
+  test('throws PitrError with exitCode 2 when NEON_API_KEY missing', async () => {
+    try {
+      await main({
+        env: makeEnv({ NEON_API_KEY: undefined }),
+        fetchFn: async () => {
+          throw new Error('should not fetch');
+        },
+        spawnFn: () => {
+          throw new Error('should not spawn');
+        },
+        sleepFn: async () => {},
+        now: () => 0,
+        log: () => {},
+        scriptPath: '/tmp/verify.sh',
+      });
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e instanceof PitrError);
+      assert.equal(e.exitCode, 2);
+      assert.match(e.message, /NEON_API_KEY/);
+    }
+  });
+
+  test('throws PitrError with exitCode 2 when NEON_PROJECT_ID missing', async () => {
+    try {
+      await main({
+        env: makeEnv({ NEON_PROJECT_ID: undefined }),
+        fetchFn: async () => {
+          throw new Error('should not fetch');
+        },
+        spawnFn: () => {
+          throw new Error('should not spawn');
+        },
+        sleepFn: async () => {},
+        now: () => 0,
+        log: () => {},
+        scriptPath: '/tmp/verify.sh',
+      });
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e instanceof PitrError);
+      assert.equal(e.exitCode, 2);
+      assert.match(e.message, /NEON_PROJECT_ID/);
+    }
+  });
+
+  test('sends parent_timestamp hours before now', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_new' },
+      connection_uris: [{ connection_uri: 'x' }],
+      operations: [],
+    });
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: true, body: '{}' },
+    ]);
+    const spawnFn = () => {
+      const listeners = {};
+      const child = {
+        on: (event, fn) => {
+          listeners[event] = fn;
+          return child;
+        },
+      };
+      setImmediate(() => listeners.exit?.(0));
+      return child;
+    };
+    await main({
+      env: makeEnv({ HOURS_AGO: '6' }),
+      fetchFn,
+      spawnFn,
+      sleepFn: async () => {},
+      now: () => Date.parse('2026-04-11T12:00:00Z'),
+      log: () => {},
+      scriptPath: '/tmp/verify.sh',
+    });
+    const postBody = JSON.parse(calls[0].init.body);
+    assert.equal(postBody.branch.parent_timestamp, '2026-04-11T06:00:00.000Z');
+    assert.equal(postBody.endpoints[0].type, 'read_only');
+  });
+});

--- a/scripts/pitr-verify.test.mjs
+++ b/scripts/pitr-verify.test.mjs
@@ -448,6 +448,34 @@ describe('main', () => {
     assert.equal(calls[2].init.method, 'DELETE');
   });
 
+  test('deletes branch when parseCreateResponse throws (missing connection_uris)', async () => {
+    const createBody = JSON.stringify({
+      branch: { id: 'br_leak' },
+      operations: [{ id: 'op_1' }],
+    });
+    const { fetchFn, calls } = makeFetch([
+      { ok: true, body: createBody },
+      { ok: true, body: '{}' },
+    ]);
+    await assert.rejects(
+      main({
+        env: makeEnv(),
+        fetchFn,
+        spawnFn: () => {
+          throw new Error('should not spawn');
+        },
+        sleepFn: async () => {},
+        now: () => Date.parse('2026-04-11T12:00:00Z'),
+        log: () => {},
+        scriptPath: '/tmp/verify.sh',
+      }),
+      (err) => err instanceof PitrError && err.message.includes('connection_uri'),
+    );
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1].init.method, 'DELETE');
+    assert.match(calls[1].url, /\/branches\/br_leak$/);
+  });
+
   test('swallows delete failure with warning', async () => {
     const createBody = JSON.stringify({
       branch: { id: 'br_new' },


### PR DESCRIPTION
## Summary

Automates the Neon PITR verification that `docs/database-backup-restore.md` has always prescribed but nobody actually ran. The monthly checklist and quarterly drill were never executed — this PR wires them into CI so PITR is exercised end-to-end on the 1st of each month.

## What this PR does

- **`scripts/pitr-verify.mjs`** — Node ES module that drives the Neon API:
  1. Creates a read-only branch from `(now - HOURS_AGO)` hours ago
  2. Polls the branch's `create_branch` operations until they finish
  3. Runs `scripts/verify-db-backup.sh` against the recovery branch's connection URI
  4. Deletes the branch in a `finally` block (always, even on failure)
- **`scripts/pitr-verify.test.mjs`** — 34 unit tests using Node's built-in `node --test` runner (zero external deps). Covers happy path, timeout, auth errors, verify script failure, cleanup invariants, missing env vars, and timestamp math.
- **`.github/workflows/pitr-verify.yml`** — Monthly cron (`0 8 1 * *`) + `workflow_dispatch` with optional `hours_ago` input. Installs `postgresql-client`, runs unit tests, then runs the driver. On scheduled failure, opens a P0 issue tagged `priority-p0, area-infra, disaster-recovery`.
- **`docs/database-backup-restore.md`** — New "Automated verification" section documenting the workflow, the required secrets, and how to trigger manually.

## Design choices

- **Testable by construction**: `main()` takes injected `fetchFn`, `spawnFn`, `sleepFn`, `now`, `log`, `scriptPath`. The real entrypoint only wires `globalThis.fetch`, `node:child_process.spawn`, `setTimeout`, and `Date.now` at the bottom of the file guarded by `fileURLToPath(import.meta.url) === path.resolve(process.argv[1])`.
- **Node's built-in test runner**: Root repo has no vitest config and adding one for a single infra script was overkill. `node --test` ships with Node 20+, needs zero deps, runs in GitHub Actions out of the box.
- **Cleanup is unconditional**: Branch deletion is in a `finally` block around both the wait-for-ops loop and the verify script, so a runaway test branch can't get left behind if anything throws. If the delete itself fails, the driver logs a `WARN` rather than masking the real failure.
- **Exit codes**: 0 pass, 1 verify failed, 2 missing env, 3 Neon API error, 4 timeout — so the workflow's "Open issue on failure" step can fire on any non-zero without losing the root cause.
- **P0 on scheduled failure only**: Manual runs via `workflow_dispatch` don't open issues so you can probe without noise.

## Required repo secrets (already configured)

- `NEON_API_KEY` — generated at Neon console → Account settings → API keys
- `NEON_PROJECT_ID` — from the Neon project settings

`DATABASE_URL` is not sufficient — that's a Postgres connection string, not an API credential. Creating/deleting branches requires the Neon API key.

Closes #8212

## Test plan

- [x] `node --test scripts/pitr-verify.test.mjs` — 34 tests pass locally
- [ ] After merge: Actions tab → PITR Verification → Run workflow (hours_ago=1) → confirm green
- [ ] Confirm the run-summary shows branch created, verify script ran, branch deleted
- [ ] Intentionally fail a future run (e.g. set HOURS_AGO to a value outside retention) to exercise the issue-creation path