### PR TITLE
test: add comprehensive negative case tests for 4 API routes

### DIFF
--- a/.changeset/negative-test-suite.md
+++ b/.changeset/negative-test-suite.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": patch
+---
+
+Add comprehensive negative/error case test suite for 4 API routes (52 tests)

--- a/web/src/app/api/feedback/negative-cases.test.ts
+++ b/web/src/app/api/feedback/negative-cases.test.ts
@@ -1,0 +1,236 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { authenticateClerkSession } from '@/lib/auth/api-auth';
+import { getUserByClerkId } from '@/lib/auth/user-service';
+import { distributedRateLimit } from '@/lib/rateLimit/distributed';
+import { getDb } from '@/lib/db/client';
+
+vi.mock('@/lib/auth/api-auth');
+vi.mock('@/lib/auth/user-service');
+vi.mock('@/lib/rateLimit/distributed');
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimitResponse: vi.fn(() => new Response('Rate limited', { status: 429 })),
+}));
+vi.mock('@/lib/db/client');
+vi.mock('@/lib/db/schema', () => ({
+  feedback: { id: 'id', userId: 'userId', type: 'type', description: 'description', metadata: 'metadata' },
+}));
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+const BASE_URL = 'http://localhost:3000/api/feedback';
+
+function makeReq(body: string) {
+  return new NextRequest(BASE_URL, {
+    method: 'POST',
+    body,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function setupAuth() {
+  vi.mocked(authenticateClerkSession).mockResolvedValue({
+    ok: true as const,
+    clerkId: 'clerk_1',
+  });
+  vi.mocked(getUserByClerkId).mockResolvedValue({ id: 'user_1' } as never);
+  vi.mocked(distributedRateLimit).mockResolvedValue({
+    allowed: true,
+    remaining: 9,
+    resetAt: Date.now() + 60000,
+  });
+}
+
+function setupDb() {
+  const mockDb = {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: 'fb-1' }]),
+    }),
+  };
+  vi.mocked(getDb).mockReturnValue(mockDb as never);
+}
+
+describe('PF-675: Negative cases for /api/feedback', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setupAuth();
+    setupDb();
+  });
+
+  describe('malformed request body', () => {
+    it('returns 400 for non-JSON body', async () => {
+      const { POST } = await import('./route');
+      const req = new NextRequest(BASE_URL, {
+        method: 'POST',
+        body: 'this is not json',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toContain('Invalid JSON');
+    });
+
+    it('returns 400 for empty body', async () => {
+      const { POST } = await import('./route');
+      const req = new NextRequest(BASE_URL, {
+        method: 'POST',
+        body: '',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('schema validation', () => {
+    it('returns 422 for missing type field', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ description: 'Long enough description for test' })));
+      const body = await res.json();
+
+      expect(res.status).toBe(422);
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 422 for type not in enum', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        type: 'complaint',
+        description: 'Long enough description for test',
+      })));
+      const body = await res.json();
+
+      expect(res.status).toBe(422);
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 422 for description shorter than 10 chars', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ type: 'bug', description: 'short' })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 for description longer than 5000 chars', async () => {
+      const { POST } = await import('./route');
+      const longDesc = 'A'.repeat(5001);
+      const res = await POST(makeReq(JSON.stringify({ type: 'bug', description: longDesc })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 for whitespace-only description (trimmed to empty)', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ type: 'bug', description: '         ' })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when description is null', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ type: 'bug', description: null })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when description is a number', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ type: 'bug', description: 42 })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when body is an array instead of object', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify([{ type: 'bug', description: 'This is an array' }])));
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('service errors', () => {
+    it('returns 500 when DB insert throws', async () => {
+      const mockDb = {
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnThis(),
+          returning: vi.fn().mockRejectedValue(new Error('unique constraint violation')),
+        }),
+      };
+      vi.mocked(getDb).mockReturnValue(mockDb as never);
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        type: 'bug',
+        description: 'Something is broken in the editor panel',
+      })));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toContain('Failed to submit');
+    });
+
+    it('does not leak DB error details to client', async () => {
+      const mockDb = {
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnThis(),
+          returning: vi.fn().mockRejectedValue(
+            new Error('relation "feedback" does not exist')
+          ),
+        }),
+      };
+      vi.mocked(getDb).mockReturnValue(mockDb as never);
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        type: 'feature',
+        description: 'I want a new feature in the editor',
+      })));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).not.toContain('relation');
+      expect(body.error).not.toContain('does not exist');
+    });
+  });
+
+  describe('HTML/script injection in valid fields', () => {
+    it('accepts HTML in description (stored as-is, rendering layer escapes)', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        type: 'bug',
+        description: '<script>alert("xss")</script> This has HTML content in it',
+      })));
+      const body = await res.json();
+
+      // The route stores raw text; XSS prevention is the rendering layer's job.
+      // This test verifies the API doesn't reject valid text containing angle brackets.
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts metadata with nested objects', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        type: 'general',
+        description: 'Feedback with complex metadata object',
+        metadata: {
+          browser: 'Chrome 130',
+          viewport: { width: 1920, height: 1080 },
+          nested: { deep: { value: true } },
+        },
+      })));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+});

--- a/web/src/app/api/game/pipeline/negative-cases.test.ts
+++ b/web/src/app/api/game/pipeline/negative-cases.test.ts
@@ -1,0 +1,252 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { withApiMiddleware } from '@/lib/api/middleware';
+import { reserveTokenBudget, releaseUnusedBudget, recordStepUsage } from '@/lib/tokens/budget';
+
+vi.mock('@/lib/api/middleware');
+vi.mock('@/lib/tokens/budget');
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+const BASE_URL = 'http://localhost:3000/api/game/pipeline';
+
+function makeReq(body: string) {
+  return new NextRequest(BASE_URL, {
+    method: 'POST',
+    body,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function mockMiddlewareSuccess(userId = 'user_1') {
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: undefined,
+    userId,
+    authContext: { clerkId: 'clerk_1', user: { id: userId, tier: 'creator' } as never },
+    body: undefined,
+  });
+}
+
+function mockMiddlewareError(status: number, error: string) {
+  const mockResponse = new Response(JSON.stringify({ error }), { status });
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: mockResponse as never,
+    userId: null,
+    authContext: null,
+    body: undefined,
+  });
+}
+
+describe('PF-675: Negative cases for /api/game/pipeline', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockMiddlewareSuccess();
+  });
+
+  describe('auth & rate limiting', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockMiddlewareError(401, 'Unauthorized');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: 100 })));
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 429 when rate limited', async () => {
+      mockMiddlewareError(429, 'Rate limited');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: 100 })));
+
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('returns 400 for malformed JSON', async () => {
+      const { POST } = await import('./route');
+      const req = new NextRequest(BASE_URL, {
+        method: 'POST',
+        body: 'not json at all',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+      expect(body.details).toContain('Invalid JSON body');
+    });
+
+    it('returns 400 for empty body', async () => {
+      const { POST } = await import('./route');
+      const req = new NextRequest(BASE_URL, {
+        method: 'POST',
+        body: '',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('discriminated union validation', () => {
+    it('returns 400 for unknown action value', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'destroy' })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 for missing action field', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ estimatedTotal: 100 })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 when action is null', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: null })));
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('reserve action — validation', () => {
+    it('returns 400 for negative estimatedTotal', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: -1 })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 for estimatedTotal exceeding MAX_PIPELINE_TOKENS', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: 1_000_001 })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 for float estimatedTotal', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: 100.5 })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 for string estimatedTotal', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: '100' })));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 402 when user has insufficient tokens', async () => {
+      vi.mocked(reserveTokenBudget).mockResolvedValue({
+        success: false,
+        balance: 50,
+        cost: 1000,
+      } as never);
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({ action: 'reserve', estimatedTotal: 1000 })));
+      const body = await res.json();
+
+      expect(res.status).toBe(402);
+      expect(body.error).toBe('insufficient_tokens');
+      expect(body.balance).toBe(50);
+      expect(body.cost).toBe(1000);
+    });
+  });
+
+  describe('record_step action — validation', () => {
+    it('returns 400 for invalid UUID in reservationId', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'record_step',
+        reservationId: 'not-a-uuid',
+        stepId: 'step1',
+        tokensUsed: 10,
+      })));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('validation_error');
+    });
+
+    it('returns 400 for empty stepId', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'record_step',
+        reservationId: '550e8400-e29b-41d4-a716-446655440000',
+        stepId: '',
+        tokensUsed: 10,
+      })));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for negative tokensUsed', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'record_step',
+        reservationId: '550e8400-e29b-41d4-a716-446655440000',
+        stepId: 'step1',
+        tokensUsed: -5,
+      })));
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('release action — validation', () => {
+    it('returns 400 for missing reservationId', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'release',
+        actualUsed: 50,
+      })));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for negative actualUsed', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'release',
+        reservationId: '550e8400-e29b-41d4-a716-446655440000',
+        actualUsed: -10,
+      })));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for actualUsed exceeding MAX_PIPELINE_TOKENS', async () => {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq(JSON.stringify({
+        action: 'release',
+        reservationId: '550e8400-e29b-41d4-a716-446655440000',
+        actualUsed: 2_000_000,
+      })));
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/web/src/app/api/game/pipeline/negative-cases.test.ts
+++ b/web/src/app/api/game/pipeline/negative-cases.test.ts
@@ -3,7 +3,7 @@ vi.mock('server-only', () => ({}));
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { withApiMiddleware } from '@/lib/api/middleware';
-import { reserveTokenBudget, releaseUnusedBudget, recordStepUsage } from '@/lib/tokens/budget';
+import { reserveTokenBudget } from '@/lib/tokens/budget';
 
 vi.mock('@/lib/api/middleware');
 vi.mock('@/lib/tokens/budget');

--- a/web/src/app/api/projects/negative-cases.test.ts
+++ b/web/src/app/api/projects/negative-cases.test.ts
@@ -1,0 +1,167 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { withApiMiddleware } from '@/lib/api/middleware';
+import { listProjects, createProject } from '@/lib/projects/service';
+
+vi.mock('@/lib/api/middleware');
+vi.mock('@/lib/projects/service');
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+function makeReq(method = 'GET', body?: string) {
+  const url = 'http://localhost:3000/api/projects';
+  if (body) {
+    return new NextRequest(url, {
+      method,
+      body,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new NextRequest(url, { method });
+}
+
+function mockMiddlewareSuccess(
+  userId = 'user_1',
+  body: unknown = { name: 'Test', sceneData: {} },
+) {
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: undefined,
+    userId,
+    authContext: { clerkId: 'clerk_1', user: { id: userId, tier: 'creator' } as never },
+    body,
+  });
+}
+
+function mockMiddlewareError(status: number, error: string) {
+  const mockResponse = new Response(JSON.stringify({ error }), { status });
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: mockResponse as never,
+    userId: null,
+    authContext: null,
+    body: undefined,
+  });
+}
+
+describe('PF-675: Negative cases for /api/projects', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockMiddlewareSuccess();
+  });
+
+  describe('GET /api/projects — error paths', () => {
+    it('returns 500 when listProjects throws a DB error', async () => {
+      vi.mocked(listProjects).mockRejectedValue(new Error('connection refused'));
+
+      const { GET } = await import('./route');
+      const res = await GET(makeReq());
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.code).toBe('INTERNAL_ERROR');
+    });
+
+    it('returns 500 when listProjects throws a non-Error value', async () => {
+      vi.mocked(listProjects).mockRejectedValue('string error');
+
+      const { GET } = await import('./route');
+      const res = await GET(makeReq());
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('POST /api/projects — input validation', () => {
+    it('returns 422 when middleware rejects invalid JSON body', async () => {
+      mockMiddlewareError(400, 'Invalid JSON body');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', 'not-json'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 422 when middleware rejects empty name', async () => {
+      mockMiddlewareError(422, 'Validation failed');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: '', sceneData: {} })));
+      const body = await res.json();
+
+      expect(res.status).toBe(422);
+      expect(body.error).toContain('Validation');
+    });
+
+    it('returns 422 when middleware rejects oversized name (>200 chars)', async () => {
+      mockMiddlewareError(422, 'Validation failed');
+
+      const { POST } = await import('./route');
+      const longName = 'A'.repeat(201);
+      const res = await POST(makeReq('POST', JSON.stringify({ name: longName, sceneData: {} })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when sceneData is not an object', async () => {
+      mockMiddlewareError(422, 'Validation failed');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: 'Test', sceneData: 'not-object' })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when body is missing sceneData entirely', async () => {
+      mockMiddlewareError(422, 'Validation failed');
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: 'Test' })));
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('POST /api/projects — service errors', () => {
+    it('returns 500 when createProject throws a generic DB error', async () => {
+      mockMiddlewareSuccess('user_1', { name: 'Good Project', sceneData: {} });
+      vi.mocked(createProject).mockRejectedValue(new Error('database timeout'));
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: 'Good Project', sceneData: {} })));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.code).toBe('INTERNAL_ERROR');
+    });
+
+    it('returns 403 with limit info when project limit exceeded with limit=1', async () => {
+      mockMiddlewareSuccess('user_1', { name: 'Project', sceneData: {} });
+      const error = new Error('Project limit exceeded') as Error & { limit?: number };
+      error.limit = 1;
+      vi.mocked(createProject).mockRejectedValue(error);
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: 'Project', sceneData: {} })));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.code).toBe('PROJECT_LIMIT');
+      // Singular form when limit is 1
+      expect(body.error).toContain('1 project');
+      expect(body.error).not.toContain('projects');
+    });
+
+    it('returns 500 when createProject throws a non-Error value', async () => {
+      mockMiddlewareSuccess('user_1', { name: 'Project', sceneData: {} });
+      vi.mocked(createProject).mockRejectedValue(42);
+
+      const { POST } = await import('./route');
+      const res = await POST(makeReq('POST', JSON.stringify({ name: 'Project', sceneData: {} })));
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/web/src/app/api/user/profile/negative-cases.test.ts
+++ b/web/src/app/api/user/profile/negative-cases.test.ts
@@ -1,0 +1,173 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { withApiMiddleware } from '@/lib/api/middleware';
+import { updateDisplayName } from '@/lib/auth/user-service';
+
+vi.mock('@/lib/api/middleware');
+vi.mock('@/lib/auth/user-service');
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+const BASE_URL = 'http://localhost:3000/api/user/profile';
+
+function makeReq(method: string, body?: string) {
+  const opts: RequestInit = { method };
+  if (body) {
+    opts.body = body;
+    opts.headers = { 'Content-Type': 'application/json' };
+  }
+  return new NextRequest(BASE_URL, opts);
+}
+
+function mockMiddlewareSuccess(
+  userId = 'user_1',
+  body: unknown = undefined,
+) {
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: undefined,
+    userId,
+    authContext: {
+      clerkId: 'clerk_1',
+      user: {
+        id: userId,
+        tier: 'creator',
+        displayName: 'Existing Name',
+        email: 'user@example.com',
+        createdAt: new Date('2026-01-01'),
+      } as never,
+    },
+    body,
+  });
+}
+
+function mockMiddlewareError(status: number, error: string, code?: string) {
+  const respBody: Record<string, unknown> = { error };
+  if (code) respBody.code = code;
+  const mockResponse = new Response(JSON.stringify(respBody), { status });
+  vi.mocked(withApiMiddleware).mockResolvedValue({
+    error: mockResponse as never,
+    userId: null,
+    authContext: null,
+    body: undefined,
+  });
+}
+
+describe('PF-675: Negative cases for /api/user/profile', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  describe('GET — error paths', () => {
+    it('returns 401 when middleware rejects unauthenticated request', async () => {
+      mockMiddlewareError(401, 'Unauthorized', 'UNAUTHORIZED');
+
+      const { GET } = await import('./route');
+      const res = await GET(makeReq('GET'));
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 429 when middleware rejects rate-limited request', async () => {
+      mockMiddlewareError(429, 'Rate limited');
+
+      const { GET } = await import('./route');
+      const res = await GET(makeReq('GET'));
+
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('PUT — input validation', () => {
+    it('returns 400 when middleware rejects malformed JSON', async () => {
+      mockMiddlewareError(400, 'Invalid JSON body', 'BAD_REQUEST');
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', '{bad json'));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 422 when middleware rejects displayName > 100 chars', async () => {
+      mockMiddlewareError(422, 'Validation failed', 'VALIDATION_ERROR');
+
+      const { PUT } = await import('./route');
+      const longName = 'X'.repeat(101);
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: longName })));
+      const body = await res.json();
+
+      expect(res.status).toBe(422);
+      expect(body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns 422 when displayName is null', async () => {
+      mockMiddlewareError(422, 'Validation failed', 'VALIDATION_ERROR');
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: null })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when displayName is a number', async () => {
+      mockMiddlewareError(422, 'Validation failed', 'VALIDATION_ERROR');
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: 42 })));
+
+      expect(res.status).toBe(422);
+    });
+
+    it('returns 422 when body contains extra fields but displayName is missing', async () => {
+      mockMiddlewareError(422, 'Validation failed', 'VALIDATION_ERROR');
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ email: 'hacker@evil.com' })));
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe('PUT — service errors', () => {
+    it('returns 500 when updateDisplayName throws a DB error', async () => {
+      mockMiddlewareSuccess('user_1', { displayName: 'Valid Name' });
+      vi.mocked(updateDisplayName).mockRejectedValue(new Error('connection reset'));
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: 'Valid Name' })));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.code).toBe('INTERNAL_ERROR');
+    });
+
+    it('returns 500 when updateDisplayName throws a non-Error value', async () => {
+      mockMiddlewareSuccess('user_1', { displayName: 'Valid Name' });
+      vi.mocked(updateDisplayName).mockRejectedValue(null);
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: 'Valid Name' })));
+
+      expect(res.status).toBe(500);
+    });
+
+    it('does not leak internal error details to the client', async () => {
+      mockMiddlewareSuccess('user_1', { displayName: 'Valid Name' });
+      vi.mocked(updateDisplayName).mockRejectedValue(
+        new Error('FATAL: password authentication failed for user "spawnforge_rw"')
+      );
+
+      const { PUT } = await import('./route');
+      const res = await PUT(makeReq('PUT', JSON.stringify({ displayName: 'Valid Name' })));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      // Error message must be generic, not the internal DB error
+      expect(body.error).not.toContain('password');
+      expect(body.error).not.toContain('spawnforge_rw');
+    });
+  });
+});

--- a/web/src/app/api/user/profile/negative-cases.test.ts
+++ b/web/src/app/api/user/profile/negative-cases.test.ts
@@ -14,12 +14,14 @@ vi.mock('@/lib/monitoring/sentry-server', () => ({
 const BASE_URL = 'http://localhost:3000/api/user/profile';
 
 function makeReq(method: string, body?: string) {
-  const opts: RequestInit = { method };
   if (body) {
-    opts.body = body;
-    opts.headers = { 'Content-Type': 'application/json' };
+    return new NextRequest(BASE_URL, {
+      method,
+      body,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
-  return new NextRequest(BASE_URL, opts);
+  return new NextRequest(BASE_URL, { method });
 }
 
 function mockMiddlewareSuccess(


### PR DESCRIPTION
## Summary
- Adds 52 negative/error case tests across 4 API routes: `/api/projects`, `/api/user/profile`, `/api/game/pipeline`, `/api/feedback`
- Tests cover: malformed JSON, invalid types, oversized fields, missing required fields, DB failure paths, non-Error throws, internal error detail leakage, discriminated union edge cases, 402 insufficient tokens, HTML injection passthrough
- All tests use the `withApiMiddleware` mock pattern (or direct auth mock for feedback) for consistency

Closes #7003

## Test plan
- [x] All 52 new tests pass locally
- [x] ESLint zero warnings
- [x] TypeScript compiles clean
- [ ] CI green