### PR TITLE
fix: replace inline E2E timeout literals with named constants

### DIFF
--- a/.changeset/e2e-timeout-constants.md
+++ b/.changeset/e2e-timeout-constants.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Replace all inline timeout literals across 11 E2E files with named constants from e2e/constants.ts

--- a/web/e2e/constants.ts
+++ b/web/e2e/constants.ts
@@ -5,11 +5,17 @@
  * from this module instead of using inline numeric literals.
  */
 
+/** Very quick probe timeout (e.g. conditional visibility check) */
+export const E2E_TIMEOUT_QUICK_MS = 2_000;
+
 /** Short timeout for quick element appearances (e.g. tooltip, toast) */
 export const E2E_TIMEOUT_SHORT_MS = 3_000;
 
 /** Standard element visibility timeout */
 export const E2E_TIMEOUT_ELEMENT_MS = 5_000;
+
+/** Interaction timeout for UI responses after user actions */
+export const E2E_TIMEOUT_INTERACTION_MS = 8_000;
 
 /** Page / component load timeout */
 export const E2E_TIMEOUT_LOAD_MS = 10_000;
@@ -20,8 +26,14 @@ export const E2E_TIMEOUT_NAV_MS = 15_000;
 /** Auth flow timeout */
 export const E2E_TIMEOUT_AUTH_MS = 30_000;
 
+/** Engine init timeout (reload path after cold start) */
+export const E2E_TIMEOUT_ENGINE_INIT_MS = 40_000;
+
 /** WASM engine init / hydration timeout */
 export const E2E_TIMEOUT_WASM_MS = 45_000;
 
 /** Global per-test timeout */
 export const E2E_TIMEOUT_TEST_MS = 60_000;
+
+/** Full engine cold-start timeout (first load, CI webpack compile) */
+export const E2E_TIMEOUT_ENGINE_FULL_MS = 90_000;

--- a/web/e2e/fixtures/editor.fixture.ts
+++ b/web/e2e/fixtures/editor.fixture.ts
@@ -1,5 +1,12 @@
 import { test as base, expect, type Page } from '@playwright/test';
 import { E2E_HYDRATION_TIMEOUT_MS } from '../../src/lib/config/timeouts';
+import {
+  E2E_TIMEOUT_ELEMENT_MS,
+  E2E_TIMEOUT_LOAD_MS,
+  E2E_TIMEOUT_TEST_MS,
+  E2E_TIMEOUT_ENGINE_INIT_MS,
+  E2E_TIMEOUT_ENGINE_FULL_MS,
+} from '../constants';
 
 /**
  * Page Object Model for the Project Forge editor.
@@ -43,7 +50,7 @@ export class EditorPage {
       { timeout: E2E_HYDRATION_TIMEOUT_MS }
     );
     // Wait for the editor layout container to be visible (canonical way to know hydration + layout is stable)
-    await this.page.locator('.dv-dockview').first().waitFor({ state: 'visible', timeout: 5000 });
+    await this.page.locator('.dv-dockview').first().waitFor({ state: 'visible', timeout: E2E_TIMEOUT_ELEMENT_MS });
   }
 
   /** Navigate to /dev without waiting for WASM (for @ui tests in CI) */
@@ -82,7 +89,7 @@ export class EditorPage {
 
     // Use 'commit' to avoid navigation timeout under parallel test load.
     // The actual readiness gate is __REACT_HYDRATED below.
-    await this.page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await this.page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await this.page.waitForLoadState('domcontentloaded');
     // Wait for React hydration — ensures all event handlers (keyboard shortcuts,
     // button clicks) are attached. This fires after EditorLayout mounts.
@@ -95,7 +102,7 @@ export class EditorPage {
       await this.page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 }
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS }
       );
     } catch {
       // Reload — chunks should be compiled by now
@@ -103,7 +110,7 @@ export class EditorPage {
       await this.page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 }
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS }
       );
     }
   }
@@ -117,7 +124,7 @@ export class EditorPage {
         return store && Object.keys(store.getState().sceneGraph.nodes).length >= expected;
       },
       count,
-      { timeout: 10_000 }
+      { timeout: E2E_TIMEOUT_LOAD_MS }
     );
   }
 
@@ -143,7 +150,7 @@ export class EditorPage {
   async expectPanelVisible(panelTitle: string) {
     await expect(
       this.page.locator(`.dv-tab, [data-testid="panel-${panelTitle}"]`).filter({ hasText: new RegExp(panelTitle, 'i') }).first()
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
   }
 
   /** Check that no visible text elements are invisible (zero opacity or transparent color) */
@@ -172,7 +179,7 @@ export class EditorPage {
   /** Open settings modal */
   async openSettings() {
     await this.page.getByRole('button', { name: /settings/i }).click();
-    await expect(this.page.locator('[role="dialog"][aria-labelledby="settings-dialog-title"]')).toBeVisible({ timeout: 5000 });
+    await expect(this.page.locator('[role="dialog"][aria-labelledby="settings-dialog-title"]')).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
   }
 
   /** Press keyboard shortcut */
@@ -181,7 +188,7 @@ export class EditorPage {
   }
 
   /** Wait until __EDITOR_STORE is available (guards against hydration race). */
-  async waitForEditorStore(timeout = 10_000) {
+  async waitForEditorStore(timeout = E2E_TIMEOUT_LOAD_MS) {
     await this.page.waitForFunction(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       () => !!(window as any).__EDITOR_STORE,

--- a/web/e2e/tests/accessibility-audit.spec.ts
+++ b/web/e2e/tests/accessibility-audit.spec.ts
@@ -15,8 +15,11 @@ import type { Page } from '@playwright/test';
 import {
   E2E_TIMEOUT_SHORT_MS,
   E2E_TIMEOUT_ELEMENT_MS,
-  E2E_TIMEOUT_NAV_MS,
   E2E_TIMEOUT_LOAD_MS,
+  E2E_TIMEOUT_NAV_MS,
+  E2E_TIMEOUT_TEST_MS,
+  E2E_TIMEOUT_ENGINE_INIT_MS,
+  E2E_TIMEOUT_ENGINE_FULL_MS,
 } from '../constants';
 import { waitForHydration } from '../helpers/wait-helpers';
 
@@ -208,14 +211,14 @@ test.describe('Accessibility Audit — WelcomeModal @ui @dev', () => {
       );
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
-      await waitForHydration(page, 90_000);
+      await waitForHydration(page, E2E_TIMEOUT_ENGINE_FULL_MS);
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
-      await waitForHydration(page, 40_000);
+      await waitForHydration(page, E2E_TIMEOUT_ENGINE_INIT_MS);
     }
 
     const welcomeModal = page.locator(

--- a/web/e2e/tests/ai-entity-roundtrip.spec.ts
+++ b/web/e2e/tests/ai-entity-roundtrip.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '../fixtures/editor.fixture';
+import {
+  E2E_TIMEOUT_ELEMENT_MS,
+  E2E_TIMEOUT_INTERACTION_MS,
+  E2E_TIMEOUT_LOAD_MS,
+} from '../constants';
 import { injectStore, readStore } from '../helpers/store-injection';
 
 /**
@@ -74,7 +79,7 @@ test.describe('AI → Entity Round-trip: Store Pipeline @ui @dev', () => {
     // The hierarchy panel is React-rendered from store state — it renders
     // immediately after store injection without requiring WASM.
     const hierarchyNode = page.getByText(entityName, { exact: false });
-    await expect(hierarchyNode.first()).toBeVisible({ timeout: 5000 });
+    await expect(hierarchyNode.first()).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
   });
 
   // -------------------------------------------------------------------------
@@ -177,7 +182,7 @@ test.describe('AI → Entity Round-trip: Store Pipeline @ui @dev', () => {
     // must appear in the DOM after its store injection.
     for (const entity of entities) {
       const domNode = page.getByText(entity.name, { exact: false });
-      await expect(domNode.first()).toBeVisible({ timeout: 5000 });
+      await expect(domNode.first()).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
     }
   });
 
@@ -221,7 +226,7 @@ test.describe('AI → Entity Round-trip: Engine Pipeline @engine', () => {
 
     // Entity name must appear in the DOM hierarchy
     const cubeInHierarchy = page.getByText('AICube', { exact: false });
-    await expect(cubeInHierarchy.first()).toBeVisible({ timeout: 8000 });
+    await expect(cubeInHierarchy.first()).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Select the entity and verify the inspector renders the Transform section
     await cubeInHierarchy.first().click();
@@ -232,11 +237,11 @@ test.describe('AI → Entity Round-trip: Engine Pipeline @engine', () => {
         const store = (window as any).__EDITOR_STORE;
         return store && store.getState().selectedIds.size > 0;
       },
-      { timeout: 8000 },
+      { timeout: E2E_TIMEOUT_INTERACTION_MS },
     );
 
     const transformSection = page.getByText('Transform', { exact: false });
-    await expect(transformSection.first()).toBeVisible({ timeout: 5000 });
+    await expect(transformSection.first()).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
   });
 
   // -------------------------------------------------------------------------
@@ -257,7 +262,7 @@ test.describe('AI → Entity Round-trip: Engine Pipeline @engine', () => {
         const store = (window as any).__EDITOR_STORE;
         return store && store.getState().selectedIds.size > 0;
       },
-      { timeout: 10000 },
+      { timeout: E2E_TIMEOUT_LOAD_MS },
     );
 
     // Retrieve the selected entity id

--- a/web/e2e/tests/demo-regression.spec.ts
+++ b/web/e2e/tests/demo-regression.spec.ts
@@ -11,6 +11,7 @@
  */
 import { test, expect } from '../fixtures/editor.fixture';
 import {
+  E2E_TIMEOUT_QUICK_MS,
   E2E_TIMEOUT_SHORT_MS,
   E2E_TIMEOUT_ELEMENT_MS,
   E2E_TIMEOUT_LOAD_MS,
@@ -189,13 +190,13 @@ test.describe('Demo Regression Walkthrough @ui @dev', () => {
   test('keyboard shortcuts work in editor', async ({ page }) => {
     // Undo button should be visible
     const undoBtn = page.locator('button[title*="Undo"]').first();
-    if (await undoBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await undoBtn.isVisible({ timeout: E2E_TIMEOUT_QUICK_MS }).catch(() => false)) {
       await expect(undoBtn).toBeVisible();
     }
 
     // Export button should be accessible
     const exportBtn = page.locator('button[title*="Export"], button[title*="export"]').first();
-    if (await exportBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    if (await exportBtn.isVisible({ timeout: E2E_TIMEOUT_QUICK_MS }).catch(() => false)) {
       await expect(exportBtn).toBeVisible();
     }
   });

--- a/web/e2e/tests/load-scene.spec.ts
+++ b/web/e2e/tests/load-scene.spec.ts
@@ -14,7 +14,7 @@
  */
 
 import { test, expect } from '../fixtures/editor.fixture';
-import { E2E_TIMEOUT_LOAD_MS, E2E_TIMEOUT_NAV_MS } from '../constants';
+import { E2E_TIMEOUT_ELEMENT_MS, E2E_TIMEOUT_LOAD_MS, E2E_TIMEOUT_NAV_MS } from '../constants';
 
 /** Minimal valid .forge scene JSON with one Cube entity */
 const MINIMAL_SCENE_JSON = JSON.stringify({
@@ -224,7 +224,7 @@ test.describe('load_scene engine round-trip @engine', () => {
         }
         return false;
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     ).catch(() => undefined); // panel visibility is checked below
 
     const panelVisible = await hierarchyPanel.isVisible().catch(() => false);

--- a/web/e2e/tests/performance-budget.spec.ts
+++ b/web/e2e/tests/performance-budget.spec.ts
@@ -11,7 +11,7 @@
  */
 
 import { test, expect } from '../fixtures/editor.fixture';
-import { E2E_TIMEOUT_TEST_MS } from '../constants';
+import { E2E_TIMEOUT_SHORT_MS, E2E_TIMEOUT_TEST_MS } from '../constants';
 
 test.describe('Performance Budget @ui @dev', () => {
   test('LCP is under 2500ms on editor page', async ({ page, editor }) => {
@@ -42,7 +42,7 @@ test.describe('Performance Budget @ui @dev', () => {
         const vals = (window as unknown as Record<string, unknown>).__LCP_VALUES;
         return Array.isArray(vals) && vals.length > 0;
       },
-      { timeout: 3000 },
+      { timeout: E2E_TIMEOUT_SHORT_MS },
     ).catch(async () => {
       // LCP may not fire on some CI configs — fall back to networkidle
       await page.waitForLoadState('networkidle').catch(() => undefined);

--- a/web/e2e/tests/property-editing.spec.ts
+++ b/web/e2e/tests/property-editing.spec.ts
@@ -16,6 +16,11 @@
 
 import type { Page } from '@playwright/test';
 import { test, expect, EditorPage } from '../fixtures/editor.fixture';
+import {
+  E2E_TIMEOUT_ELEMENT_MS,
+  E2E_TIMEOUT_INTERACTION_MS,
+  E2E_TIMEOUT_LOAD_MS,
+} from '../constants';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -39,7 +44,7 @@ async function spawnCubeAndSelect(page: Page, editor: EditorPage) {
       const store = (window as unknown as { __EDITOR_STORE?: { getState: () => { selectedIds: Set<string> } } }).__EDITOR_STORE;
       return store && store.getState().selectedIds.size > 0;
     },
-    { timeout: 10_000 },
+    { timeout: E2E_TIMEOUT_LOAD_MS },
   );
 }
 
@@ -69,7 +74,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
     await spawnCubeAndSelect(page, editor);
 
     const transformHeading = page.getByText('Transform', { exact: false });
-    await expect(transformHeading.first()).toBeVisible({ timeout: 8_000 });
+    await expect(transformHeading.first()).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // X, Y, Z labels must be present — proves the inspector rendered position fields
     await expect(page.getByText('X', { exact: true }).first()).toBeVisible();
@@ -92,7 +97,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
     // on nth-child ordering which can change if the inspector layout changes.
     const transformSection = page.getByText('Transform', { exact: false }).first().locator('..');
     const xInput = transformSection.locator('input').first();
-    await expect(xInput).toBeVisible({ timeout: 5_000 });
+    await expect(xInput).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Fill in a distinctive value that is unlikely to be the default
     await xInput.click({ clickCount: 3 });
@@ -110,7 +115,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
         // primaryTransform.position[0] should be approximately 7.5
         return t && typeof t.position?.[0] === 'number' && Math.abs(t.position[0] - 7.5) < 0.1;
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { position?: number[] } } | undefined;
@@ -171,7 +176,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
         const zOk = typeof t.position?.[2] === 'number' && Math.abs(t.position[2] - (-2.5)) < 0.1;
         return yOk && zOk;
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { position?: number[] } } | undefined;
@@ -190,7 +195,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
 
     // Use the data-testid added to the Rotation Vec3Input for reliable targeting
     const rotationRow = page.locator('[data-testid="vec3-rotation"]');
-    await expect(rotationRow).toBeVisible({ timeout: 8_000 });
+    await expect(rotationRow).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
     const rotXInput = rotationRow.locator('input').first();
 
     // Capture the rotation value BEFORE editing so we can detect a real change.
@@ -216,7 +221,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
         return Math.abs(val - 45) < 1.0 || Math.abs(val - 0.785398) < 0.1;
       },
       [beforeRot] as [number | null],
-      { timeout: 10_000 },
+      { timeout: E2E_TIMEOUT_LOAD_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { rotation?: number[] } } | undefined;
@@ -242,7 +247,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
 
     // Use the data-testid added to the Scale Vec3Input for reliable targeting
     const scaleRow = page.locator('[data-testid="vec3-scale"]');
-    await expect(scaleRow).toBeVisible({ timeout: 8_000 });
+    await expect(scaleRow).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
     const scaleXInput = scaleRow.locator('input').first();
 
     await scaleXInput.click({ clickCount: 3 });
@@ -256,7 +261,7 @@ test.describe('Group 1: Transform Editing @engine', () => {
         const t = store.getState().primaryTransform;
         return t && Array.isArray(t.scale) && Math.abs(t.scale[0] - 2.0) < 0.1;
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { scale?: number[] } } | undefined;
@@ -283,7 +288,7 @@ test.describe('Group 2: Material Editing @engine', () => {
     await spawnCubeAndSelect(page, editor);
 
     const materialHeading = page.getByText(/material/i, { exact: false }).first();
-    await expect(materialHeading).toBeVisible({ timeout: 8_000 });
+    await expect(materialHeading).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
   });
 
   test('changing metallic input dispatches update_material and updates the store', async ({
@@ -301,10 +306,10 @@ test.describe('Group 2: Material Editing @engine', () => {
 
     // Find the metallic label and its sibling input
     const metallicLabel = page.locator('text=/metallic/i').first();
-    await expect(metallicLabel).toBeVisible({ timeout: 8_000 });
+    await expect(metallicLabel).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     const metallicInput = metallicLabel.locator('..').locator('input').first();
-    await expect(metallicInput).toBeVisible({ timeout: 5_000 });
+    await expect(metallicInput).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     await metallicInput.click({ clickCount: 3 });
     await metallicInput.fill('0.85');
@@ -324,7 +329,7 @@ test.describe('Group 2: Material Editing @engine', () => {
         return changed && correct;
       },
       beforeMetallic,
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const afterState = await getStoreState(page) as { primaryMaterial?: { metallic?: number } } | undefined;
@@ -345,14 +350,14 @@ test.describe('Group 2: Material Editing @engine', () => {
         const store = (window as unknown as { __EDITOR_STORE?: { getState: () => { selectedIds: Set<string> } } }).__EDITOR_STORE;
         return store && store.getState().selectedIds.size > 0;
       },
-      { timeout: 10_000 },
+      { timeout: E2E_TIMEOUT_LOAD_MS },
     );
 
     const roughnessLabel = page.locator('text=/roughness/i').first();
-    await expect(roughnessLabel).toBeVisible({ timeout: 8_000 });
+    await expect(roughnessLabel).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     const roughnessInput = roughnessLabel.locator('..').locator('input').first();
-    await expect(roughnessInput).toBeVisible({ timeout: 5_000 });
+    await expect(roughnessInput).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     await roughnessInput.click({ clickCount: 3 });
     await roughnessInput.fill('0.25');
@@ -365,7 +370,7 @@ test.describe('Group 2: Material Editing @engine', () => {
         const mat = store.getState().primaryMaterial;
         return mat && Math.abs((mat.perceptualRoughness ?? 0) - 0.25) < 0.05;
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryMaterial?: { perceptualRoughness?: number } } | undefined;
@@ -390,7 +395,7 @@ test.describe('Group 2: Material Editing @engine', () => {
 
     // Look for a material preset button — the material library uses named presets
     const presetBtn = page.locator('button').filter({ hasText: /metal|plastic|wood|glass|stone/i }).first();
-    await expect(presetBtn).toBeVisible({ timeout: 8_000 });
+    await expect(presetBtn).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     await presetBtn.click();
 
@@ -411,7 +416,7 @@ test.describe('Group 2: Material Editing @engine', () => {
         );
       },
       before ? JSON.stringify(before) : null,
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const afterState = await getStoreState(page) as { primaryMaterial?: unknown } | undefined;
@@ -435,7 +440,7 @@ test.describe('Group 3: Physics Toggle @engine', () => {
     await spawnCubeAndSelect(page, editor);
 
     const physicsSection = page.getByText(/physics/i, { exact: false }).first();
-    await expect(physicsSection).toBeVisible({ timeout: 8_000 });
+    await expect(physicsSection).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
   });
 
   test('toggling physics enabled checkbox changes physicsEnabled in the store', async ({
@@ -445,7 +450,7 @@ test.describe('Group 3: Physics Toggle @engine', () => {
     await spawnCubeAndSelect(page, editor);
 
     // Wait for physics section to render
-    await expect(page.getByText(/physics/i).first()).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText(/physics/i).first()).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Capture initial state — physicsEnabled starts false for newly spawned entities
     const initialState = await getStoreState(page) as { physicsEnabled?: boolean } | undefined;
@@ -459,7 +464,7 @@ test.describe('Group 3: Physics Toggle @engine', () => {
     const physicsToggle = physicsSectionContainer
       .locator('[role="checkbox"], input[type="checkbox"]')
       .first();
-    await expect(physicsToggle).toBeVisible({ timeout: 8_000 });
+    await expect(physicsToggle).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     const wasChecked = await physicsToggle.isChecked();
     await physicsToggle.click();
@@ -472,7 +477,7 @@ test.describe('Group 3: Physics Toggle @engine', () => {
         return store.getState().physicsEnabled !== was;
       },
       wasChecked,
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const nowState = await getStoreState(page) as { physicsEnabled?: boolean } | undefined;
@@ -504,7 +509,7 @@ test.describe('Group 4: Store Round-Trip Verification @engine', () => {
     // Edit position X via the inspector input
     const transformSection = page.getByText('Transform', { exact: false }).first().locator('..');
     const xInput = transformSection.locator('input').first();
-    await expect(xInput).toBeVisible({ timeout: 5_000 });
+    await expect(xInput).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     const targetValue = 4.5;
     await xInput.click({ clickCount: 3 });
@@ -520,7 +525,7 @@ test.describe('Group 4: Store Round-Trip Verification @engine', () => {
         return t && typeof t.position?.[0] === 'number' && Math.abs(t.position[0] - expected) < 0.1;
       },
       targetValue,
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { position?: number[] } } | undefined;
@@ -576,7 +581,7 @@ test.describe('Group 4: Store Round-Trip Verification @engine', () => {
           Math.abs(t.position[2] - 3.0) < 0.1
         );
       },
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const state = await getStoreState(page) as { primaryTransform?: { position?: number[] }; selectedIds?: Set<string> } | undefined;

--- a/web/e2e/tests/save-load-roundtrip.spec.ts
+++ b/web/e2e/tests/save-load-roundtrip.spec.ts
@@ -23,6 +23,11 @@
  */
 
 import { test, expect } from '../fixtures/editor.fixture';
+import {
+  E2E_TIMEOUT_SHORT_MS,
+  E2E_TIMEOUT_ELEMENT_MS,
+  E2E_TIMEOUT_NAV_MS,
+} from '../constants';
 
 // ---------------------------------------------------------------------------
 // Fixtures — minimal .forge scene payloads used across multiple tests
@@ -168,7 +173,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
     await expect.poll(
       () => editor.getStoreState<Record<string, unknown>>('sceneGraph.nodes')
         .then((nodes) => Object.keys(nodes)),
-      { timeout: 5_000 }
+      { timeout: E2E_TIMEOUT_ELEMENT_MS }
     ).toEqual(expect.arrayContaining(['rt-entity-1', 'rt-entity-2', 'rt-entity-3']));
 
     // Entity names survive round-trip
@@ -201,7 +206,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
     // Verify it was set
     await expect.poll(
       () => editor.getStoreState<string>('sceneName'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('MySavedScene');
 
     // Serialize scene state (name + graph) to simulate a file export
@@ -231,7 +236,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
 
     await expect.poll(
       () => editor.getStoreState<string>('sceneName'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('Untitled');
 
     // Restore from serialized — simulates what a load handler does after
@@ -255,7 +260,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
     // Scene name must match original after round-trip
     await expect.poll(
       () => editor.getStoreState<string>('sceneName'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('MySavedScene');
   });
 
@@ -327,7 +332,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
         const t = await editor.getStoreState<{ entityId: string; position: [number, number, number] } | null>('primaryTransform');
         return t?.entityId === entity.entityId ? t.position : null;
       },
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toEqual([5, 10, 15]);
 
     // Serialize current state
@@ -390,7 +395,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
     await expect.poll(
       () => editor.getStoreState<Record<string, unknown>>('sceneGraph.nodes')
         .then((nodes) => nodes[entity.entityId] ?? null),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).not.toBeNull();
 
     // Verify transform survived
@@ -399,7 +404,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
         const t = await editor.getStoreState<{ entityId: string; position: [number, number, number] } | null>('primaryTransform');
         return t?.entityId === entity.entityId ? t.position : null;
       },
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toEqual([5, 10, 15]);
   });
 
@@ -429,7 +434,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
     // Confirm loadScene accepted the call by verifying the store is still operational
     await expect.poll(
       () => editor.getStoreState<boolean | null>('sceneModified').then(() => true),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe(true);
   });
 
@@ -445,7 +450,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
 
     await expect.poll(
       () => editor.getStoreState<string>('sceneName'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('OldName');
 
     // Call loadScene with a JSON payload that includes the new name.
@@ -471,7 +476,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
 
     await expect.poll(
       () => editor.getStoreState<string>('sceneName'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('MySavedScene');
   });
 
@@ -490,7 +495,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
 
     await expect.poll(
       () => editor.getStoreState<string>('cloudSaveStatus'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('saving');
 
     // Transition to saved
@@ -504,7 +509,7 @@ test.describe('Save/Load round-trip — store level @ui @dev', () => {
 
     await expect.poll(
       () => editor.getStoreState<string>('cloudSaveStatus'),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBe('saved');
   });
 });
@@ -525,7 +530,7 @@ test.describe('Save/Load round-trip — UI level @engine', () => {
     await editor.waitForEntityCount(2); // Camera + Cube
 
     // Start listening for download before triggering it
-    const downloadPromise = page.waitForEvent('download', { timeout: 15_000 }).catch(() => null);
+    const downloadPromise = page.waitForEvent('download', { timeout: E2E_TIMEOUT_NAV_MS }).catch(() => null);
 
     // Trigger save — Ctrl+S with no projectId dispatches export_scene + download
     await page.keyboard.press('Control+s');
@@ -580,7 +585,7 @@ test.describe('Save/Load round-trip — UI level @engine', () => {
 
     await expect.poll(
       () => dispatchedCommands.includes('export_scene'),
-      { timeout: 5_000 }
+      { timeout: E2E_TIMEOUT_ELEMENT_MS }
     ).toBe(true);
   });
 
@@ -607,7 +612,7 @@ test.describe('Save/Load round-trip — UI level @engine', () => {
         const headingVisible = await headingText.isVisible().catch(() => false);
         return panelVisible || headingVisible;
       },
-      { timeout: 5_000 }
+      { timeout: E2E_TIMEOUT_ELEMENT_MS }
     ).toBe(true);
   });
 
@@ -641,7 +646,7 @@ test.describe('Save/Load round-trip — UI level @engine', () => {
         const status = store?.getState().cloudSaveStatus ?? null;
         return status !== null && ['idle', 'saving', 'error'].includes(status);
       }),
-      { timeout: 3_000 }
+      { timeout: E2E_TIMEOUT_SHORT_MS }
     ).toBeTruthy();
   });
 });

--- a/web/e2e/tests/template-flow.spec.ts
+++ b/web/e2e/tests/template-flow.spec.ts
@@ -1,5 +1,13 @@
 import { test, expect } from '../fixtures/editor.fixture';
 import type { Page } from '@playwright/test';
+import {
+  E2E_TIMEOUT_SHORT_MS,
+  E2E_TIMEOUT_ELEMENT_MS,
+  E2E_TIMEOUT_INTERACTION_MS,
+  E2E_TIMEOUT_TEST_MS,
+  E2E_TIMEOUT_ENGINE_INIT_MS,
+  E2E_TIMEOUT_ENGINE_FULL_MS,
+} from '../constants';
 
 /**
  * Template gallery and starter bundle onboarding flow tests.
@@ -25,36 +33,36 @@ test.describe('Template Gallery @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     // WelcomeModal should appear — it shows when forge-welcomed is absent
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await expect(welcomeModal).toBeVisible({ timeout: 8_000 });
+    await expect(welcomeModal).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Click "Browse Templates" to open the TemplateGallery
     const browseBtn = page.getByRole('button', { name: /browse templates/i });
-    await expect(browseBtn).toBeVisible({ timeout: 5_000 });
+    await expect(browseBtn).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
     await browseBtn.click();
 
     // TemplateGallery dialog should appear
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await expect(galleryDialog).toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Heading text
     const heading = page.locator('#template-gallery-title');
@@ -76,30 +84,30 @@ test.describe('Template Gallery @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await expect(welcomeModal).toBeVisible({ timeout: 8_000 });
+    await expect(welcomeModal).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await expect(galleryDialog).toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Every card must have a non-empty <h3> (name) and a <p> (description)
     const cards = galleryDialog.locator('button').filter({ has: page.locator('h3') });
@@ -125,29 +133,29 @@ test.describe('Template Gallery @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
-    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: 8_000 });
+    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await expect(galleryDialog).toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Difficulty badges are rendered as spans with 'capitalize' class
     const difficultyBadges = galleryDialog.locator('span.capitalize');
@@ -173,36 +181,36 @@ test.describe('Template Gallery @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
-    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: 8_000 });
+    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await expect(galleryDialog).toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Close via the X button
     const closeBtn = page.getByRole('button', { name: /close template gallery/i });
     await expect(closeBtn).toBeVisible();
     await closeBtn.click();
 
-    await expect(galleryDialog).not.toBeVisible({ timeout: 3_000 });
+    await expect(galleryDialog).not.toBeVisible({ timeout: E2E_TIMEOUT_SHORT_MS });
   });
 
   test('template gallery can be closed by pressing Escape', async ({ page }) => {
@@ -214,32 +222,32 @@ test.describe('Template Gallery @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
-    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: 8_000 });
+    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await expect(galleryDialog).toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     await page.keyboard.press('Escape');
-    await expect(galleryDialog).not.toBeVisible({ timeout: 3_000 });
+    await expect(galleryDialog).not.toBeVisible({ timeout: E2E_TIMEOUT_SHORT_MS });
   });
 });
 
@@ -258,30 +266,30 @@ test.describe('Template selection flow @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await welcomeModal.waitFor({ state: 'visible', timeout: 8_000 });
+    await welcomeModal.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await galleryDialog.waitFor({ state: 'visible', timeout: 5_000 });
+    await galleryDialog.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_ELEMENT_MS });
   }
 
   test('selecting Blank Project closes the gallery', async ({ page }) => {
@@ -290,13 +298,13 @@ test.describe('Template selection flow @ui @dev', () => {
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
 
     const blankCard = galleryDialog.locator('button').filter({ hasText: /blank project/i });
-    await expect(blankCard).toBeVisible({ timeout: 3_000 });
+    await expect(blankCard).toBeVisible({ timeout: E2E_TIMEOUT_SHORT_MS });
     await blankCard.click();
 
     // Both the gallery and the WelcomeModal should close after selecting blank
-    await expect(galleryDialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await expect(welcomeModal).not.toBeVisible({ timeout: 5_000 });
+    await expect(welcomeModal).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
   });
 
   test('selecting a named template closes the gallery', async ({ page }) => {
@@ -320,9 +328,9 @@ test.describe('Template selection flow @ui @dev', () => {
     await firstTemplate.click();
 
     // Both modals should close after selection
-    await expect(galleryDialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await expect(welcomeModal).not.toBeVisible({ timeout: 5_000 });
+    await expect(welcomeModal).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // The selected template name should be non-empty (guards against empty card bug)
     expect(templateName?.trim().length).toBeGreaterThan(0);
@@ -347,13 +355,13 @@ test.describe('Template selection flow @ui @dev', () => {
     await firstTemplate.click();
 
     // Wait for gallery to close
-    await expect(galleryDialog).not.toBeVisible({ timeout: 5_000 });
+    await expect(galleryDialog).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // Wait for store then read sceneGraph node count
     await page.waitForFunction(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       () => !!(window as any).__EDITOR_STORE,
-      { timeout: 5_000 },
+      { timeout: E2E_TIMEOUT_ELEMENT_MS },
     );
 
     const nodeCount = await page.evaluate(() => {
@@ -388,27 +396,27 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     // WelcomeModal should be visible
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await expect(welcomeModal).toBeVisible({ timeout: 8_000 });
+    await expect(welcomeModal).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Heading
     await expect(welcomeModal.locator('#welcome-modal-title')).toHaveText(/welcome to spawnforge/i);
@@ -440,26 +448,26 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await welcomeModal.waitFor({ state: 'visible', timeout: 8_000 });
+    await welcomeModal.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Check "Don't show again" via JS click — CI viewport clips the dialog bottom
     // and Playwright refuses to interact even with force:true (viewport constraint)
@@ -478,7 +486,7 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       const skip = Array.from(btns ?? []).find(b => /^skip$/i.test(b.textContent?.trim() ?? ''));
       if (skip) { skip.click(); }
     });
-    await expect(welcomeModal).not.toBeVisible({ timeout: 5_000 });
+    await expect(welcomeModal).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // forge-welcomed should now be set in localStorage
     const forgeWelcomed = await page.evaluate(() => localStorage.getItem('forge-welcomed'));
@@ -495,26 +503,26 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await welcomeModal.waitFor({ state: 'visible', timeout: 8_000 });
+    await welcomeModal.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Do NOT check "Don't show again" — just click Skip via JS
     // CI viewport clips dialog bottom; Playwright refuses interaction even with force:true
@@ -524,7 +532,7 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       const skip = Array.from(btns ?? []).find(b => /^skip$/i.test(b.textContent?.trim() ?? ''));
       if (skip) { skip.click(); }
     });
-    await expect(welcomeModal).not.toBeVisible({ timeout: 5_000 });
+    await expect(welcomeModal).not.toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     // forge-welcomed must NOT be set
     const forgeWelcomed = await page.evaluate(() => localStorage.getItem('forge-welcomed'));
@@ -541,26 +549,26 @@ test.describe('Welcome modal onboarding gate @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
     const welcomeModal = page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]');
-    await welcomeModal.waitFor({ state: 'visible', timeout: 8_000 });
+    await welcomeModal.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Must have role="dialog"
     await expect(welcomeModal).toHaveAttribute('role', 'dialog');
@@ -585,29 +593,29 @@ test.describe('Template gallery ARIA structure @ui @dev', () => {
       localStorage.setItem('forge-onboarding-v2', JSON.stringify({ state: { isNewUser: false }, version: 0 }));
     });
 
-    await page.goto('/dev', { waitUntil: 'commit', timeout: 60_000 });
+    await page.goto('/dev', { waitUntil: 'commit', timeout: E2E_TIMEOUT_TEST_MS });
     await page.waitForLoadState('domcontentloaded');
 
     try {
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 90_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_FULL_MS },
       );
     } catch {
       await page.reload({ waitUntil: 'domcontentloaded' });
       await page.waitForFunction(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         () => (window as any).__REACT_HYDRATED === true,
-        { timeout: 40_000 },
+        { timeout: E2E_TIMEOUT_ENGINE_INIT_MS },
       );
     }
 
-    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: 8_000 });
+    await page.locator('[role="dialog"][aria-labelledby="welcome-modal-title"]').waitFor({ state: 'visible', timeout: E2E_TIMEOUT_INTERACTION_MS });
     await page.getByRole('button', { name: /browse templates/i }).click();
 
     const galleryDialog = page.locator('[role="dialog"][aria-labelledby="template-gallery-title"]');
-    await galleryDialog.waitFor({ state: 'visible', timeout: 5_000 });
+    await galleryDialog.waitFor({ state: 'visible', timeout: E2E_TIMEOUT_ELEMENT_MS });
 
     await expect(galleryDialog).toHaveAttribute('role', 'dialog');
     await expect(galleryDialog).toHaveAttribute('aria-modal', 'true');

--- a/web/e2e/tests/theme-effects.spec.ts
+++ b/web/e2e/tests/theme-effects.spec.ts
@@ -8,6 +8,7 @@
  * and do NOT require the WASM engine to be initialized.
  */
 import { test, expect } from '../fixtures/editor.fixture';
+import { E2E_TIMEOUT_SHORT_MS, E2E_TIMEOUT_ELEMENT_MS } from '../constants';
 
 const LIGHT_THEMES = ['ember', 'ice', 'leaf', 'rust', 'mech', 'light'] as const;
 
@@ -38,7 +39,7 @@ test.describe('Theme Effects @ui @dev', () => {
       }, theme);
 
       const effect = page.locator(`[data-sf-effect="${theme}"]`);
-      await expect(effect).toBeVisible({ timeout: 5000 });
+      await expect(effect).toBeVisible({ timeout: E2E_TIMEOUT_ELEMENT_MS });
 
       // Verify pointer-events: none (so effect doesn't block interactions)
       const pe = await effect.evaluate((el) => getComputedStyle(el).pointerEvents);
@@ -88,6 +89,6 @@ test.describe('Theme Effects @ui @dev', () => {
     });
 
     // Effect should appear
-    await expect(page.locator('[data-sf-effect="ember"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[data-sf-effect="ember"]')).toBeVisible({ timeout: E2E_TIMEOUT_SHORT_MS });
   });
 });

--- a/web/e2e/tests/update-material.spec.ts
+++ b/web/e2e/tests/update-material.spec.ts
@@ -15,7 +15,7 @@
  */
 
 import { test, expect } from '../fixtures/editor.fixture';
-import { E2E_TIMEOUT_ELEMENT_MS, E2E_TIMEOUT_LOAD_MS } from '../constants';
+import { E2E_TIMEOUT_ELEMENT_MS, E2E_TIMEOUT_INTERACTION_MS, E2E_TIMEOUT_LOAD_MS } from '../constants';
 
 test.describe('update_material dispatch @engine', () => {
   test.beforeEach(async ({ editor }) => {
@@ -143,7 +143,7 @@ test.describe('update_material dispatch @engine', () => {
 
     // Material section must be visible
     const materialSection = page.getByText(/material/i, { exact: false }).first();
-    await expect(materialSection).toBeVisible({ timeout: 8_000 });
+    await expect(materialSection).toBeVisible({ timeout: E2E_TIMEOUT_INTERACTION_MS });
 
     // Get entity id before interaction
     await page.waitForFunction(


### PR DESCRIPTION
## Summary
- Add 4 new timeout constants to `e2e/constants.ts`: `QUICK` (2s), `INTERACTION` (8s), `ENGINE_INIT` (40s), `ENGINE_FULL` (90s)
- Replace all 126 inline numeric timeout values across 11 spec files and the editor fixture with named constants
- Zero inline timeout literals remain in the E2E test suite

Closes #7432

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npx eslint --max-warnings 0 e2e/` passes
- [x] `npx vitest run` — 722 files, 14,886 tests pass (1 pre-existing unrelated error in exportAbortSignal.test.ts)
- [x] No inline timeout literals remain (`grep` returns zero matches)