### PR TITLE
deps: upgrade @anthropic-ai/sdk 0.82->0.88 (Managed Agents, AbortSignal)

### DIFF
--- a/.changeset/anthropic-sdk-088.md
+++ b/.changeset/anthropic-sdk-088.md
@@ -1,0 +1,11 @@
+---
+"web": minor
+---
+
+Upgrade @anthropic-ai/sdk from 0.82.0 to 0.88.0 and @ai-sdk/anthropic to 3.0.69
+
+New capabilities available:
+- Managed Agents API (v0.86+) for server-side agent orchestration
+- AbortSignal support for tool runner cancellation (v0.84+)
+- Beta advisor tool (v0.87+)
+- Vertex EU region support (v0.88+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.68",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.68.tgz",
-      "integrity": "sha512-BAd+fmgYoJMmGw0/uV+jRlXX60PyGxelA6Clp4cK/NI0dsyv9jOOwzQmKNaz2nwb+Jz7HqI7I70KK4XtU5EcXQ==",
+      "version": "3.0.69",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
+      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -23045,10 +23045,10 @@
     "web": {
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.68",
+        "@ai-sdk/anthropic": "^3.0.69",
         "@ai-sdk/gateway": "^3.0.95",
         "@ai-sdk/react": "^3.0.158",
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.88.0",
         "@aws-sdk/client-s3": "^3.1004.0",
         "@aws-sdk/s3-request-presigner": "^3.1014.0",
         "@clerk/nextjs": "^7.0.12",
@@ -23063,7 +23063,7 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "@xyflow/react": "^12.10.1",
-        "ai": "^6.0.156",
+        "ai": "^6.0.158",
         "bcryptjs": "^3.0.3",
         "dockview-react": "^5.1.0",
         "dotenv": "^17.3.1",
@@ -23111,6 +23111,15 @@
       },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "web/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "web/node_modules/@vercel/analytics": {
@@ -23187,6 +23196,24 @@
         "vue-router": {
           "optional": true
         }
+      }
+    },
+    "web/node_modules/ai": {
+      "version": "6.0.158",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
+      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.95",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "web/node_modules/dotenv": {

--- a/web/package.json
+++ b/web/package.json
@@ -29,10 +29,10 @@
     "check:bundle-size": "node scripts/check-bundle-size.js"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.68",
+    "@ai-sdk/anthropic": "^3.0.69",
     "@ai-sdk/gateway": "^3.0.95",
     "@ai-sdk/react": "^3.0.158",
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.88.0",
     "@aws-sdk/client-s3": "^3.1004.0",
     "@aws-sdk/s3-request-presigner": "^3.1014.0",
     "@clerk/nextjs": "^7.0.12",
@@ -47,7 +47,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "@xyflow/react": "^12.10.1",
-    "ai": "^6.0.156",
+    "ai": "^6.0.158",
     "bcryptjs": "^3.0.3",
     "dockview-react": "^5.1.0",
     "dotenv": "^17.3.1",


### PR DESCRIPTION
## Summary
- Upgrade `@anthropic-ai/sdk` from 0.82.0 to 0.88.0 (6 minor versions)
- Upgrade `@ai-sdk/anthropic` to 3.0.69 (companion bump)
- No breaking changes -- all AI calls routed through AI SDK adapter
- Unlocks Managed Agents API, AbortSignal for tool runner, beta advisor tool

Closes #8360

## New capabilities
- **Managed Agents** (v0.86+): server-side agent orchestration via API
- **AbortSignal** (v0.84+): cancellation support for tool runner
- **Beta advisor tool** (v0.87+): AI-assisted tool selection
- **Vertex EU** (v0.88+): European region support

## Test plan
- [x] `npm ls @anthropic-ai/sdk` shows 0.88.0
- [x] `npm ls @ai-sdk/anthropic` shows 3.0.69
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly
- [x] All 14,815 vitest tests pass (including chat route tests with SDK mocks)