### PR TITLE
fix: replace regex loop detection with acorn tokenizer

### DIFF
--- a/.changeset/loop-guards-acorn-tokenizer.md
+++ b/.changeset/loop-guards-acorn-tokenizer.md
@@ -1,0 +1,5 @@
+---
+'spawnforge': patch
+---
+
+Loop guard injection now uses acorn tokenizer for accurate keyword detection in template literals

--- a/package-lock.json
+++ b/package-lock.json
@@ -23063,6 +23063,7 @@
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
         "@xyflow/react": "^12.10.1",
+        "acorn": "^8.16.0",
         "ai": "^6.0.158",
         "bcryptjs": "^3.0.3",
         "dockview-react": "^5.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "@xyflow/react": "^12.10.1",
+    "acorn": "^8.16.0",
     "ai": "^6.0.158",
     "bcryptjs": "^3.0.3",
     "dockview-react": "^5.1.0",

--- a/web/src/lib/scripting/__tests__/loopGuards.test.ts
+++ b/web/src/lib/scripting/__tests__/loopGuards.test.ts
@@ -327,5 +327,32 @@ describe('injectLoopGuards (production implementation)', () => {
       const { guardVarNames } = injectLoopGuards(source);
       expect(guardVarNames).toHaveLength(0);
     });
+
+    it('does not inject into loop keywords inside template literals (#8289)', () => {
+      const source = 'const s = `for each item do while processing`; const x = 1;';
+      const { source: output, guardVarNames } = injectLoopGuards(source);
+      expect(output).toBe(source);
+      expect(guardVarNames).toHaveLength(0);
+    });
+
+    it('guards loops inside template literal expressions (#8289)', () => {
+      const source = 'const s = `result: ${(() => { let n = 0; for (let i = 0; i < 3; i++) { n += i; } return n; })()}`;';
+      const { guardVarNames } = injectLoopGuards(source);
+      expect(guardVarNames).toHaveLength(1);
+    });
+
+    it('handles nested template literals correctly (#8289)', () => {
+      const source = 'const s = `outer ${`inner ${x}`} rest`;';
+      const { source: output, guardVarNames } = injectLoopGuards(source);
+      expect(output).toBe(source);
+      expect(guardVarNames).toHaveLength(0);
+    });
+
+    it('returns source unchanged for syntax errors (#8289)', () => {
+      const source = 'const x = {{{;';
+      const { source: output, guardVarNames } = injectLoopGuards(source);
+      expect(output).toBe(source);
+      expect(guardVarNames).toHaveLength(0);
+    });
   });
 });

--- a/web/src/lib/scripting/loopGuards.ts
+++ b/web/src/lib/scripting/loopGuards.ts
@@ -11,7 +11,14 @@
  * script entry-point call (onStart/onUpdate/onDestroy). This prevents legitimate
  * loops with moderate iteration counts from accumulating across frames and
  * falsely triggering the guard after extended play time.
+ *
+ * PF-8289: Uses acorn's tokenizer for keyword detection instead of regex. This
+ * correctly handles template literals with ${...} expressions, nested backticks,
+ * strings, and comments — eliminating both false positives (keywords in strings)
+ * and false negatives (loops inside template expressions).
  */
+
+import { tokenizer } from 'acorn';
 
 export interface LoopGuardResult {
   source: string;
@@ -19,6 +26,32 @@ export interface LoopGuardResult {
 }
 
 export function injectLoopGuards(source: string): LoopGuardResult {
+  // PF-8289: Use acorn's tokenizer to find positions of real loop keywords.
+  // This properly handles template literals with ${...} expressions, nested
+  // backticks, strings, and comments — replacing the previous regex approach.
+  const loopKeywords = new Map<number, string>();
+  const braceTokenPositions = new Map<number, '{' | '}'>();
+  try {
+    for (const token of tokenizer(source, {
+      ecmaVersion: 2025,
+      allowReturnOutsideFunction: true,
+    })) {
+      const kw = (token.type as { keyword?: string }).keyword;
+      if (kw === 'for' || kw === 'while' || kw === 'do') {
+        loopKeywords.set(token.start, kw);
+      }
+      if (token.type.label === '{') braceTokenPositions.set(token.start, '{');
+      if (token.type.label === '}') braceTokenPositions.set(token.start, '}');
+    }
+  } catch {
+    // Syntax error — return unchanged; the sandbox will catch it at runtime
+    return { source, guardVarNames: [] };
+  }
+
+  if (loopKeywords.size === 0) {
+    return { source, guardVarNames: [] };
+  }
+
   // PF-524: Each loop gets its own counter variable (__lg0, __lg1, ...)
   // declared immediately before the loop statement so the counter resets
   // each time control reaches the loop. The guard check increments the
@@ -44,9 +77,10 @@ export function injectLoopGuards(source: string): LoopGuardResult {
   const doBodyStartDepths: number[] = [];
   let skipNextWhile = false;
   while (i < len) {
-    // Track brace depth for do-while detection
-    if (src[i] === '{') braceDepth++;
-    if (src[i] === '}') {
+    // Track brace depth using acorn-validated positions (not affected by
+    // braces inside strings, comments, or template expressions)
+    if (braceTokenPositions.get(i) === '{') braceDepth++;
+    if (braceTokenPositions.get(i) === '}') {
       braceDepth--;
       // If we just closed a do-while body, flag to skip the next `while`
       if (doBodyStartDepths.length > 0 && braceDepth === doBodyStartDepths[doBodyStartDepths.length - 1]) {
@@ -54,38 +88,10 @@ export function injectLoopGuards(source: string): LoopGuardResult {
         skipNextWhile = true;
       }
     }
-    if (src[i] === '"' || src[i] === "'" || src[i] === '`') {
-      // KNOWN LIMITATION: Template literals with ${...} expressions are scanned
-      // with a simple quote-matching loop that does NOT track expression depth.
-      // A template literal containing a nested loop — e.g. `${[1,2].forEach(i=>{for(;;){}})}` —
-      // will have the loop scanner skip the inner loop body because it's inside the
-      // string range delimited by the backtick pair. This means loop guards are NOT
-      // injected into loops inside template literal expressions.
-      // Mitigation: the worker runs with a per-frame iteration budget (onUpdate timeout)
-      // so such loops will eventually be killed by the frame watchdog even without guards.
-      // TODO(PF): Implement a proper JS tokenizer (or use acorn) to correctly handle
-      // nested expressions in template literals.
-      const quote = src[i];
-      result += src[i++];
-      while (i < len && src[i] !== quote) {
-        if (src[i] === '\\') { result += src[i++]; }
-        if (i < len) { result += src[i++]; }
-      }
-      if (i < len) result += src[i++];
-      continue;
-    }
-    if (src[i] === '/' && i + 1 < len && src[i + 1] === '/') {
-      while (i < len && src[i] !== '\n') result += src[i++];
-      continue;
-    }
-    if (src[i] === '/' && i + 1 < len && src[i + 1] === '*') {
-      result += src[i++]; result += src[i++];
-      while (i < len && !(src[i] === '*' && i + 1 < len && src[i + 1] === '/')) result += src[i++];
-      if (i < len) { result += src[i++]; result += src[i++]; }
-      continue;
-    }
-    const remaining = src.slice(i);
-    if (/^while\b/.test(remaining) && (i === 0 || !/\w/.test(src[i - 1]))) {
+
+    const kw = loopKeywords.get(i);
+
+    if (kw === 'while') {
       if (skipNextWhile) {
         // This is the condition part of a do-while — emit verbatim
         skipNextWhile = false;
@@ -108,7 +114,7 @@ export function injectLoopGuards(source: string): LoopGuardResult {
       }
       continue;
     }
-    if (/^for\b/.test(remaining) && (i === 0 || !/\w/.test(src[i - 1]))) {
+    if (kw === 'for') {
       const gv = '__lg' + loopIndex++;
       guardVarNames.push(gv);
       const gd = 'let ' + gv + '=0;';
@@ -125,7 +131,7 @@ export function injectLoopGuards(source: string): LoopGuardResult {
       }
       continue;
     }
-    if (/^do\b/.test(remaining) && (i === 0 || !/\w/.test(src[i - 1]))) {
+    if (kw === 'do') {
       const gv = '__lg' + loopIndex++;
       guardVarNames.push(gv);
       const gd = 'let ' + gv + '=0;';


### PR DESCRIPTION
## Summary
- Replaced regex-based loop keyword detection with acorn's tokenizer in `loopGuards.ts`
- Acorn correctly handles template literals with `${...}` expressions, nested backticks, and all string/comment types
- Added acorn as an explicit dependency (previously only transitive via Next.js)
- Fixes false positives (keywords inside template literal text) and false negatives (loops inside template expressions)

Closes #8289

## Test plan
- [x] All 33 existing loop guard tests pass unchanged
- [x] 4 new tests for template literal edge cases: keyword in template text, loop in template expression, nested template literals, syntax error graceful handling
- [x] ESLint zero warnings
- [x] TypeScript clean