### PR TITLE
fix: atomic Lua EVAL for distributed rate limiter (PF-744)

### DIFF
--- a/.changeset/rate-limiter-lua-atomic.md
+++ b/.changeset/rate-limiter-lua-atomic.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Replace pipeline+ZREM with atomic Lua EVAL in distributed rate limiter to eliminate phantom entries on deny cleanup failures

--- a/web/src/lib/rateLimit/__tests__/distributed.test.ts
+++ b/web/src/lib/rateLimit/__tests__/distributed.test.ts
@@ -11,18 +11,14 @@ globalThis.fetch = mockFetch;
 // Dynamic import so env vars and mocks are applied per test
 let distributedRateLimit: typeof import('../distributed').distributedRateLimit;
 
-// Helper to build a successful Upstash pipeline response with a given ZCARD result
-function makePipelineResponse(zcard: number) {
+// Helper to build a successful Upstash EVAL response.
+// The Lua script returns [allowed (0|1), count].
+function makeEvalResponse(allowed: boolean, count: number) {
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
-    json: async () => [
-      { result: 3 },         // ZREMRANGEBYSCORE
-      { result: 1 },         // ZADD
-      { result: zcard },     // ZCARD
-      { result: 1 },         // EXPIRE
-    ],
+    json: async () => ({ result: [allowed ? 1 : 0, count] }),
   };
 }
 
@@ -88,8 +84,8 @@ describe('distributedRateLimit — Upstash path', () => {
     process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
   });
 
-  it('returns allowed=true when ZCARD is below limit', async () => {
-    mockFetch.mockResolvedValue(makePipelineResponse(3)); // 3 out of 10
+  it('returns allowed=true when count is below limit', async () => {
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 3)); // 3 out of 10
 
     const result = await distributedRateLimit('key-1', 10, 60);
 
@@ -97,8 +93,8 @@ describe('distributedRateLimit — Upstash path', () => {
     expect(result.remaining).toBe(7); // 10 - 3
   });
 
-  it('returns allowed=true when ZCARD equals limit exactly', async () => {
-    mockFetch.mockResolvedValue(makePipelineResponse(5)); // exactly at limit
+  it('returns allowed=true when count equals limit exactly', async () => {
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 5)); // exactly at limit
 
     const result = await distributedRateLimit('key-2', 5, 60);
 
@@ -106,10 +102,9 @@ describe('distributedRateLimit — Upstash path', () => {
     expect(result.remaining).toBe(0);
   });
 
-  it('returns allowed=false when ZCARD exceeds limit', async () => {
-    // First call: pipeline response showing over limit
-    mockFetch.mockResolvedValueOnce(makePipelineResponse(6)) // ZCARD = 6, limit = 5
-      .mockResolvedValueOnce({ ok: true, json: async () => [{ result: 1 }] }); // ZREM cleanup
+  it('returns allowed=false when count exceeds limit', async () => {
+    // Single EVAL call — no separate ZREM needed (PF-744)
+    mockFetch.mockResolvedValue(makeEvalResponse(false, 5)); // at limit, denied
 
     const result = await distributedRateLimit('key-3', 5, 60);
 
@@ -117,13 +112,13 @@ describe('distributedRateLimit — Upstash path', () => {
     expect(result.remaining).toBe(0);
   });
 
-  it('calls the Upstash pipeline endpoint with correct headers', async () => {
-    mockFetch.mockResolvedValue(makePipelineResponse(1));
+  it('calls the Upstash EVAL endpoint with correct headers', async () => {
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 1));
 
     await distributedRateLimit('test-key', 10, 30);
 
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://redis.upstash.io/pipeline',
+      'https://redis.upstash.io/eval',
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
@@ -134,28 +129,30 @@ describe('distributedRateLimit — Upstash path', () => {
     );
   });
 
-  it('sends ZREMRANGEBYSCORE, ZADD, ZCARD, EXPIRE pipeline commands', async () => {
-    mockFetch.mockResolvedValue(makePipelineResponse(1));
+  it('sends Lua script with correct arguments to EVAL', async () => {
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 1));
 
-    await distributedRateLimit('pipeline-key', 5, 30);
+    await distributedRateLimit('lua-key', 5, 30);
 
-    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string) as string[][];
-    // Keys are prefixed with @spawnforge/ratelimit: to match the @upstash/ratelimit prefix
-    const prefixed = '@spawnforge/ratelimit:pipeline-key';
-    expect(callBody[0][0]).toBe('ZREMRANGEBYSCORE');
-    expect(callBody[0][1]).toBe(prefixed);
-    expect(callBody[1][0]).toBe('ZADD');
-    expect(callBody[1][1]).toBe(prefixed);
-    expect(callBody[2][0]).toBe('ZCARD');
-    expect(callBody[2][1]).toBe(prefixed);
-    expect(callBody[3][0]).toBe('EXPIRE');
-    expect(callBody[3][1]).toBe(prefixed);
-    // windowSeconds must be a number (not a string) — Redis sorted-set scores require numeric values
-    expect(callBody[3][2]).toBe(30); // windowSeconds as number
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string) as unknown[];
+    const prefixed = '@spawnforge/ratelimit:lua-key';
+    // [luaScript, numkeys, key, windowStart, limit, now, member, windowSeconds]
+    expect(typeof callBody[0]).toBe('string'); // Lua script
+    expect((callBody[0] as string)).toContain('ZREMRANGEBYSCORE');
+    expect((callBody[0] as string)).toContain('ZADD');
+    expect((callBody[0] as string)).toContain('ZCARD');
+    expect(callBody[1]).toBe(1);              // numkeys
+    expect(callBody[2]).toBe(prefixed);       // KEYS[1]
+    // ARGV: windowStart, limit, now, member, windowSeconds
+    expect(typeof callBody[3]).toBe('number'); // windowStart
+    expect(callBody[4]).toBe(5);              // limit
+    expect(typeof callBody[5]).toBe('number'); // now
+    expect(typeof callBody[6]).toBe('string'); // member
+    expect(callBody[7]).toBe(30);             // windowSeconds
   });
 
   it('provides a resetAt timestamp in the future', async () => {
-    mockFetch.mockResolvedValue(makePipelineResponse(2));
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 2));
 
     const before = Date.now();
     const result = await distributedRateLimit('reset-key', 10, 60);
@@ -192,34 +189,26 @@ describe('distributedRateLimit — Upstash path', () => {
     expect(result.allowed).toBe(false);
   });
 
-  it('attempts cleanup via Lua EVAL when over limit', async () => {
-    // Over-limit: ZCARD = 6 for limit = 5
-    mockFetch
-      .mockResolvedValueOnce(makePipelineResponse(6))
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ result: 1 }) });
+  it('makes exactly one fetch call (atomic EVAL) regardless of allow/deny', async () => {
+    // Denied request: single EVAL, no second ZREM call needed (PF-744)
+    mockFetch.mockResolvedValue(makeEvalResponse(false, 5));
 
-    await distributedRateLimit('cleanup-key', 5, 60);
+    await distributedRateLimit('atomic-key', 5, 60);
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    // Second call must go to the /eval endpoint (Lua EVAL for atomic remove-if-over-limit)
-    const [evalUrl, evalInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [evalUrl] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(evalUrl).toBe('https://redis.upstash.io/eval');
-    expect(evalInit.method).toBe('POST');
-    // Body is [luaScript, numkeys, key, member]
-    const evalBody = JSON.parse(evalInit.body as string) as [string, number, string, string];
-    expect(typeof evalBody[0]).toBe('string'); // Lua script
-    expect(evalBody[0]).toContain('ZREM');     // script performs ZREM
-    expect(evalBody[1]).toBe(1);               // numkeys = 1
-    expect(evalBody[2]).toBe('@spawnforge/ratelimit:cleanup-key');   // KEYS[1]
   });
 
-  it('does not throw if Lua EVAL cleanup fails', async () => {
-    mockFetch
-      .mockResolvedValueOnce(makePipelineResponse(6))
-      .mockRejectedValueOnce(new Error('cleanup failed'));
+  it('never adds a phantom entry on deny (no ZADD in deny path)', async () => {
+    // The Lua script only calls ZADD when count < limit.
+    // On deny, the entry is never written — nothing to clean up.
+    mockFetch.mockResolvedValue(makeEvalResponse(false, 10));
 
-    // Should not throw despite cleanup failure
-    await expect(distributedRateLimit('no-throw-key', 5, 60)).resolves.toBeDefined();
+    const result = await distributedRateLimit('no-phantom-key', 10, 60);
+
+    expect(result.allowed).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // No second cleanup call
   });
 });
 
@@ -274,17 +263,7 @@ describe('PF-738: distributedRateLimit result shape matches in-memory RateLimitR
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.upstash.io';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
 
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => [
-        { result: 3 },  // ZREMRANGEBYSCORE
-        { result: 1 },  // ZADD
-        { result: 4 },  // ZCARD (4 out of 10)
-        { result: 1 },  // EXPIRE
-      ],
-    });
+    mockFetch.mockResolvedValue(makeEvalResponse(true, 4)); // 4 out of 10
 
     const result = await distributedRateLimit('upstash-shape-key', 10, 60);
 

--- a/web/src/lib/rateLimit/distributed.ts
+++ b/web/src/lib/rateLimit/distributed.ts
@@ -25,19 +25,45 @@ function isUpstashConfigured(): boolean {
 }
 
 /**
- * Execute a Redis pipeline via the Upstash REST API.
- * Uses MULTI/EXEC-style pipeline to atomically ZADD + ZREMRANGEBYSCORE + ZCARD.
+ * Atomic sliding window rate limiter via a single Lua EVAL script (PF-744).
  *
- * Sliding window algorithm:
+ * Sliding window algorithm — all steps run atomically in Redis:
  * 1. Remove all timestamps older than `now - windowMs`
  * 2. Count remaining timestamps in the window
- * 3. If count < limit, add current timestamp and allow
- * 4. Set TTL on the key to clean up after the window expires
+ * 3. If count < limit, add current timestamp and set TTL → allow
+ * 4. If count >= limit, set TTL only (never add the entry) → deny
  *
- * All steps run in a single pipelined request for atomicity.
+ * This eliminates phantom entries: the entry is never written when over limit,
+ * so there's nothing to clean up and no window for ZREM failures to leave
+ * stale data behind.
  */
 /** Prefix must match the @upstash/ratelimit prefix used by rateLimit.ts */
 const REDIS_KEY_PREFIX = '@spawnforge/ratelimit';
+
+/**
+ * Lua script for atomic sliding window rate limiting.
+ *
+ * KEYS[1] = rate limit key
+ * ARGV[1] = windowStart (oldest allowed timestamp)
+ * ARGV[2] = limit (max entries per window)
+ * ARGV[3] = now (score for ZADD)
+ * ARGV[4] = member (unique value for ZADD)
+ * ARGV[5] = windowSeconds (TTL for EXPIRE)
+ *
+ * Returns {allowed (0|1), count} as a two-element array.
+ */
+const SLIDING_WINDOW_SCRIPT = `
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+local count = redis.call('ZCARD', KEYS[1])
+if count < tonumber(ARGV[2]) then
+  redis.call('ZADD', KEYS[1], tonumber(ARGV[3]), ARGV[4])
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+  return {1, count + 1}
+else
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[5]))
+  return {0, count}
+end
+`;
 
 async function upstashSlidingWindow(
   key: string,
@@ -55,58 +81,25 @@ async function upstashSlidingWindow(
   // requests arrive in the same millisecond (each member must be unique).
   const member = `${now}:${Math.random().toString(36).slice(2, 8)}`;
 
-  // Pipeline: ZREMRANGEBYSCORE, ZADD, ZCARD, EXPIRE
-  // We issue these as a pipeline (array of commands) for a single round-trip.
-  // ZADD score must be a number (not a string) for the Redis sorted set to order correctly.
-  const pipeline = [
-    ['ZREMRANGEBYSCORE', prefixedKey, '-inf', windowStart],
-    ['ZADD', prefixedKey, now, member],
-    ['ZCARD', prefixedKey],
-    ['EXPIRE', prefixedKey, windowSeconds],
-  ];
-
-  const response = await fetch(`${url}/pipeline`, {
+  const response = await fetch(`${url}/eval`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(pipeline),
+    body: JSON.stringify([SLIDING_WINDOW_SCRIPT, 1, prefixedKey, windowStart, limit, now, member, windowSeconds]),
   });
 
   if (!response.ok) {
-    throw new Error(`Upstash pipeline failed: ${response.status} ${response.statusText}`);
+    throw new Error(`Upstash EVAL failed: ${response.status} ${response.statusText}`);
   }
 
-  const results = await response.json() as Array<{ result: number | string | null }>;
+  const result = await response.json() as { result: [number, number] };
+  const [allowed, count] = result.result;
 
-  // Index 2 is ZCARD — count of entries currently in window (including the one we just added)
-  const countAfterAdd = typeof results[2]?.result === 'number' ? results[2].result : 1;
+  const remaining = Math.max(0, limit - count);
 
-  const allowed = countAfterAdd <= limit;
-
-  if (!allowed) {
-    // Atomically remove the member we just added using a Lua script.
-    // A plain ZREM in a separate request is non-atomic — the Lua EVAL guarantees
-    // the remove-if-over-limit check is atomic on the Redis side.
-    const luaScript = "if redis.call('ZSCORE', KEYS[1], ARGV[1]) then return redis.call('ZREM', KEYS[1], ARGV[1]) else return 0 end";
-    await fetch(`${url}/eval`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify([luaScript, 1, prefixedKey, member]),
-    }).catch(() => {
-      // Best-effort cleanup; don't throw on failure
-    });
-  }
-
-  const remaining = Math.max(0, limit - countAfterAdd);
-
-  // resetAt: oldest entry in window + windowMs (when the window will open up a slot)
-  // For simplicity, use now + windowMs as the conservative upper bound
-  return { allowed, remaining, resetAt };
+  return { allowed: allowed === 1, remaining, resetAt };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace two-step pipeline+ZREM with a single atomic Lua EVAL script in the distributed rate limiter
- The Lua script conditionally ZADDs only when count < limit — entries are never written on deny
- Eliminates phantom entries that persisted when the separate ZREM cleanup failed

Closes #7071

## Test plan
- [x] 18 tests passing — updated for new EVAL-based approach
- [x] Tests verify single fetch call on deny (no second cleanup needed)
- [x] Tests verify Lua script arguments and EVAL endpoint
- [x] Fallback to in-memory on Upstash errors unchanged
- [x] Lint clean