### PR TITLE
fix: add vi.resetModules() to 81 test files for cache isolation (#7104)

### DIFF
--- a/.changeset/vi-reset-modules-test-isolation.md
+++ b/.changeset/vi-reset-modules-test-isolation.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add vi.resetModules() to 81 test files using dynamic imports to prevent module cache contamination between tests

--- a/web/src/app/__tests__/opengraph-image.test.tsx
+++ b/web/src/app/__tests__/opengraph-image.test.tsx
@@ -3,9 +3,13 @@
  *
  * @vitest-environment node
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 describe('Root OG Image', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   it('exports correct size (1200x630)', async () => {
     const mod = await import('../opengraph-image');
     expect(mod.size).toEqual({ width: 1200, height: 630 });

--- a/web/src/app/api/feedback/route.test.ts
+++ b/web/src/app/api/feedback/route.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('POST /api/feedback', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateClerkSession).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/__tests__/route-integration.test.ts
+++ b/web/src/app/api/generate/__tests__/route-integration.test.ts
@@ -169,6 +169,7 @@ function makeRequest(url: string, body: unknown): NextRequest {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
+  vi.resetModules();
   vi.clearAllMocks();
   mockAuth.mockResolvedValue({
     ok: true,

--- a/web/src/app/api/generate/localize/route.test.ts
+++ b/web/src/app/api/generate/localize/route.test.ts
@@ -72,6 +72,7 @@ const validBody = {
 
 describe('POST /api/generate/localize', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
 
     vi.mocked(authenticateRequest).mockResolvedValue({

--- a/web/src/app/api/generate/model/__tests__/negative-cases.test.ts
+++ b/web/src/app/api/generate/model/__tests__/negative-cases.test.ts
@@ -107,6 +107,7 @@ describe('POST /api/generate/model — negative cases', () => {
   let POST: (request: NextRequest) => Promise<Response>;
 
   beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
 
     vi.mocked(authenticateRequest).mockResolvedValue({

--- a/web/src/app/api/generate/model/__tests__/route.test.ts
+++ b/web/src/app/api/generate/model/__tests__/route.test.ts
@@ -55,6 +55,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/model', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/model/route.test.ts
+++ b/web/src/app/api/generate/model/route.test.ts
@@ -48,6 +48,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/model', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/music/route.test.ts
+++ b/web/src/app/api/generate/music/route.test.ts
@@ -47,6 +47,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/music', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/pacing/route.test.ts
+++ b/web/src/app/api/generate/pacing/route.test.ts
@@ -84,6 +84,7 @@ const aiSuggestions = [
 
 describe('POST /api/generate/pacing', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
 
     vi.mocked(authenticateRequest).mockResolvedValue({

--- a/web/src/app/api/generate/pixel-art/__tests__/route.test.ts
+++ b/web/src/app/api/generate/pixel-art/__tests__/route.test.ts
@@ -80,6 +80,7 @@ const validBody = {
 
 describe('POST /api/generate/pixel-art', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({
       ok: true,

--- a/web/src/app/api/generate/sfx/__tests__/route.test.ts
+++ b/web/src/app/api/generate/sfx/__tests__/route.test.ts
@@ -66,6 +66,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/sfx', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/skybox/route.test.ts
+++ b/web/src/app/api/generate/skybox/route.test.ts
@@ -47,6 +47,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/skybox', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/sprite-sheet/route.test.ts
+++ b/web/src/app/api/generate/sprite-sheet/route.test.ts
@@ -45,6 +45,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/sprite-sheet', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/sprite/route.test.ts
+++ b/web/src/app/api/generate/sprite/route.test.ts
@@ -45,6 +45,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/sprite', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/texture/route.test.ts
+++ b/web/src/app/api/generate/texture/route.test.ts
@@ -48,6 +48,7 @@ const makeRequest = (body: Record<string, unknown>) =>
 
 describe('POST /api/generate/texture', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 9, resetAt: Date.now() + 60000 });
   });

--- a/web/src/app/api/generate/tileset-gen/route.test.ts
+++ b/web/src/app/api/generate/tileset-gen/route.test.ts
@@ -47,6 +47,7 @@ const makeRequest = (body: Record<string, unknown>) =>
 
 describe('POST /api/generate/tileset-gen', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 9, resetAt: Date.now() + 60000 });
   });

--- a/web/src/app/api/generate/voice/__tests__/route.test.ts
+++ b/web/src/app/api/generate/voice/__tests__/route.test.ts
@@ -55,6 +55,7 @@ function makeRequest(body: unknown): NextRequest {
 
 describe('POST /api/generate/voice', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/generate/voice/batch/route.test.ts
+++ b/web/src/app/api/generate/voice/batch/route.test.ts
@@ -74,6 +74,7 @@ const defaultVoiceSettings: VoiceSettings = {
 
 describe('POST /api/generate/voice/batch', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 4, resetAt: Date.now() + 60000 });
   });

--- a/web/src/app/api/generate/voice/route.test.ts
+++ b/web/src/app/api/generate/voice/route.test.ts
@@ -48,6 +48,7 @@ const makeRequest = (body: Record<string, unknown>) =>
 
 describe('POST /api/generate/voice', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 9, resetAt: Date.now() + 60000 });
   });

--- a/web/src/app/api/jobs/[id]/route.test.ts
+++ b/web/src/app/api/jobs/[id]/route.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('PATCH /api/jobs/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/keys/[provider]/route.test.ts
+++ b/web/src/app/api/keys/[provider]/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('PUT /api/keys/[provider]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/keys/api-key/[id]/route.test.ts
+++ b/web/src/app/api/keys/api-key/[id]/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('DELETE /api/keys/api-key/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/keys/api-key/route.test.ts
+++ b/web/src/app/api/keys/api-key/route.test.ts
@@ -21,6 +21,7 @@ vi.mock('bcryptjs', () => ({
 
 describe('POST /api/keys/api-key', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/assets/[id]/download/route.test.ts
+++ b/web/src/app/api/marketplace/assets/[id]/download/route.test.ts
@@ -25,6 +25,7 @@ vi.mock('@/lib/storage/r2', () => ({
 
 describe('GET /api/marketplace/assets/[id]/download', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/assets/[id]/purchase/route.test.ts
+++ b/web/src/app/api/marketplace/assets/[id]/purchase/route.test.ts
@@ -109,6 +109,7 @@ const { withApiMiddleware } = await import('@/lib/api/middleware');
 
 describe('POST /api/marketplace/assets/[id]/purchase', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
 
     // Reset withApiMiddleware to default (authenticated user)

--- a/web/src/app/api/marketplace/assets/[id]/route.test.ts
+++ b/web/src/app/api/marketplace/assets/[id]/route.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/marketplace/assets/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/marketplace/assets/__tests__/purchase-idempotency.test.ts
+++ b/web/src/app/api/marketplace/assets/__tests__/purchase-idempotency.test.ts
@@ -129,6 +129,7 @@ function setupDbChain(calls: Array<{ type: 'select' | 'insert' | 'update'; resul
 
 describe('POST /api/marketplace/assets/[id]/purchase — downloadCount idempotency', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/marketplace/assets/route.test.ts
+++ b/web/src/app/api/marketplace/assets/route.test.ts
@@ -32,6 +32,7 @@ function mockDbChain(data: unknown[] = []) {
 
 describe('GET /api/marketplace/assets', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/marketplace/purchases/route.test.ts
+++ b/web/src/app/api/marketplace/purchases/route.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/marketplace/purchases', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/seller/assets/[id]/route.test.ts
+++ b/web/src/app/api/marketplace/seller/assets/[id]/route.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('PATCH /api/marketplace/seller/assets/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/seller/assets/[id]/upload/route.test.ts
+++ b/web/src/app/api/marketplace/seller/assets/[id]/upload/route.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/lib/storage/r2', () => ({
 
 describe('POST /api/marketplace/seller/assets/[id]/upload', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/seller/assets/route.test.ts
+++ b/web/src/app/api/marketplace/seller/assets/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/marketplace/seller/assets', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,
@@ -73,6 +74,7 @@ describe('GET /api/marketplace/seller/assets', () => {
 
 describe('POST /api/marketplace/seller/assets', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/marketplace/seller/route.test.ts
+++ b/web/src/app/api/marketplace/seller/route.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/marketplace/seller', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,
@@ -83,6 +84,7 @@ describe('GET /api/marketplace/seller', () => {
 
 describe('POST /api/marketplace/seller', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/play/[userId]/[slug]/leaderboard/route.test.ts
+++ b/web/src/app/api/play/[userId]/[slug]/leaderboard/route.test.ts
@@ -84,6 +84,7 @@ const BOARD_DESC: {
 
 describe('GET /api/play/[userId]/[slug]/leaderboard', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 
@@ -222,6 +223,7 @@ function makeNeonSqlFn(result: unknown[] = DEFAULT_NEON_INSERT_RESULT) {
 
 describe('POST /api/play/[userId]/[slug]/leaderboard', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/play/[userId]/[slug]/remix/route.test.ts
+++ b/web/src/app/api/play/[userId]/[slug]/remix/route.test.ts
@@ -50,6 +50,7 @@ vi.mock('@/lib/monitoring/sentry-server', () => ({
 
 describe('POST /api/play/[userId]/[slug]/remix', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/play/[userId]/[slug]/route.test.ts
+++ b/web/src/app/api/play/[userId]/[slug]/route.test.ts
@@ -54,6 +54,7 @@ function mockUpdateChain() {
 
 describe('GET /api/play/[userId]/[slug]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/api/projects/[id]/route.test.ts
+++ b/web/src/app/api/projects/[id]/route.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/projects/service');
 
 describe('GET /api/projects/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,
@@ -58,6 +59,7 @@ describe('GET /api/projects/[id]', () => {
 
 describe('PUT /api/projects/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,
@@ -168,6 +170,7 @@ describe('PUT /api/projects/[id]', () => {
 
 describe('DELETE /api/projects/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/projects/route.test.ts
+++ b/web/src/app/api/projects/route.test.ts
@@ -38,6 +38,7 @@ function mockMiddlewareSuccess(
 
 describe('GET /api/projects', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockMiddlewareSuccess();
   });
@@ -74,6 +75,7 @@ describe('GET /api/projects', () => {
 
 describe('POST /api/projects', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockMiddlewareSuccess();
   });

--- a/web/src/app/api/publish/[id]/route.test.ts
+++ b/web/src/app/api/publish/[id]/route.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('DELETE /api/publish/[id]', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/publish/check-slug/route.test.ts
+++ b/web/src/app/api/publish/check-slug/route.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/publish/check-slug', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateClerkSession).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/publish/list/route.test.ts
+++ b/web/src/app/api/publish/list/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('GET /api/publish/list', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateClerkSession).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/stripe/webhook/__tests__/negative-cases.test.ts
+++ b/web/src/app/api/stripe/webhook/__tests__/negative-cases.test.ts
@@ -128,6 +128,7 @@ function makeSubscription(overrides: Record<string, unknown> = {}) {
 
 describe('POST /api/stripe/webhook — negative cases', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockClaimEvent.mockResolvedValue(true);
     mockHandleSubscriptionCreated.mockResolvedValue(undefined);

--- a/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -142,6 +142,7 @@ function makeStripeEvent(type: string, dataObject: unknown, id = 'evt_001') {
 
 describe('POST /api/stripe/webhook', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockClaimEvent.mockResolvedValue(true);
     mockHandleSubscriptionCreated.mockResolvedValue(undefined);

--- a/web/src/app/api/tokens/purchase/route.test.ts
+++ b/web/src/app/api/tokens/purchase/route.test.ts
@@ -36,6 +36,7 @@ vi.mock('stripe', () => {
 
 describe('POST /api/tokens/purchase', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/tokens/usage/route.test.ts
+++ b/web/src/app/api/tokens/usage/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/lib/rateLimit/distributed', () => ({
 
 describe('GET /api/tokens/usage', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true as const,

--- a/web/src/app/api/vitals/__tests__/route.test.ts
+++ b/web/src/app/api/vitals/__tests__/route.test.ts
@@ -41,6 +41,7 @@ function makeRawRequest(body: string): NextRequest {
 
 describe('POST /api/vitals', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/app/play/[userId]/[slug]/__tests__/opengraph-image.test.tsx
+++ b/web/src/app/play/[userId]/[slug]/__tests__/opengraph-image.test.tsx
@@ -23,6 +23,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('Per-Game OG Image', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/components/editor/__tests__/AutoIterationPanel.test.tsx
+++ b/web/src/components/editor/__tests__/AutoIterationPanel.test.tsx
@@ -50,6 +50,7 @@ vi.mock('@/lib/ai/autoIteration', () => ({
 
 describe('AutoIterationPanel', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/components/editor/__tests__/EditorErrorBoundary.test.tsx
+++ b/web/src/components/editor/__tests__/EditorErrorBoundary.test.tsx
@@ -20,6 +20,7 @@ function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
 describe('EditorErrorBoundary', () => {
   const origErr = console.error;
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     console.error = vi.fn();
     Object.defineProperty(window, 'location', { value: { ...window.location, reload: vi.fn(), href: '' }, writable: true, configurable: true });

--- a/web/src/components/editor/__tests__/ExportDialog.test.tsx
+++ b/web/src/components/editor/__tests__/ExportDialog.test.tsx
@@ -59,6 +59,7 @@ function setupStore(overrides: {
 
 describe('ExportDialog', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/components/editor/__tests__/PacingAnalyzerPanel.test.tsx
+++ b/web/src/components/editor/__tests__/PacingAnalyzerPanel.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/stores/editorStore', () => ({
 
 describe('PacingAnalyzerPanel', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(useEditorStore).mockImplementation((selector: any) =>

--- a/web/src/components/editor/__tests__/SpriteSheetImportDialog.test.tsx
+++ b/web/src/components/editor/__tests__/SpriteSheetImportDialog.test.tsx
@@ -55,6 +55,7 @@ function setupStore(overrides: { primaryId?: string | null } = {}) {
 
 describe('SpriteSheetImportDialog', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/components/editor/__tests__/WelcomeModal.test.tsx
+++ b/web/src/components/editor/__tests__/WelcomeModal.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/data/tutorials', () => mockTutorials);
 
 describe('WelcomeModal', () => {
   beforeEach(() => {
+    vi.resetModules();
     localStorage.clear();
     vi.clearAllMocks();
     const workspaceState = { navigateDocs: vi.fn() } as unknown as WorkspaceState;

--- a/web/src/components/editor/__tests__/WorkspaceProvider.test.tsx
+++ b/web/src/components/editor/__tests__/WorkspaceProvider.test.tsx
@@ -130,6 +130,7 @@ function setupStore() {
 
 describe('WorkspaceProvider', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     capturedOnReady = null;
     setupStore();

--- a/web/src/components/errors/__tests__/routeWrappers.test.tsx
+++ b/web/src/components/errors/__tests__/routeWrappers.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@/test/utils/componentTestUtils';
 
 const captureExceptionMock = vi.fn();
@@ -33,6 +33,10 @@ function makeError(message = 'boom') {
 }
 
 const reset = vi.fn();
+
+beforeEach(() => {
+  vi.resetModules();
+});
 
 afterEach(() => {
   cleanup();

--- a/web/src/components/marketplace/__tests__/AssetDetailModal.test.tsx
+++ b/web/src/components/marketplace/__tests__/AssetDetailModal.test.tsx
@@ -54,6 +54,7 @@ describe('AssetDetailModal', () => {
   const mockOnClose = vi.fn();
 
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/web/src/hooks/__tests__/useEngine.test.ts
+++ b/web/src/hooks/__tests__/useEngine.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/monitoring/sentry-client', () => ({
 // Instead we'll test the hook behavior by creating a mock canvas and controlling SSR state.
 describe('useEngine', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     resetEngine();
 
@@ -143,6 +144,7 @@ describe('useEngine', () => {
 
 describe('recoverEngine', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     resetEngine();
 

--- a/web/src/lib/__tests__/sceneFile.test.ts
+++ b/web/src/lib/__tests__/sceneFile.test.ts
@@ -125,6 +125,7 @@ describe('getAutoSave and clearAutoSave', () => {
   let mockStore: Record<string, string>;
 
   beforeEach(() => {
+    vi.resetModules();
     mockStore = {};
     vi.stubGlobal('localStorage', {
       getItem: (key: string) => mockStore[key] ?? null,
@@ -194,6 +195,7 @@ describe('saveAutoSave', () => {
   }
 
   beforeEach(() => {
+    vi.resetModules();
     mockStore = {};
     vi.stubGlobal('localStorage', makeLocalStorageMock());
   });

--- a/web/src/lib/__tests__/sentry-regressions.test.ts
+++ b/web/src/lib/__tests__/sentry-regressions.test.ts
@@ -11,7 +11,11 @@
  * - #17: Array spread on large arrays (lesson #17)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
 
 // ---------------------------------------------------------------------------
 // Bug #3: Number(undefined) ?? 60 → NaN regression

--- a/web/src/lib/ai/__tests__/clientQueueIntegration.test.ts
+++ b/web/src/lib/ai/__tests__/clientQueueIntegration.test.ts
@@ -45,6 +45,7 @@ function makeErrorResponse(status: number, error: string): Response {
 let mockFetch: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
+  vi.resetModules();
   mockFetch = vi.fn();
   vi.stubGlobal('fetch', mockFetch);
 });

--- a/web/src/lib/ai/__tests__/cutsceneGenerator.test.ts
+++ b/web/src/lib/ai/__tests__/cutsceneGenerator.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
 import {
   buildCutscenePrompt,
   parseCutsceneResponse,

--- a/web/src/lib/ai/__tests__/gameReviewer.test.ts
+++ b/web/src/lib/ai/__tests__/gameReviewer.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
 import {
   parseReviewResponse,
   clampScore,

--- a/web/src/lib/ai/__tests__/gddGenerator.test.ts
+++ b/web/src/lib/ai/__tests__/gddGenerator.test.ts
@@ -415,6 +415,7 @@ describe('generateGDD', () => {
   let fetchAIMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    vi.resetModules();
     vi.resetAllMocks();
     const client = await import('@/lib/ai/client');
     fetchAIMock = vi.mocked(client.fetchAI);

--- a/web/src/lib/ai/__tests__/pipeline-integration.test.ts
+++ b/web/src/lib/ai/__tests__/pipeline-integration.test.ts
@@ -54,6 +54,7 @@ function makeStreamingResponse(text: string): Response {
 
 describe('gddGenerator — generateGDD contract', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 
@@ -143,6 +144,7 @@ describe('gddGenerator — generateGDD contract', () => {
 
 describe('levelGenerator — generateLevel contract', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 
@@ -204,6 +206,7 @@ describe('levelGenerator — generateLevel contract', () => {
 
 describe('effectSystem — generateEffectBindings contract', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 
@@ -286,6 +289,7 @@ describe('effectSystem — generateEffectBindings contract', () => {
 
 describe('gameReviewer — generateReview contract', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/lib/ai/__tests__/tutorialGenerator.test.ts
+++ b/web/src/lib/ai/__tests__/tutorialGenerator.test.ts
@@ -423,6 +423,7 @@ describe('generateTutorialPlan', () => {
   let fetchAIMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    vi.resetModules();
     vi.resetAllMocks();
     const client = await import('@/lib/ai/client');
     fetchAIMock = vi.mocked(client.fetchAI);

--- a/web/src/lib/analytics/__tests__/events.test.ts
+++ b/web/src/lib/analytics/__tests__/events.test.ts
@@ -15,6 +15,7 @@ vi.mock('@vercel/analytics', () => ({
 
 describe('Vercel analytics event wrappers', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/lib/analytics/__tests__/panelTracking.test.ts
+++ b/web/src/lib/analytics/__tests__/panelTracking.test.ts
@@ -11,6 +11,7 @@ vi.mock('@vercel/analytics', () => ({
 
 describe('panelTracking', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/lib/api/__tests__/createGenerationHandler.test.ts
+++ b/web/src/lib/api/__tests__/createGenerationHandler.test.ts
@@ -89,6 +89,7 @@ const testHandler = createGenerationHandler({
 
 describe('createGenerationHandler', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockAuth.mockResolvedValue({
       ok: true,

--- a/web/src/lib/chat/handlers/__tests__/assetMaterialPerformanceHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/assetMaterialPerformanceHandlers.test.ts
@@ -8,7 +8,11 @@
  * - Return value shape
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
 import { invokeHandler, createMockStore } from './handlerTestUtils';
 import { assetHandlers } from '../assetHandlers';
 import { materialHandlers } from '../materialHandlers';

--- a/web/src/lib/chat/handlers/__tests__/audioEntityHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/audioEntityHandlers.test.ts
@@ -3,7 +3,11 @@
  * Tests for audioEntityHandlers — core entity audio, bus management,
  * layering, transitions, reverb zones, and ducking rules.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
 import { createMockStore } from './handlerTestUtils';
 import { audioEntityHandlers } from '../audioEntityHandlers';
 

--- a/web/src/lib/chat/handlers/__tests__/audioPhysicsGameHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/audioPhysicsGameHandlers.test.ts
@@ -90,6 +90,7 @@ vi.mock('@/lib/export/exportEngine', () => ({
 let audioHandlers: Record<string, (args: Record<string, unknown>, ctx: ToolCallContext) => Promise<ExecutionResult>>;
 
 beforeEach(async () => {
+  vi.resetModules();
   const mod = await import('../audioHandlers');
   audioHandlers = mod.audioHandlers;
   // Reset mock snapshot storage

--- a/web/src/lib/chat/handlers/__tests__/cutsceneHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/cutsceneHandlers.test.ts
@@ -41,7 +41,6 @@ function makeCutscene(id = 'cs1'): Cutscene {
 }
 
 beforeEach(() => {
-  vi.resetModules();
   vi.clearAllMocks();
   useCutsceneStore.setState({
     cutscenes: {},

--- a/web/src/lib/chat/handlers/__tests__/cutsceneHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/cutsceneHandlers.test.ts
@@ -41,6 +41,7 @@ function makeCutscene(id = 'cs1'): Cutscene {
 }
 
 beforeEach(() => {
+  vi.resetModules();
   vi.clearAllMocks();
   useCutsceneStore.setState({
     cutscenes: {},

--- a/web/src/lib/chat/handlers/__tests__/exportAsset2dHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/exportAsset2dHandlers.test.ts
@@ -42,6 +42,7 @@ vi.mock('@/stores/editorStore', () => ({
 
 describe('exportHandlers', () => {
   beforeEach(async () => {
+    vi.resetModules();
     // Reset mutable state and clear call history
     mockEditorState.sceneName = 'TestScene';
     mockEditorState.loadingScreenConfig = null;

--- a/web/src/lib/chat/handlers/__tests__/shaderHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/shaderHandlers.test.ts
@@ -69,6 +69,7 @@ async function invoke(
 }
 
 beforeEach(async () => {
+  vi.resetModules();
   vi.clearAllMocks();
   mockGraphState = makeDefaultGraphState();
   const mod = await import('../shaderHandlers');

--- a/web/src/lib/costs/__tests__/costLogger.test.ts
+++ b/web/src/lib/costs/__tests__/costLogger.test.ts
@@ -36,6 +36,7 @@ vi.mock('@/lib/db/schema', () => ({
 
 describe('logCost', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     resetChain();
   });

--- a/web/src/lib/export/__tests__/errorScenarios.test.ts
+++ b/web/src/lib/export/__tests__/errorScenarios.test.ts
@@ -87,6 +87,7 @@ function scheduleSceneExportedEvent(detail: unknown, delayMs = 50) {
 
 describe('exportGame: missing scene data', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     // Mock fetch to return minimal WASM data so single-HTML export succeeds.
     // These tests focus on scene data fallback, not WASM inlining.
@@ -188,6 +189,7 @@ describe('exportGame: missing scene data', () => {
 
 describe('exportGame: empty entity list', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     // Mock fetch to return minimal WASM data so single-HTML export succeeds.
     mockFetchWithWasm();
@@ -284,6 +286,7 @@ describe('exportGame: empty entity list', () => {
 
 describe('exportGame: WASM fetch failure (#8186)', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     // All WASM fetches fail — simulates CDN down or engine not built
     global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
@@ -322,6 +325,7 @@ describe('exportGame: WASM fetch failure (#8186)', () => {
 
 describe('exportGame: AbortSignal cancellation (#8266)', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     mockFetchWithWasm();
   });
@@ -426,6 +430,7 @@ describe('downloadBlob: zero-byte blob', () => {
   let clickSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.resetModules();
     createObjectURLSpy = vi.fn(() => 'blob:zero-url');
     revokeObjectURLSpy = vi.fn();
     global.URL.createObjectURL = createObjectURLSpy as unknown as (obj: Blob | MediaSource) => string;

--- a/web/src/lib/game-creation/__tests__/decomposer.test.ts
+++ b/web/src/lib/game-creation/__tests__/decomposer.test.ts
@@ -94,6 +94,7 @@ let fetchAI: ReturnType<typeof vi.fn>;
 let sanitizePrompt: ReturnType<typeof vi.fn>;
 
 beforeEach(async () => {
+  vi.resetModules();
   vi.clearAllMocks();
 
   // Default: fetchAI returns valid JSON

--- a/web/src/lib/game-creation/__tests__/executors.test.ts
+++ b/web/src/lib/game-creation/__tests__/executors.test.ts
@@ -148,6 +148,10 @@ function makeMockCtx(overrides: Partial<ExecutorContext> = {}): ExecutorContext 
   };
 }
 
+beforeEach(() => {
+  vi.resetModules();
+});
+
 // ---------------------------------------------------------------------------
 // scene_create executor
 // ---------------------------------------------------------------------------

--- a/web/src/lib/i18n/__tests__/useTranslation.test.ts
+++ b/web/src/lib/i18n/__tests__/useTranslation.test.ts
@@ -17,6 +17,7 @@ vi.mock('next-intl', () => ({
 
 describe('useT', () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 

--- a/web/src/lib/keys/__tests__/encryption.test.ts
+++ b/web/src/lib/keys/__tests__/encryption.test.ts
@@ -11,7 +11,7 @@
  *  - Edge inputs: empty string, very long string, binary-safe unicode, newlines
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomBytes } from 'crypto';
 
 // ----- helpers -----
@@ -36,6 +36,7 @@ describe('encryption module', () => {
   let savedEnv: string | undefined;
 
   beforeEach(() => {
+    vi.resetModules();
     savedEnv = process.env.ENCRYPTION_MASTER_KEY;
     process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
   });

--- a/web/src/stores/__tests__/generationStore.test.ts
+++ b/web/src/stores/__tests__/generationStore.test.ts
@@ -40,6 +40,7 @@ describe('generationStore', () => {
   };
 
   beforeEach(() => {
+    vi.resetModules();
     // Mock fetch for addJob persistence (fire-and-forget)
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- Added `vi.resetModules()` to the `beforeEach` block of 81 test files that use dynamic `await import()` without module cache reset
- Prevents module cache contamination between tests within the same file, improving test reliability and isolation
- Skipped 5 files where dynamic imports are: JSON fixtures, Node stdlib, `beforeAll` single-load patterns, or string-matching false positives

## Details
Without `vi.resetModules()`, tests using `await import()` share the module cache. The first test's import gets reused by later tests, meaning mock setup changes between tests may not take effect. While `pool: forks` isolates between files, tests within a file share the module cache.

**Files modified:** 81 across API routes, components, hooks, libs, and stores
**Files correctly skipped:** 5 (false positives or patterns where reset would be ineffective)

Closes #7104

## Test plan
- [x] All 14,878 unit tests pass (1 pre-existing unhandled rejection in exportAbortSignal.test.ts, same on main)
- [x] ESLint: 0 warnings
- [x] TypeScript: 0 errors
- [x] Spot-checked batch 1, 2, 3 files individually — all pass