### PR TITLE
test: add k6 load testing scripts for API routes

### DIFF
--- a/.changeset/load-testing-scripts.md
+++ b/.changeset/load-testing-scripts.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": patch
+---
+
+Add k6 load test scripts for chat API, generation routes, and Stripe webhook storm

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -165,6 +165,8 @@ const eslintConfig = defineConfig([
     "public/engine-pkg-webgpu-runtime/**",
     // Test coverage output
     "coverage/**",
+    // k6 load test scripts (k6 runtime, not Node.js)
+    "load-tests/**",
   ]),
 ]);
 

--- a/web/load-tests/chat-load.js
+++ b/web/load-tests/chat-load.js
@@ -1,0 +1,110 @@
+/**
+ * k6 load test: /api/chat concurrent requests
+ *
+ * Simulates 50 concurrent users sending chat messages to verify:
+ * - p95 response time < 5s
+ * - Zero 500 errors under load
+ * - Rate limiting returns 429 (not 500)
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:3000 CLERK_SESSION_TOKEN=<token> k6 run chat-load.js
+ *
+ * Requires a valid Clerk session token. Get one from browser DevTools:
+ *   document.cookie → __session value
+ *
+ * For dev-mode testing without auth, use:
+ *   BASE_URL=http://spawnforge.localhost:1355 k6 run chat-load.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const SESSION_TOKEN = __ENV.CLERK_SESSION_TOKEN || '';
+
+// Custom metrics
+const errorRate = new Rate('errors');
+const rateLimitRate = new Rate('rate_limited');
+const chatLatency = new Trend('chat_latency', true);
+
+export const options = {
+  scenarios: {
+    ramp_up: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '30s', target: 10 },  // Warm up
+        { duration: '1m', target: 50 },   // Ramp to 50 users
+        { duration: '2m', target: 50 },   // Sustained load
+        { duration: '30s', target: 0 },   // Cool down
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<5000'],  // p95 < 5s
+    errors: ['rate<0.01'],              // < 1% error rate
+  },
+};
+
+const PROMPTS = [
+  'Add a red cube to the scene',
+  'Create a directional light',
+  'Set the background color to blue',
+  'Add physics to the selected entity',
+  'Rename the entity to Player',
+  'Move the camera to position 0 5 -10',
+  'Add a sphere with metallic material',
+  'Create a ground plane',
+];
+
+export default function () {
+  const prompt = PROMPTS[Math.floor(Math.random() * PROMPTS.length)];
+
+  const headers = {
+    'Content-Type': 'application/json',
+  };
+
+  if (SESSION_TOKEN) {
+    headers['Cookie'] = `__session=${SESSION_TOKEN}`;
+  }
+
+  const payload = JSON.stringify({
+    messages: [{ role: 'user', content: prompt }],
+    sceneContext: { entities: [], selectedId: null },
+  });
+
+  const res = http.post(`${BASE_URL}/api/chat`, payload, { headers });
+
+  chatLatency.add(res.timings.duration);
+
+  const is429 = res.status === 429;
+  rateLimitRate.add(is429);
+
+  // 429 is expected under load — not an error
+  const isError = res.status >= 500;
+  errorRate.add(isError);
+
+  check(res, {
+    'status is not 500': (r) => r.status < 500,
+    'status is 200 or 429': (r) => r.status === 200 || r.status === 429,
+    'response has body': (r) => r.body && r.body.length > 0,
+  });
+
+  // Random think time between requests (1-3s)
+  sleep(1 + Math.random() * 2);
+}
+
+export function handleSummary(data) {
+  const p95 = data.metrics.http_req_duration?.values?.['p(95)'] ?? 0;
+  const errRate = data.metrics.errors?.values?.rate ?? 0;
+  const rlRate = data.metrics.rate_limited?.values?.rate ?? 0;
+
+  console.log('\n========== CHAT LOAD TEST SUMMARY ==========');
+  console.log(`p95 latency:    ${p95.toFixed(0)}ms (target: <5000ms)`);
+  console.log(`Error rate:     ${(errRate * 100).toFixed(2)}% (target: <1%)`);
+  console.log(`Rate limited:   ${(rlRate * 100).toFixed(1)}%`);
+  console.log('=============================================\n');
+
+  return {};
+}

--- a/web/load-tests/generate-load.js
+++ b/web/load-tests/generate-load.js
@@ -1,0 +1,116 @@
+/**
+ * k6 load test: /api/generate/* concurrent generation requests
+ *
+ * Simulates 20 concurrent users submitting generation requests to verify:
+ * - Rate limiting returns 429 (not 500)
+ * - No 500 errors under concurrent load
+ * - Graceful degradation when providers are saturated
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:3000 CLERK_SESSION_TOKEN=<token> k6 run generate-load.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const SESSION_TOKEN = __ENV.CLERK_SESSION_TOKEN || '';
+
+const errorRate = new Rate('errors');
+const rateLimitRate = new Rate('rate_limited');
+const genLatency = new Trend('generation_latency', true);
+
+export const options = {
+  scenarios: {
+    concurrent_gen: {
+      executor: 'ramping-vus',
+      startVUs: 1,
+      stages: [
+        { duration: '20s', target: 5 },   // Warm up
+        { duration: '1m', target: 20 },   // Ramp to 20 concurrent
+        { duration: '2m', target: 20 },   // Sustained load
+        { duration: '20s', target: 0 },   // Cool down
+      ],
+    },
+  },
+  thresholds: {
+    errors: ['rate<0.05'],  // < 5% error rate (providers may throttle)
+  },
+};
+
+const GENERATE_ROUTES = [
+  {
+    path: '/api/generate/model',
+    payload: { prompt: 'A low-poly tree', style: 'low-poly' },
+  },
+  {
+    path: '/api/generate/texture',
+    payload: { prompt: 'Brick wall texture seamless', width: 512, height: 512 },
+  },
+  {
+    path: '/api/generate/sfx',
+    payload: { prompt: 'Explosion sound effect', duration: 2 },
+  },
+  {
+    path: '/api/generate/sprite',
+    payload: { prompt: 'Pixel art character idle', width: 64, height: 64 },
+  },
+  {
+    path: '/api/generate/voice',
+    payload: { text: 'Welcome to the game', voice: 'neutral' },
+  },
+  {
+    path: '/api/generate/skybox',
+    payload: { prompt: 'Sunset over mountains' },
+  },
+  {
+    path: '/api/generate/music',
+    payload: { prompt: 'Upbeat adventure theme', duration: 30 },
+  },
+];
+
+export default function () {
+  const route = GENERATE_ROUTES[Math.floor(Math.random() * GENERATE_ROUTES.length)];
+
+  const headers = { 'Content-Type': 'application/json' };
+  if (SESSION_TOKEN) {
+    headers['Cookie'] = `__session=${SESSION_TOKEN}`;
+  }
+
+  const res = http.post(
+    `${BASE_URL}${route.path}`,
+    JSON.stringify(route.payload),
+    { headers, timeout: '30s' },
+  );
+
+  genLatency.add(res.timings.duration);
+
+  const is429 = res.status === 429;
+  rateLimitRate.add(is429);
+
+  const isError = res.status >= 500;
+  errorRate.add(isError);
+
+  check(res, {
+    'no 500 errors': (r) => r.status < 500,
+    'valid response status': (r) => [200, 201, 400, 401, 402, 429].includes(r.status),
+  });
+
+  // Generation requests are expensive — longer think time
+  sleep(2 + Math.random() * 3);
+}
+
+export function handleSummary(data) {
+  const p95 = data.metrics.http_req_duration?.values?.['p(95)'] ?? 0;
+  const errRate = data.metrics.errors?.values?.rate ?? 0;
+  const rlRate = data.metrics.rate_limited?.values?.rate ?? 0;
+
+  console.log('\n========= GENERATE LOAD TEST SUMMARY =========');
+  console.log(`p95 latency:    ${p95.toFixed(0)}ms`);
+  console.log(`Error rate:     ${(errRate * 100).toFixed(2)}% (target: <5%)`);
+  console.log(`Rate limited:   ${(rlRate * 100).toFixed(1)}%`);
+  console.log('================================================\n');
+
+  return {};
+}

--- a/web/load-tests/webhook-storm.js
+++ b/web/load-tests/webhook-storm.js
@@ -85,12 +85,13 @@ function signPayload(payload, secret) {
 }
 
 export default function () {
-  const eventType = EVENT_TYPES[Math.floor(Math.random() * EVENT_TYPES.length)];
-  // Use a 50-slot repeating pool so half the requests reuse event IDs,
-  // exercising the server-side idempotency guard. The pool is keyed by event
-  // type so different event types don't collide with each other.
+  // Use a 50-slot repeating pool so half the requests (iterations 50-99)
+  // reuse event IDs from iterations 0-49, exercising the idempotency guard.
   const pool = 50;
   const index = exec.scenario.iterationInTest % pool;
+  // Derive eventType from index (not random) so repeated indices produce
+  // identical event IDs — random selection would reduce duplicate rate to ~10%.
+  const eventType = EVENT_TYPES[index % EVENT_TYPES.length];
   const payload = makeWebhookPayload(eventType, index);
   const body = JSON.stringify(payload);
 

--- a/web/load-tests/webhook-storm.js
+++ b/web/load-tests/webhook-storm.js
@@ -18,6 +18,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 import { Rate } from 'k6/metrics';
 import { crypto } from 'k6/experimental/webcrypto';
+import exec from 'k6/execution';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
 const WEBHOOK_SECRET = __ENV.STRIPE_WEBHOOK_SECRET || '';
@@ -80,7 +81,9 @@ function signPayload(payload, _secret) {
 
 export default function () {
   const eventType = EVENT_TYPES[Math.floor(Math.random() * EVENT_TYPES.length)];
-  const index = __ITER;
+  // Use globally unique iteration counter (not per-VU __ITER which collides
+  // across virtual users in shared-iterations mode).
+  const index = exec.scenario.iterationInTest;
   const payload = makeWebhookPayload(eventType, index);
   const body = JSON.stringify(payload);
 
@@ -89,27 +92,35 @@ export default function () {
     'Stripe-Signature': signPayload(body, WEBHOOK_SECRET),
   };
 
-  const res = http.post(`${BASE_URL}/api/webhooks/stripe`, body, { headers });
+  const res = http.post(`${BASE_URL}/api/stripe/webhook`, body, { headers });
 
   const isError = res.status >= 500;
   errorRate.add(isError);
 
+  // Track duplicate detection: a 200 on a previously-sent event ID means the
+  // handler processed it; a 409 or identical 200 with "already processed" in
+  // the body indicates the idempotency guard fired correctly.
+  const isDuplicate = res.status === 200 && res.body && res.body.includes('already_processed');
+  duplicateRate.add(isDuplicate ? 1 : 0);
+
   // 400 is expected when signature verification fails (no real secret)
   check(res, {
     'no 500 errors': (r) => r.status < 500,
-    'valid response': (r) => [200, 400].includes(r.status),
+    'valid response': (r) => [200, 400, 409].includes(r.status),
   });
 }
 
 export function handleSummary(data) {
   const total = data.metrics.http_reqs?.values?.count ?? 0;
   const errRate = data.metrics.errors?.values?.rate ?? 0;
+  const dupRate = data.metrics.duplicates?.values?.rate ?? 0;
   const p95 = data.metrics.http_req_duration?.values?.['p(95)'] ?? 0;
 
   console.log('\n======== WEBHOOK STORM TEST SUMMARY ========');
   console.log(`Total webhooks:  ${total}`);
   console.log(`p95 latency:     ${p95.toFixed(0)}ms`);
   console.log(`Error rate:      ${(errRate * 100).toFixed(2)}% (target: <1%)`);
+  console.log(`Duplicate rate:  ${(dupRate * 100).toFixed(2)}%`);
   console.log('=============================================\n');
 
   return {};

--- a/web/load-tests/webhook-storm.js
+++ b/web/load-tests/webhook-storm.js
@@ -17,7 +17,7 @@
 import http from 'k6/http';
 import { check } from 'k6';
 import { Rate } from 'k6/metrics';
-import { crypto } from 'k6/experimental/webcrypto';
+import crypto from 'k6/crypto';
 import exec from 'k6/execution';
 
 const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
@@ -72,11 +72,16 @@ function makeWebhookPayload(eventType, index) {
   };
 }
 
-function signPayload(payload, _secret) {
-  // k6 does not have Node.js crypto — return a placeholder signature.
-  // For real testing, use `stripe listen --forward-to` which signs properly.
+function signPayload(payload, secret) {
   const timestamp = Math.floor(Date.now() / 1000);
-  return `t=${timestamp},v1=placeholder_signature_for_load_test`;
+  if (!secret) {
+    // Without a secret, return a placeholder that will fail server-side
+    // verification with a 400. For real testing, pass STRIPE_WEBHOOK_SECRET.
+    return `t=${timestamp},v1=placeholder_signature_for_load_test`;
+  }
+  const signedPayload = `${timestamp}.${payload}`;
+  const mac = crypto.hmac('sha256', secret, signedPayload, 'hex');
+  return `t=${timestamp},v1=${mac}`;
 }
 
 export default function () {

--- a/web/load-tests/webhook-storm.js
+++ b/web/load-tests/webhook-storm.js
@@ -1,0 +1,116 @@
+/**
+ * k6 load test: Stripe webhook flood
+ *
+ * Simulates 100 Stripe webhooks arriving within 10 seconds to verify:
+ * - Idempotent processing (no double credit, no duplicate subscription updates)
+ * - All webhooks return 200 (no 500 errors)
+ * - System handles burst without queue overflow
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:3000 STRIPE_WEBHOOK_SECRET=whsec_xxx k6 run webhook-storm.js
+ *
+ * Note: This test sends mock webhook payloads. The Stripe signature is faked
+ * unless STRIPE_WEBHOOK_SECRET is provided for proper HMAC signing.
+ * In production-like testing, use `stripe trigger` CLI instead.
+ */
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate } from 'k6/metrics';
+import { crypto } from 'k6/experimental/webcrypto';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const WEBHOOK_SECRET = __ENV.STRIPE_WEBHOOK_SECRET || '';
+
+const errorRate = new Rate('errors');
+const duplicateRate = new Rate('duplicates');
+
+export const options = {
+  scenarios: {
+    webhook_burst: {
+      executor: 'shared-iterations',
+      vus: 10,
+      iterations: 100,
+      maxDuration: '30s',
+    },
+  },
+  thresholds: {
+    errors: ['rate<0.01'],  // < 1% error rate
+  },
+};
+
+const EVENT_TYPES = [
+  'checkout.session.completed',
+  'customer.subscription.updated',
+  'customer.subscription.deleted',
+  'invoice.payment_succeeded',
+  'invoice.payment_failed',
+];
+
+function makeWebhookPayload(eventType, index) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id: `evt_test_${eventType.replace(/\./g, '_')}_${index}`,
+    object: 'event',
+    type: eventType,
+    created: now,
+    data: {
+      object: {
+        id: `sub_test_${index}`,
+        customer: `cus_test_${index % 10}`,
+        status: eventType.includes('deleted') ? 'canceled' : 'active',
+        items: {
+          data: [{
+            price: { id: 'price_creator_monthly', product: 'prod_creator' },
+          }],
+        },
+        metadata: { userId: `user_${index % 10}` },
+      },
+    },
+    livemode: false,
+  };
+}
+
+function signPayload(payload, _secret) {
+  // k6 does not have Node.js crypto — return a placeholder signature.
+  // For real testing, use `stripe listen --forward-to` which signs properly.
+  const timestamp = Math.floor(Date.now() / 1000);
+  return `t=${timestamp},v1=placeholder_signature_for_load_test`;
+}
+
+export default function () {
+  const eventType = EVENT_TYPES[Math.floor(Math.random() * EVENT_TYPES.length)];
+  const index = __ITER;
+  const payload = makeWebhookPayload(eventType, index);
+  const body = JSON.stringify(payload);
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'Stripe-Signature': signPayload(body, WEBHOOK_SECRET),
+  };
+
+  const res = http.post(`${BASE_URL}/api/webhooks/stripe`, body, { headers });
+
+  const isError = res.status >= 500;
+  errorRate.add(isError);
+
+  // 400 is expected when signature verification fails (no real secret)
+  check(res, {
+    'no 500 errors': (r) => r.status < 500,
+    'valid response': (r) => [200, 400].includes(r.status),
+  });
+}
+
+export function handleSummary(data) {
+  const total = data.metrics.http_reqs?.values?.count ?? 0;
+  const errRate = data.metrics.errors?.values?.rate ?? 0;
+  const p95 = data.metrics.http_req_duration?.values?.['p(95)'] ?? 0;
+
+  console.log('\n======== WEBHOOK STORM TEST SUMMARY ========');
+  console.log(`Total webhooks:  ${total}`);
+  console.log(`p95 latency:     ${p95.toFixed(0)}ms`);
+  console.log(`Error rate:      ${(errRate * 100).toFixed(2)}% (target: <1%)`);
+  console.log('=============================================\n');
+
+  return {};
+}

--- a/web/load-tests/webhook-storm.js
+++ b/web/load-tests/webhook-storm.js
@@ -44,7 +44,7 @@ const EVENT_TYPES = [
   'checkout.session.completed',
   'customer.subscription.updated',
   'customer.subscription.deleted',
-  'invoice.payment_succeeded',
+  'invoice.paid',
   'invoice.payment_failed',
 ];
 
@@ -86,9 +86,11 @@ function signPayload(payload, secret) {
 
 export default function () {
   const eventType = EVENT_TYPES[Math.floor(Math.random() * EVENT_TYPES.length)];
-  // Use globally unique iteration counter (not per-VU __ITER which collides
-  // across virtual users in shared-iterations mode).
-  const index = exec.scenario.iterationInTest;
+  // Use a 50-slot repeating pool so half the requests reuse event IDs,
+  // exercising the server-side idempotency guard. The pool is keyed by event
+  // type so different event types don't collide with each other.
+  const pool = 50;
+  const index = exec.scenario.iterationInTest % pool;
   const payload = makeWebhookPayload(eventType, index);
   const body = JSON.stringify(payload);
 
@@ -102,10 +104,17 @@ export default function () {
   const isError = res.status >= 500;
   errorRate.add(isError);
 
-  // Track duplicate detection: a 200 on a previously-sent event ID means the
-  // handler processed it; a 409 or identical 200 with "already processed" in
-  // the body indicates the idempotency guard fired correctly.
-  const isDuplicate = res.status === 200 && res.body && res.body.includes('already_processed');
+  // Track duplicate detection: server returns {"received":true,"duplicate":true}
+  // when the idempotency guard fires for a previously-processed event ID.
+  let isDuplicate = false;
+  if (res.status === 200 && res.body) {
+    try {
+      const json = res.json();
+      isDuplicate = json.duplicate === true;
+    } catch (_) {
+      // non-JSON body (e.g. 400 from failed sig verification) — not a duplicate
+    }
+  }
   duplicateRate.add(isDuplicate ? 1 : 0);
 
   // 400 is expected when signature verification fails (no real secret)


### PR DESCRIPTION
## Summary
- Adds 3 on-demand k6 load test scripts in `web/load-tests/`:
  - `chat-load.js`: 50 concurrent users hitting /api/chat (p95 <5s, <1% errors)
  - `generate-load.js`: 20 concurrent users across 7 /api/generate routes
  - `webhook-storm.js`: 100 Stripe webhooks in 10s for idempotency verification
- Scripts are on-demand only — NOT integrated into CI
- Require k6 CLI and a Clerk session token for authenticated routes

Closes #7866

## Test plan
- [x] Scripts have valid k6 syntax (options, scenarios, thresholds, metrics)
- [x] Custom metrics track error rate, rate limiting, and latency
- [x] Summary handlers print actionable results
- [ ] Manual run against staging environment