### PR TITLE
fix(tests): update stale claude-3-5-sonnet model references

### DIFF
--- a/.changeset/stale-model-refs.md
+++ b/.changeset/stale-model-refs.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Update test fixtures from deprecated claude-3-5-sonnet to current claude-sonnet-4-6 model IDs

--- a/web/src/app/api/__tests__/contracts.test.ts
+++ b/web/src/app/api/__tests__/contracts.test.ts
@@ -336,7 +336,7 @@ describe('POST /api/chat — invalid body contract', () => {
 
   it('returns { error } object with 4xx for missing messages field', async () => {
     const { POST } = await import('@/app/api/chat/route');
-    const req = makePostRequest('http://localhost/api/chat', { model: 'claude-3-5-sonnet-20241022' });
+    const req = makePostRequest('http://localhost/api/chat', { model: 'claude-sonnet-4-6' });
     const res = await POST(req);
 
     // Auth or validation should reject — either way, shape must be { error }

--- a/web/src/lib/analytics/__tests__/events.test.ts
+++ b/web/src/lib/analytics/__tests__/events.test.ts
@@ -58,8 +58,8 @@ describe('Vercel analytics event wrappers', () => {
 
   it('trackAIChatMessageSent calls track with model', async () => {
     const { trackAIChatMessageSent } = await import('@/lib/analytics/events');
-    trackAIChatMessageSent('claude-3-5-sonnet');
-    expect(mockTrack).toHaveBeenCalledWith('ai_chat_message_sent', expect.objectContaining({ model: 'claude-3-5-sonnet' }));
+    trackAIChatMessageSent('claude-sonnet-4-6');
+    expect(mockTrack).toHaveBeenCalledWith('ai_chat_message_sent', expect.objectContaining({ model: 'claude-sonnet-4-6' }));
   });
 
   it('trackAIAssetGenerated calls track with type and provider', async () => {
@@ -161,7 +161,7 @@ describe('Vercel analytics event wrappers', () => {
     const mod = await import('@/lib/analytics/events');
     mod.trackSignupComplete('starter');
     mod.trackFirstSceneCreated();
-    mod.trackAIChatMessageSent('claude-3-opus');
+    mod.trackAIChatMessageSent('claude-sonnet-4-6');
     mod.trackCommandDispatched('delete_entity');
     mod.trackAIAssetGenerated('texture', 'meshy');
     mod.trackEditorPanelOpened('inspector');

--- a/web/src/lib/game-creation/__tests__/executors.test.ts
+++ b/web/src/lib/game-creation/__tests__/executors.test.ts
@@ -119,7 +119,7 @@ vi.mock('@/lib/ai/contentSafety', () => ({
 }));
 
 vi.mock('@/lib/ai/models', () => ({
-  AI_MODEL_PRIMARY: 'claude-3-5-sonnet-20241022',
+  AI_MODEL_PRIMARY: 'claude-sonnet-4-6',
 }));
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Update 4 test fixtures referencing deprecated `claude-3-5-sonnet-20241022` and `claude-3-opus`
- Use current model ID `claude-sonnet-4-6` matching production constants in `@/lib/ai/models`
- 3 files changed: `executors.test.ts`, `events.test.ts`, `contracts.test.ts`

Closes #8361

## Test plan
- [x] All 3 modified test files pass (89 tests)
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly (exit 0)
- [x] Full vitest suite passes (14815 tests, 717 files)