### PR TITLE
fix(deps): upgrade AI SDK to 6.0.158

### DIFF
--- a/.changeset/ai-sdk-6-0-158.md
+++ b/.changeset/ai-sdk-6-0-158.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Upgrade AI SDK from 6.0.156 to 6.0.158 -- fixes Google Vertex streamFunctionCallArguments default, adds Anthropic inference_geo support

--- a/package-lock.json
+++ b/package-lock.json
@@ -23063,7 +23063,7 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "@xyflow/react": "^12.10.1",
-        "ai": "^6.0.156",
+        "ai": "^6.0.158",
         "bcryptjs": "^3.0.3",
         "dockview-react": "^5.1.0",
         "dotenv": "^17.3.1",
@@ -23111,6 +23111,15 @@
       },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "web/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "web/node_modules/@vercel/analytics": {
@@ -23187,6 +23196,24 @@
         "vue-router": {
           "optional": true
         }
+      }
+    },
+    "web/node_modules/ai": {
+      "version": "6.0.158",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
+      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.95",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "web/node_modules/dotenv": {

--- a/web/package.json
+++ b/web/package.json
@@ -47,7 +47,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "@xyflow/react": "^12.10.1",
-    "ai": "^6.0.156",
+    "ai": "^6.0.158",
     "bcryptjs": "^3.0.3",
     "dockview-react": "^5.1.0",
     "dotenv": "^17.3.1",


### PR DESCRIPTION
## Summary
- Bumps `ai` package from 6.0.156 to 6.0.158 in `web/package.json`
- Fixes Google Vertex `streamFunctionCallArguments` default behavior
- Adds Anthropic `inference_geo` support

Closes #8356

## Test plan
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly
- [x] All 14,815 vitest tests pass (717 files)
- [x] No new test failures introduced