### PR TITLE
feat: expose WASM command batching to JS for AI modules

### DIFF
--- a/.changeset/wasm-command-batching.md
+++ b/.changeset/wasm-command-batching.md
@@ -1,0 +1,5 @@
+---
+'spawnforge': minor
+---
+
+Expose WASM command batching to JS: `sendCommandBatch` on useEngine hook, `dispatchCommandBatch` on store/context interfaces. Migrated entitySetupExecutor and autoPolishExecutor to batch dispatch with sequential fallback.

--- a/web/src/hooks/__tests__/useEngine.test.ts
+++ b/web/src/hooks/__tests__/useEngine.test.ts
@@ -72,6 +72,17 @@ describe('useEngine', () => {
     consoleSpy.mockRestore();
   });
 
+  it('sendCommandBatch returns failure result when engine not initialized', () => {
+    const { result } = renderHook(() => useEngine('forge-canvas'));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const batchResult = result.current.sendCommandBatch([{ command: 'test', payload: {} }]);
+    expect(batchResult).toEqual({ success: false, results: [] });
+    expect(consoleSpy).toHaveBeenCalledWith('Engine not initialized');
+
+    consoleSpy.mockRestore();
+  });
+
   it('getWasmModule returns null when not initialized', async () => {
     const { getWasmModule } = await import('../useEngine');
     expect(getWasmModule()).toBeNull();

--- a/web/src/hooks/__tests__/useEngineEvents.test.ts
+++ b/web/src/hooks/__tests__/useEngineEvents.test.ts
@@ -131,6 +131,16 @@ describe('useEngineEvents', () => {
     expect(result).toEqual({ success: false, results: [] });
   });
 
+  it('batch dispatcher rejects oversized batches (>256)', () => {
+    renderHook(() => useEngineEvents({ wasmModule }));
+
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const oversized = Array.from({ length: 257 }, (_, i) => ({ command: `cmd_${i}` }));
+    const result = batchDispatcher(oversized);
+    expect(result).toEqual({ success: false, results: [] });
+    expect(wasmModule.handle_command_batch).not.toHaveBeenCalled();
+  });
+
   it('batch dispatcher catches errors and returns failure', () => {
     wasmModule.handle_command_batch.mockImplementation(() => { throw new Error('WASM batch crash'); });
     renderHook(() => useEngineEvents({ wasmModule }));

--- a/web/src/hooks/__tests__/useEngineEvents.test.ts
+++ b/web/src/hooks/__tests__/useEngineEvents.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useEngineEvents } from '../useEngineEvents';
-import { useEditorStore, setCommandDispatcher } from '@/stores/editorStore';
+import { useEditorStore, setCommandDispatcher, setCommandBatchDispatcher } from '@/stores/editorStore';
 import * as events from '../events';
 
 vi.mock('@/stores/editorStore', () => ({
@@ -35,6 +35,7 @@ describe('useEngineEvents', () => {
     wasmModule = {
       set_event_callback: vi.fn(),
       handle_command: vi.fn(),
+      handle_command_batch: vi.fn(),
     };
     
     // Silence console.warn for unknown events
@@ -99,6 +100,45 @@ describe('useEngineEvents', () => {
     expect(events.handleTransformEvent).toHaveBeenCalled();
     expect(events.handleEditModeEvent).toHaveBeenCalled();
     expect(console.warn).toHaveBeenCalledWith('Unknown engine event:', 'unknown_event');
+  });
+
+  it('registers batch command dispatcher on mount', () => {
+    renderHook(() => useEngineEvents({ wasmModule }));
+    expect(setCommandBatchDispatcher).toHaveBeenCalled();
+
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    wasmModule.handle_command_batch.mockReturnValue([
+      { success: true },
+      { success: true },
+    ]);
+    const result = batchDispatcher([
+      { command: 'spawn_entity', payload: { entityType: 'cube' } },
+      { command: 'update_transform', payload: { position: [0, 1, 0] } },
+    ]);
+    expect(wasmModule.handle_command_batch).toHaveBeenCalledWith([
+      { command: 'spawn_entity', payload: { entityType: 'cube' } },
+      { command: 'update_transform', payload: { position: [0, 1, 0] } },
+    ]);
+    expect(result).toEqual({ success: true, results: [{ success: true }, { success: true }] });
+  });
+
+  it('batch dispatcher returns failure when handle_command_batch is absent', () => {
+    delete wasmModule.handle_command_batch;
+    renderHook(() => useEngineEvents({ wasmModule }));
+
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const result = batchDispatcher([{ command: 'spawn_entity' }]);
+    expect(result).toEqual({ success: false, results: [] });
+  });
+
+  it('batch dispatcher catches errors and returns failure', () => {
+    wasmModule.handle_command_batch.mockImplementation(() => { throw new Error('WASM batch crash'); });
+    renderHook(() => useEngineEvents({ wasmModule }));
+
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const result = batchDispatcher([{ command: 'crash' }]);
+    expect(result).toEqual({ success: false, results: [] });
+    expect(console.error).toHaveBeenCalledWith('Error dispatching command batch:', expect.any(Error));
   });
 
   it('does nothing if wasmModule is null', () => {

--- a/web/src/hooks/__tests__/useEngineEvents.test.ts
+++ b/web/src/hooks/__tests__/useEngineEvents.test.ts
@@ -106,7 +106,7 @@ describe('useEngineEvents', () => {
     renderHook(() => useEngineEvents({ wasmModule }));
     expect(setCommandBatchDispatcher).toHaveBeenCalled();
 
-    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0]!;
     wasmModule.handle_command_batch.mockReturnValue([
       { success: true },
       { success: true },
@@ -122,19 +122,18 @@ describe('useEngineEvents', () => {
     expect(result).toEqual({ success: true, results: [{ success: true }, { success: true }] });
   });
 
-  it('batch dispatcher returns failure when handle_command_batch is absent', () => {
+  it('registers undefined batch dispatcher when handle_command_batch is absent', () => {
     delete wasmModule.handle_command_batch;
     renderHook(() => useEngineEvents({ wasmModule }));
 
     const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
-    const result = batchDispatcher([{ command: 'spawn_entity' }]);
-    expect(result).toEqual({ success: false, results: [] });
+    expect(batchDispatcher).toBeUndefined();
   });
 
   it('batch dispatcher rejects oversized batches (>256)', () => {
     renderHook(() => useEngineEvents({ wasmModule }));
 
-    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0]!;
     const oversized = Array.from({ length: 257 }, (_, i) => ({ command: `cmd_${i}` }));
     const result = batchDispatcher(oversized);
     expect(result).toEqual({ success: false, results: [] });
@@ -145,7 +144,7 @@ describe('useEngineEvents', () => {
     wasmModule.handle_command_batch.mockImplementation(() => { throw new Error('WASM batch crash'); });
     renderHook(() => useEngineEvents({ wasmModule }));
 
-    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0];
+    const batchDispatcher = vi.mocked(setCommandBatchDispatcher).mock.calls[0][0]!;
     const result = batchDispatcher([{ command: 'crash' }]);
     expect(result).toEqual({ success: false, results: [] });
     expect(console.error).toHaveBeenCalledWith('Error dispatching command batch:', expect.any(Error));

--- a/web/src/hooks/__tests__/useEngineEvents.test.ts
+++ b/web/src/hooks/__tests__/useEngineEvents.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/stores/editorStore', () => ({
     getState: vi.fn(),
   },
   setCommandDispatcher: vi.fn(),
+  setCommandBatchDispatcher: vi.fn(),
 }));
 
 vi.mock('../events', () => ({

--- a/web/src/hooks/useEngine.ts
+++ b/web/src/hooks/useEngine.ts
@@ -735,7 +735,7 @@ export function useEngine(canvasId: string, options?: UseEngineOptions) {
           phase: 'handle_command_batch',
           batchSize: commands.length,
         });
-        throw err;
+        return { success: false, results: [] };
       }
     },
     [],

--- a/web/src/hooks/useEngine.ts
+++ b/web/src/hooks/useEngine.ts
@@ -39,9 +39,20 @@ export function useLoadingState(): LoadingState {
   );
 }
 
+export interface CommandResponse {
+  success: boolean;
+  error?: string;
+}
+
+export interface BatchResult {
+  success: boolean;
+  results: CommandResponse[];
+}
+
 export type WasmModule = {
   init_engine: (canvasId: string) => void;
   handle_command: (command: string, payload: unknown) => unknown;
+  handle_command_batch: (batch: unknown) => unknown;
   set_init_callback: (callback: (phase: string, message?: string, error?: string) => void) => void;
   set_event_callback: (callback: (event: unknown) => void) => void;
 };
@@ -706,7 +717,31 @@ export function useEngine(canvasId: string, options?: UseEngineOptions) {
     []
   );
 
-  return { isReady, error, sendCommand, wasmModule };
+  const sendCommandBatch = useCallback(
+    (commands: Array<{ command: string; payload?: unknown }>): BatchResult => {
+      if (!wasmModule) {
+        console.warn('Engine not initialized');
+        return { success: false, results: [] };
+      }
+      try {
+        const results = wasmModule.handle_command_batch(commands) as CommandResponse[];
+        return {
+          success: results.every((r) => r.success),
+          results,
+        };
+      } catch (err) {
+        const batchError = err instanceof Error ? err : new Error(String(err));
+        captureException(batchError, {
+          phase: 'handle_command_batch',
+          batchSize: commands.length,
+        });
+        throw err;
+      }
+    },
+    [],
+  );
+
+  return { isReady, error, sendCommand, sendCommandBatch, wasmModule };
 }
 
 // Export for use by other hooks

--- a/web/src/hooks/useEngineEvents.ts
+++ b/web/src/hooks/useEngineEvents.ts
@@ -67,6 +67,10 @@ export function useEngineEvents({ wasmModule }: UseEngineEventsOptions): void {
 
   const dispatchCommandBatch = useCallback(
     (commands: Array<{ command: string; payload?: unknown }>) => {
+      if (commands.length > 256) {
+        console.error(`Batch size ${commands.length} exceeds limit of 256`);
+        return { success: false, results: [] };
+      }
       if (wasmModule?.handle_command_batch) {
         try {
           const results = wasmModule.handle_command_batch(commands) as Array<{ success: boolean; error?: string }>;

--- a/web/src/hooks/useEngineEvents.ts
+++ b/web/src/hooks/useEngineEvents.ts
@@ -6,7 +6,7 @@
  */
 
 import { useEffect, useCallback } from 'react';
-import { useEditorStore, setCommandDispatcher } from '@/stores/editorStore';
+import { useEditorStore, setCommandDispatcher, setCommandBatchDispatcher } from '@/stores/editorStore';
 import {
   handleTransformEvent,
   handleMaterialEvent,
@@ -42,6 +42,7 @@ interface UseEngineEventsOptions {
   wasmModule: {
     set_event_callback?: (callback: (event: unknown) => void) => void;
     handle_command?: (command: string, payload: unknown) => unknown;
+    handle_command_batch?: (batch: unknown) => unknown;
   } | null;
 }
 
@@ -64,12 +65,32 @@ export function useEngineEvents({ wasmModule }: UseEngineEventsOptions): void {
     [wasmModule]
   );
 
-  // Register command dispatcher with the store
+  const dispatchCommandBatch = useCallback(
+    (commands: Array<{ command: string; payload?: unknown }>) => {
+      if (wasmModule?.handle_command_batch) {
+        try {
+          const results = wasmModule.handle_command_batch(commands) as Array<{ success: boolean; error?: string }>;
+          return {
+            success: results.every((r) => r.success),
+            results,
+          };
+        } catch (error) {
+          console.error('Error dispatching command batch:', error);
+          return { success: false, results: [] };
+        }
+      }
+      return { success: false, results: [] };
+    },
+    [wasmModule],
+  );
+
+  // Register command dispatchers with the store
   useEffect(() => {
     if (wasmModule) {
       setCommandDispatcher(dispatchCommand);
+      setCommandBatchDispatcher(dispatchCommandBatch);
     }
-  }, [wasmModule, dispatchCommand]);
+  }, [wasmModule, dispatchCommand, dispatchCommandBatch]);
 
   // Register event callback with WASM
   useEffect(() => {

--- a/web/src/hooks/useEngineEvents.ts
+++ b/web/src/hooks/useEngineEvents.ts
@@ -92,7 +92,7 @@ export function useEngineEvents({ wasmModule }: UseEngineEventsOptions): void {
   useEffect(() => {
     if (wasmModule) {
       setCommandDispatcher(dispatchCommand);
-      setCommandBatchDispatcher(dispatchCommandBatch);
+      setCommandBatchDispatcher(wasmModule.handle_command_batch ? dispatchCommandBatch : undefined);
     }
   }, [wasmModule, dispatchCommand, dispatchCommandBatch]);
 

--- a/web/src/lib/chat/__tests__/errorScenarios.test.ts
+++ b/web/src/lib/chat/__tests__/errorScenarios.test.ts
@@ -43,6 +43,7 @@ vi.mock('../handlers/compoundHandlers', () => ({ compoundHandlers: {} }));
 // ── Mock editorStore ──────────────────────────────────────────────────────────
 vi.mock('@/stores/editorStore', () => ({
   getCommandDispatcher: mocks.getCommandDispatcher,
+  getCommandBatchDispatcher: vi.fn().mockReturnValue(null),
 }));
 
 import { executeToolCall } from '../executor';

--- a/web/src/lib/chat/__tests__/executorDispatch.test.ts
+++ b/web/src/lib/chat/__tests__/executorDispatch.test.ts
@@ -45,6 +45,7 @@ vi.mock('../handlers/compoundHandlers', () => ({ compoundHandlers: {} }));
 // ── Mock editorStore ──────────────────────────────────────────────────────────
 vi.mock('@/stores/editorStore', () => ({
   getCommandDispatcher: mocks.getCommandDispatcher,
+  getCommandBatchDispatcher: vi.fn().mockReturnValue(null),
 }));
 
 import { executeToolCall } from '../executor';

--- a/web/src/lib/chat/__tests__/executorIntegration.test.ts
+++ b/web/src/lib/chat/__tests__/executorIntegration.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('@/stores/editorStore', () => ({
   getCommandDispatcher: () => mocks.dispatchCommand,
+  getCommandBatchDispatcher: () => null,
   // Provide the EditorState type stub so handler imports don't crash
   useEditorStore: { getState: () => ({}) },
 }));

--- a/web/src/lib/chat/__tests__/executorLegacy.test.ts
+++ b/web/src/lib/chat/__tests__/executorLegacy.test.ts
@@ -17,6 +17,7 @@ import type { EditorState, SceneNode } from '@/stores/editorStore';
 // ── Mock getCommandDispatcher (required by executor.ts wrapper) ───────────────
 vi.mock('@/stores/editorStore', () => ({
   getCommandDispatcher: vi.fn(() => vi.fn()),
+  getCommandBatchDispatcher: vi.fn(() => null),
 }));
 
 import { executeToolCall } from '../executor';

--- a/web/src/lib/chat/executor.ts
+++ b/web/src/lib/chat/executor.ts
@@ -4,7 +4,7 @@
  */
 
 import type { EditorState } from '@/stores/editorStore';
-import { getCommandDispatcher } from '@/stores/editorStore';
+import { getCommandDispatcher, getCommandBatchDispatcher } from '@/stores/editorStore';
 import type { ToolCallContext, ExecutionResult } from './handlers/types';
 
 // Import all handler registries
@@ -127,11 +127,13 @@ export async function executeToolCall(
 ): Promise<ExecutionResult> {
   try {
     const dispatch = getCommandDispatcher();
+    const batchDispatch = getCommandBatchDispatcher();
     const ctx: ToolCallContext = {
       store,
       dispatchCommand: dispatch ?? ((_cmd: string, _payload: unknown) => {
         console.warn('Command dispatcher not initialized');
       }),
+      dispatchCommandBatch: batchDispatch ?? undefined,
     };
     const handler = handlerRegistry[toolName];
 

--- a/web/src/lib/chat/handlers/types.ts
+++ b/web/src/lib/chat/handlers/types.ts
@@ -8,6 +8,7 @@ import type { EditorState } from '@/stores/editorStore';
 export interface ToolCallContext {
   store: EditorState;
   dispatchCommand: (command: string, payload: unknown) => void;
+  dispatchCommandBatch?: (commands: Array<{ command: string; payload?: unknown }>) => import('@/hooks/useEngine').BatchResult;
 }
 
 export type ToolHandler = (

--- a/web/src/lib/game-creation/__tests__/executors.test.ts
+++ b/web/src/lib/game-creation/__tests__/executors.test.ts
@@ -437,6 +437,51 @@ describe('entity_setup executor', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
   });
+
+  it('uses dispatchCommandBatch when available', async () => {
+    const batchFn = vi.fn().mockReturnValue({
+      success: true,
+      results: [{ success: true }, { success: true }],
+    });
+    const ctx = makeMockCtx({ dispatchCommandBatch: batchFn });
+    const result = await executor.execute(
+      { entity: baseEntity, scene: 'Level 1', projectType: '3d' },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(batchFn).toHaveBeenCalledWith([
+      { command: 'switch_scene', payload: { sceneId: 'Level 1' } },
+      { command: 'spawn_entity', payload: { entityType: 'cube', name: 'Enemy' } },
+    ]);
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('falls back to sequential dispatch when batch unavailable', async () => {
+    const ctx = makeMockCtx();
+    const result = await executor.execute(
+      { entity: baseEntity, scene: 'Level 1', projectType: '3d' },
+      ctx,
+    );
+
+    expect(result.success).toBe(true);
+    expect(ctx.dispatchCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns failure when batch reports a command error', async () => {
+    const batchFn = vi.fn().mockReturnValue({
+      success: false,
+      results: [{ success: true }, { success: false, error: 'Entity limit reached' }],
+    });
+    const ctx = makeMockCtx({ dispatchCommandBatch: batchFn });
+    const result = await executor.execute(
+      { entity: baseEntity, scene: 'Level 1', projectType: '3d' },
+      ctx,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('COMMAND_FAILED');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -820,5 +865,50 @@ describe('auto_polish executor', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('uses dispatchCommandBatch when available', async () => {
+    const batchFn = vi.fn().mockReturnValue({
+      success: true,
+      results: [{ success: true }, { success: true }],
+    });
+    const ctx = makeMockCtx({ dispatchCommandBatch: batchFn });
+    vi.mocked(ctx.resolveStepOutput).mockReturnValue({
+      issues: ['no_ambient_light', 'no_ground_plane'],
+    });
+    const result = await executor.execute(baseInput, ctx);
+
+    expect(result.success).toBe(true);
+    expect(batchFn).toHaveBeenCalledWith([
+      { command: 'update_ambient_light', payload: { color: [1, 1, 1], brightness: 0.3 } },
+      { command: 'spawn_entity', payload: { entityType: 'plane', name: 'Ground', position: [0, 0, 0] } },
+    ]);
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when batch reports a command error', async () => {
+    const batchFn = vi.fn().mockReturnValue({
+      success: false,
+      results: [{ success: false, error: 'Ambient light failed' }],
+    });
+    const ctx = makeMockCtx({ dispatchCommandBatch: batchFn });
+    vi.mocked(ctx.resolveStepOutput).mockReturnValue({
+      issues: ['no_ambient_light'],
+    });
+    const result = await executor.execute(baseInput, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('COMMAND_FAILED');
+  });
+
+  it('falls back to sequential dispatch when batch unavailable', async () => {
+    const ctx = makeMockCtx();
+    vi.mocked(ctx.resolveStepOutput).mockReturnValue({
+      issues: ['no_ambient_light', 'no_ground_plane'],
+    });
+    const result = await executor.execute(baseInput, ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.dispatchCommand).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/lib/game-creation/executors/autoPolishExecutor.ts
+++ b/web/src/lib/game-creation/executors/autoPolishExecutor.ts
@@ -43,21 +43,17 @@ export const autoPolishExecutor: ExecutorDefinition = {
     const issues = (verifyOutput?.['issues'] as string[]) ?? [];
 
     const fixes: string[] = [];
+    const commands: Array<{ command: string; payload?: unknown }> = [];
 
     // [B4] Structural heuristics only -- no telemetry data required
 
     // [FIX: NB4] update_ambient_light — manifest: { color: [r,g,b] (0-1), brightness: number }
     if (issues.includes('no_ambient_light')) {
-      ctx.dispatchCommand('update_ambient_light', {
-        color: [1, 1, 1],
-        brightness: 0.3,
-      });
+      commands.push({ command: 'update_ambient_light', payload: { color: [1, 1, 1], brightness: 0.3 } });
       fixes.push('Added ambient lighting');
     }
 
     // set_game_camera — manifest requires { entityId, mode }
-    // Every scene has a default Camera entity (Undeletable). Find it from the store
-    // and configure it as a player-following camera.
     if (issues.includes('no_camera_on_player')) {
       const nodes = Object.values(ctx.store.sceneGraph.nodes);
       const cameraNode = nodes.find(n => {
@@ -67,11 +63,7 @@ export const autoPolishExecutor: ExecutorDefinition = {
 
       if (cameraNode) {
         const mode = parsed.data.projectType === '2d' ? 'sideScroller' : 'thirdPersonFollow';
-        ctx.dispatchCommand('set_game_camera', {
-          entityId: cameraNode.entityId,
-          mode,
-          followSmoothing: 0.8,
-        });
+        commands.push({ command: 'set_game_camera', payload: { entityId: cameraNode.entityId, mode, followSmoothing: 0.8 } });
         fixes.push(`Configured camera as ${mode}`);
       } else {
         fixes.push('Warning: no camera entity found to configure');
@@ -79,22 +71,22 @@ export const autoPolishExecutor: ExecutorDefinition = {
     }
 
     // spawn_entity — manifest: { entityType, name?, position?: [x,y,z] }
-    // No 'scale' param — use update_transform after spawn for scaling
     if (issues.includes('no_ground_plane')) {
-      ctx.dispatchCommand('spawn_entity', {
-        entityType: 'plane',
-        name: 'Ground',
-        position: [0, 0, 0],
-      });
+      commands.push({ command: 'spawn_entity', payload: { entityType: 'plane', name: 'Ground', position: [0, 0, 0] } });
       fixes.push('Added ground plane');
     }
 
     // update_physics — manifest requires { entityId }
-    // verify_all_scenes emits 'physics_without_collider' (not 'player_no_physics')
     if (issues.includes('physics_without_collider')) {
-      // Cannot fix without knowing the specific entityId that has the issue.
-      // Log it as a warning for the user to address manually.
       fixes.push('Warning: entity has physics without collider — manual fix needed');
+    }
+
+    if (commands.length > 0) {
+      if (ctx.dispatchCommandBatch) {
+        ctx.dispatchCommandBatch(commands);
+      } else {
+        for (const cmd of commands) ctx.dispatchCommand(cmd.command, cmd.payload);
+      }
     }
 
     return successResult({

--- a/web/src/lib/game-creation/executors/autoPolishExecutor.ts
+++ b/web/src/lib/game-creation/executors/autoPolishExecutor.ts
@@ -83,7 +83,13 @@ export const autoPolishExecutor: ExecutorDefinition = {
 
     if (commands.length > 0) {
       if (ctx.dispatchCommandBatch) {
-        ctx.dispatchCommandBatch(commands);
+        const result = ctx.dispatchCommandBatch(commands);
+        if (!result.success) {
+          const failed = result.results.find((r) => !r.success);
+          return failResult(
+            makeStepError('COMMAND_FAILED', failed?.error ?? 'Batch command failed', this.userFacingErrorMessage),
+          );
+        }
       } else {
         for (const cmd of commands) ctx.dispatchCommand(cmd.command, cmd.payload);
       }

--- a/web/src/lib/game-creation/executors/autoPolishExecutor.ts
+++ b/web/src/lib/game-creation/executors/autoPolishExecutor.ts
@@ -85,9 +85,8 @@ export const autoPolishExecutor: ExecutorDefinition = {
       if (ctx.dispatchCommandBatch) {
         const result = ctx.dispatchCommandBatch(commands);
         if (!result.success) {
-          const failed = result.results.find((r) => !r.success);
           return failResult(
-            makeStepError('COMMAND_FAILED', failed?.error ?? 'Batch command failed', this.userFacingErrorMessage),
+            makeStepError('COMMAND_FAILED', 'Engine command rejected', this.userFacingErrorMessage),
           );
         }
       } else {

--- a/web/src/lib/game-creation/executors/entitySetupExecutor.ts
+++ b/web/src/lib/game-creation/executors/entitySetupExecutor.ts
@@ -54,16 +54,22 @@ export const entitySetupExecutor: ExecutorDefinition = {
     // Manifest: spawn_entity entityType is lowercase enum
     const entityType = projectType === '2d' ? 'plane' : (ROLE_TO_ENTITY_TYPE[entity.role] ?? 'cube');
 
-    // Switch to the target scene before spawning
-    // Manifest: switch_scene requires { sceneId: string }
-    ctx.dispatchCommand('switch_scene', { sceneId: scene });
+    const commands = [
+      { command: 'switch_scene', payload: { sceneId: scene } },
+      { command: 'spawn_entity', payload: { entityType, name: entity.name } },
+    ];
 
-    // Manifest: spawn_entity requires { entityType }, optional { name, position }
-    // Note: 'scene' is NOT a valid parameter — we switch_scene first
-    ctx.dispatchCommand('spawn_entity', {
-      entityType,
-      name: entity.name,
-    });
+    if (ctx.dispatchCommandBatch) {
+      const result = ctx.dispatchCommandBatch(commands);
+      if (!result.success) {
+        const failed = result.results.find((r) => !r.success);
+        return failResult(
+          makeStepError('COMMAND_FAILED', failed?.error ?? 'Batch command failed', this.userFacingErrorMessage),
+        );
+      }
+    } else {
+      for (const cmd of commands) ctx.dispatchCommand(cmd.command, cmd.payload);
+    }
 
     return successResult({
       entityName: entity.name,

--- a/web/src/lib/game-creation/executors/entitySetupExecutor.ts
+++ b/web/src/lib/game-creation/executors/entitySetupExecutor.ts
@@ -62,9 +62,8 @@ export const entitySetupExecutor: ExecutorDefinition = {
     if (ctx.dispatchCommandBatch) {
       const result = ctx.dispatchCommandBatch(commands);
       if (!result.success) {
-        const failed = result.results.find((r) => !r.success);
         return failResult(
-          makeStepError('COMMAND_FAILED', failed?.error ?? 'Batch command failed', this.userFacingErrorMessage),
+          makeStepError('COMMAND_FAILED', 'Engine command rejected', this.userFacingErrorMessage),
         );
       }
     } else {

--- a/web/src/lib/game-creation/types.ts
+++ b/web/src/lib/game-creation/types.ts
@@ -222,6 +222,7 @@ export type UserTier = 'starter' | 'hobbyist' | 'creator' | 'pro';
 
 export interface ExecutorContext {
   dispatchCommand: (command: string, payload: unknown) => void;
+  dispatchCommandBatch?: (commands: Array<{ command: string; payload?: unknown }>) => import('@/hooks/useEngine').BatchResult;
   store: EditorState;
   projectType: '2d' | '3d';
   userTier: UserTier;

--- a/web/src/stores/editorStore.ts
+++ b/web/src/stores/editorStore.ts
@@ -163,7 +163,10 @@ type BatchCommandDispatcher = (commands: Array<{ command: string; payload?: unkn
 let _dispatchCommandBatch: BatchCommandDispatcher | null = null;
 
 export function setCommandBatchDispatcher(dispatcher: BatchCommandDispatcher): void {
-  _dispatchCommandBatch = dispatcher;
+  _dispatchCommandBatch = (commands) => {
+    for (const { command } of commands) trackCommandDispatched(command);
+    return dispatcher(commands);
+  };
 }
 
 export function getCommandBatchDispatcher(): BatchCommandDispatcher | null {

--- a/web/src/stores/editorStore.ts
+++ b/web/src/stores/editorStore.ts
@@ -162,7 +162,11 @@ export function getCommandDispatcher(): ((command: string, payload: unknown) => 
 type BatchCommandDispatcher = (commands: Array<{ command: string; payload?: unknown }>) => import('@/hooks/useEngine').BatchResult;
 let _dispatchCommandBatch: BatchCommandDispatcher | null = null;
 
-export function setCommandBatchDispatcher(dispatcher: BatchCommandDispatcher): void {
+export function setCommandBatchDispatcher(dispatcher: BatchCommandDispatcher | undefined): void {
+  if (!dispatcher) {
+    _dispatchCommandBatch = null;
+    return;
+  }
   _dispatchCommandBatch = (commands) => {
     for (const { command } of commands) trackCommandDispatched(command);
     return dispatcher(commands);

--- a/web/src/stores/editorStore.ts
+++ b/web/src/stores/editorStore.ts
@@ -158,6 +158,18 @@ export function getCommandDispatcher(): ((command: string, payload: unknown) => 
   return _dispatchCommand;
 }
 
+// Batch command dispatcher - set by useEngine hook
+type BatchCommandDispatcher = (commands: Array<{ command: string; payload?: unknown }>) => import('@/hooks/useEngine').BatchResult;
+let _dispatchCommandBatch: BatchCommandDispatcher | null = null;
+
+export function setCommandBatchDispatcher(dispatcher: BatchCommandDispatcher): void {
+  _dispatchCommandBatch = dispatcher;
+}
+
+export function getCommandBatchDispatcher(): BatchCommandDispatcher | null {
+  return _dispatchCommandBatch;
+}
+
 // Play tick callback for script runner
 type PlayTickCallback = (data: unknown) => void;
 let _playTickCallback: PlayTickCallback | null = null;


### PR DESCRIPTION
## Summary
- Expose existing Rust `handle_command_batch` to JS via typed wrappers (`sendCommandBatch`, `dispatchCommandBatch`)
- Add `BatchResult`/`CommandResponse` types, wire batch dispatcher through store and context interfaces
- Migrate `entitySetupExecutor` and `autoPolishExecutor` to batch dispatch with sequential fallback
- Defense-in-depth: JS-side 256-item batch cap, analytics tracking parity, sanitized error strings

Closes #8124

## Review findings addressed
- Batch return value checked in both executors (Architect, Code Quality)
- Analytics tracking wraps batch dispatcher same as single dispatcher (Architect, Code Quality)
- JS-side batch size cap mirrors Rust limit (Security)
- Internal Rust error strings sanitized before propagation (Security)
- Full test coverage for batch paths: useEngineEvents, useEngine, both executors (Test)

## Test plan
- [x] `sendCommandBatch` returns `{ success: false, results: [] }` when engine not initialized
- [x] `dispatchCommandBatch` calls `handle_command_batch` and returns shaped result
- [x] Batch dispatcher rejects >256 items without crossing WASM boundary
- [x] Batch dispatcher catches errors and returns failure
- [x] `entity_setup` uses batch when available, falls back to sequential
- [x] `entity_setup` returns COMMAND_FAILED on batch error
- [x] `auto_polish` uses batch when available, falls back to sequential
- [x] `auto_polish` returns COMMAND_FAILED on batch error
- [x] All existing tests pass (14,800+ tests, 0 failures)
- [x] ESLint zero warnings, TypeScript clean