### PR TITLE
fix: enforce 44px minimum touch targets on Inspector buttons

### DIFF
--- a/.changeset/inspector-touch-targets.md
+++ b/.changeset/inspector-touch-targets.md
@@ -1,0 +1,5 @@
+---
+'spawnforge': patch
+---
+
+Inspector transform buttons now meet WCAG AA 44px minimum touch target size on mobile

--- a/web/src/components/editor/InspectorPanel.tsx
+++ b/web/src/components/editor/InspectorPanel.tsx
@@ -222,7 +222,8 @@ export const InspectorPanel = memo(function InspectorPanel() {
     : [0, 0, 0];
 
   const buttonClass = `
-    p-1 rounded transition-opacity duration-150
+    min-h-11 min-w-11 inline-flex items-center justify-center
+    rounded transition-opacity duration-150
     text-zinc-400 hover:text-zinc-200 hover:bg-[var(--sf-bg-elevated)]
     opacity-60 hover:opacity-100
     focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:opacity-100

--- a/web/src/components/editor/__tests__/InspectorPanel.test.tsx
+++ b/web/src/components/editor/__tests__/InspectorPanel.test.tsx
@@ -318,4 +318,17 @@ describe('InspectorPanel', () => {
     fireEvent.click(screen.getByText('Edit Script'));
     expect(mockSetRightPanelTab).toHaveBeenCalledWith('script');
   });
+
+  // ── Touch target compliance (#8229) ───────────────────────────────────
+
+  it('transform action buttons meet 44px minimum touch target (#8229)', () => {
+    setupStore();
+    render(<InspectorPanel />);
+    const copyBtn = screen.getByTitle('Copy transform');
+    const pasteBtn = screen.getByTitle('Paste transform');
+    for (const btn of [copyBtn, pasteBtn]) {
+      expect(btn.className).toContain('min-h-11');
+      expect(btn.className).toContain('min-w-11');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Inspector transform buttons (Copy/Paste) used `p-1` padding with 14px icons giving ~22px touch targets
- Added `min-h-11 min-w-11` (44px) with `inline-flex items-center justify-center` for WCAG AA compliance
- Desktop visual appearance preserved — icons stay the same size, tap area expands

Closes #8229

## Test plan
- [x] New test verifies `min-h-11` and `min-w-11` classes on Copy/Paste transform buttons
- [x] All 26 InspectorPanel tests pass
- [x] ESLint zero warnings
- [x] TypeScript clean