### PR TITLE
test: add server analytics + close coverage gaps (#7008)

### DIFF
--- a/.changeset/server-analytics-tests.md
+++ b/.changeset/server-analytics-tests.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add unit tests for server-side analytics event wrappers (events.server.ts)

--- a/web/src/lib/analytics/__tests__/events.server.test.ts
+++ b/web/src/lib/analytics/__tests__/events.server.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for lib/analytics/events.server.ts
+ *
+ * Verifies that each server-side event function calls @vercel/analytics/server track()
+ * with the correct event name and properties.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockTrack = vi.fn();
+vi.mock('@vercel/analytics/server', () => ({
+  track: mockTrack,
+}));
+
+describe('Server analytics event wrappers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('trackSubscriptionStarted sends tier and env', async () => {
+    const { trackSubscriptionStarted } = await import('@/lib/analytics/events.server');
+    await trackSubscriptionStarted('pro');
+    expect(mockTrack).toHaveBeenCalledWith('subscription_started', expect.objectContaining({ tier: 'pro' }));
+  });
+
+  it('trackSubscriptionCancelled sends tier and env', async () => {
+    const { trackSubscriptionCancelled } = await import('@/lib/analytics/events.server');
+    await trackSubscriptionCancelled('creator');
+    expect(mockTrack).toHaveBeenCalledWith('subscription_cancelled', expect.objectContaining({ tier: 'creator' }));
+  });
+
+  it('trackAddonTokensPurchased sends package name and env', async () => {
+    const { trackAddonTokensPurchased } = await import('@/lib/analytics/events.server');
+    await trackAddonTokensPurchased('starter_pack');
+    expect(mockTrack).toHaveBeenCalledWith('addon_tokens_purchased', expect.objectContaining({ package: 'starter_pack' }));
+  });
+
+  it('trackPaymentFailed sends tier and env', async () => {
+    const { trackPaymentFailed } = await import('@/lib/analytics/events.server');
+    await trackPaymentFailed('hobbyist');
+    expect(mockTrack).toHaveBeenCalledWith('payment_failed', expect.objectContaining({ tier: 'hobbyist' }));
+  });
+
+  it('trackGamePublishedServer sends tier, slug, and env', async () => {
+    const { trackGamePublishedServer } = await import('@/lib/analytics/events.server');
+    await trackGamePublishedServer('pro', 'my-awesome-game');
+    expect(mockTrack).toHaveBeenCalledWith('game_published', expect.objectContaining({
+      tier: 'pro',
+      slug: 'my-awesome-game',
+    }));
+  });
+
+  it('includes env dimension in all events', async () => {
+    const { trackSubscriptionStarted } = await import('@/lib/analytics/events.server');
+    await trackSubscriptionStarted('pro');
+    expect(mockTrack).toHaveBeenCalledWith('subscription_started', expect.objectContaining({ env: expect.any(String) }));
+  });
+});


### PR DESCRIPTION
## Summary
- Added unit tests for `events.server.ts` — the only module in analytics/email/i18n without test coverage
- All 5 server-side analytics functions now have tests verifying event names, properties, and env dimension

## Context
Issue #7008 reported zero test files for analytics, email, and i18n modules. Prior sessions already added:
- `analytics/__tests__/events.test.ts` (174 lines) — client event wrappers
- `analytics/__tests__/posthog.test.ts` — PostHog integration
- `analytics/__tests__/panelTracking.test.ts` — panel event tracking
- `analytics/__tests__/gameAnalytics.test.ts` — game analytics
- `email/__tests__/templates.test.ts` (307 lines) — HTML generation, XSS escaping
- `i18n/__tests__/useTranslation.test.ts` (86 lines) — namespace delegation

This PR closes the last gap: `events.server.ts` (server-side Vercel analytics).

Closes #7008

## Test plan
- [x] 6 new server analytics tests pass
- [x] All 181 analytics/email/i18n tests pass
- [x] ESLint: 0 warnings
- [x] TypeScript: 0 errors