### PR TITLE
test: add handler and executor test coverage (75 tests)

### DIFF
--- a/.changeset/handler-executor-test-coverage.md
+++ b/.changeset/handler-executor-test-coverage.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add test coverage for 5 previously untested modules: leaderboard, performance, and export chat handlers plus verify and physics profile game-creation executors (75 tests)

--- a/web/src/lib/chat/handlers/__tests__/exportHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/exportHandlers.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Tests for exportHandlers — ZIP/PWA export, loading screen config, presets.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invokeHandler } from './handlerTestUtils';
+import { exportHandlers } from '../exportHandlers';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockExportGame = vi.fn();
+const mockDownloadBlob = vi.fn();
+const mockGetPreset = vi.fn();
+const mockPresets: Record<string, unknown> = {
+  mobile: {
+    name: 'Mobile',
+    format: 'zip',
+    resolution: '720p',
+    includeDebug: false,
+    loadingScreen: { backgroundColor: '#000000' },
+  },
+  desktop: {
+    name: 'Desktop',
+    format: 'zip',
+    resolution: '1080p',
+    includeDebug: true,
+    loadingScreen: { backgroundColor: '#1a1a2e' },
+  },
+};
+
+vi.mock('@/lib/export/exportEngine', () => ({
+  exportGame: (...args: unknown[]) => mockExportGame(...args),
+  downloadBlob: (...args: unknown[]) => mockDownloadBlob(...args),
+}));
+
+vi.mock('@/lib/export/presets', () => ({
+  getPreset: (...args: unknown[]) => mockGetPreset(...args),
+  EXPORT_PRESETS: new Proxy({}, {
+    get(_t, k) { return mockPresets[k as string]; },
+    ownKeys() { return Object.keys(mockPresets); },
+    getOwnPropertyDescriptor(_t, k) {
+      if (k in mockPresets) return { enumerable: true, configurable: true, value: mockPresets[k as string] };
+    },
+  }),
+}));
+
+vi.mock('@/stores/editorStore', () => ({
+  useEditorStore: {
+    getState: () => ({
+      sceneName: 'My Game',
+      exportPreset: null,
+      loadingScreenConfig: null,
+      setLoadingScreenConfig: vi.fn(),
+      setExportPreset: vi.fn(),
+    }),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExportGame.mockResolvedValue(new Blob(['zip-data'], { type: 'application/zip' }));
+  mockGetPreset.mockImplementation((name: string) => mockPresets[name] ?? null);
+});
+
+describe('exportHandlers', () => {
+  // ---------------------------------------------------------------------------
+  // export_project_zip
+  // ---------------------------------------------------------------------------
+
+  describe('export_project_zip', () => {
+    it('exports with default title from store', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'export_project_zip', {});
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('My Game');
+      expect(mockExportGame).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'My Game', mode: 'zip' })
+      );
+      expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'My_Game.zip'
+      );
+    });
+
+    it('exports with custom title', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'export_project_zip', {
+        title: 'Space Adventure',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Space Adventure');
+      expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'Space_Adventure.zip'
+      );
+    });
+
+    it('applies preset config when specified', async () => {
+      await invokeHandler(exportHandlers, 'export_project_zip', {
+        preset: 'mobile',
+      });
+
+      expect(mockGetPreset).toHaveBeenCalledWith('mobile');
+      expect(mockExportGame).toHaveBeenCalledWith(
+        expect.objectContaining({ resolution: '720p', includeDebug: false })
+      );
+    });
+
+    it('returns error on export failure', async () => {
+      mockExportGame.mockRejectedValue(new Error('WASM not loaded'));
+
+      const { result } = await invokeHandler(exportHandlers, 'export_project_zip', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('WASM not loaded');
+    });
+
+    it('handles non-Error throw', async () => {
+      mockExportGame.mockRejectedValue('unknown error');
+
+      const { result } = await invokeHandler(exportHandlers, 'export_project_zip', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('unknown error');
+    });
+
+    it('sanitizes title for filename', async () => {
+      await invokeHandler(exportHandlers, 'export_project_zip', {
+        title: 'My Game! (v2)',
+      });
+
+      expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'My_Game___v2_.zip'
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // export_project_pwa
+  // ---------------------------------------------------------------------------
+
+  describe('export_project_pwa', () => {
+    it('exports as PWA', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'export_project_pwa', {});
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('PWA');
+      expect(mockExportGame).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'pwa' })
+      );
+      expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect.any(Blob),
+        'My_Game_pwa.zip'
+      );
+    });
+
+    it('returns error on PWA export failure', async () => {
+      mockExportGame.mockRejectedValue(new Error('Service worker generation failed'));
+
+      const { result } = await invokeHandler(exportHandlers, 'export_project_pwa', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Service worker generation failed');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // set_loading_screen
+  // ---------------------------------------------------------------------------
+
+  describe('set_loading_screen', () => {
+    it('sets loading screen with defaults', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_loading_screen', {});
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('bar');
+      expect(result.message).toContain('#18181b');
+    });
+
+    it('sets loading screen with custom values', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_loading_screen', {
+        backgroundColor: '#ff0000',
+        progressBarColor: '#00ff00',
+        progressStyle: 'spinner',
+        title: 'Loading...',
+        subtitle: 'Please wait',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('spinner');
+      expect(result.message).toContain('#ff0000');
+    });
+
+    it('rejects invalid hex color', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_loading_screen', {
+        backgroundColor: 'red',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects invalid progress style', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_loading_screen', {
+        progressStyle: 'rainbow',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('accepts valid hex formats (3, 4, 6, 8 digits)', async () => {
+      for (const color of ['#fff', '#abcd', '#aabbcc', '#aabbccdd']) {
+        const { result } = await invokeHandler(exportHandlers, 'set_loading_screen', {
+          backgroundColor: color,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // set_export_preset
+  // ---------------------------------------------------------------------------
+
+  describe('set_export_preset', () => {
+    it('sets a known preset', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_export_preset', {
+        preset: 'mobile',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Mobile');
+    });
+
+    it('rejects unknown preset', async () => {
+      mockGetPreset.mockReturnValue(null);
+
+      const { result } = await invokeHandler(exportHandlers, 'set_export_preset', {
+        preset: 'nonexistent',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unknown preset');
+      expect(result.error).toContain('nonexistent');
+    });
+
+    it('rejects empty preset name', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_export_preset', {
+        preset: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects missing preset', async () => {
+      const { result } = await invokeHandler(exportHandlers, 'set_export_preset', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+});

--- a/web/src/lib/chat/handlers/__tests__/leaderboardHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/leaderboardHandlers.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for leaderboardHandlers — CRUD operations on game leaderboards.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invokeHandler } from './handlerTestUtils';
+import { leaderboardHandlers } from '../leaderboardHandlers';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// create_leaderboard
+// ---------------------------------------------------------------------------
+
+describe('leaderboardHandlers', () => {
+  describe('create_leaderboard', () => {
+    it('creates a leaderboard with default sort order', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ id: 'lb1' }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_1',
+        name: 'High Scores',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('High Scores');
+      expect(result.message).toContain('desc');
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[0]).toBe('/api/publish/game_1/leaderboards');
+      expect(call[1]?.method).toBe('POST');
+      const body = JSON.parse(call[1]?.body as string);
+      expect(body.sortOrder).toBe('desc');
+    });
+
+    it('creates a leaderboard with custom options', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ id: 'lb2' }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_2',
+        name: 'Fastest Times',
+        sortOrder: 'asc',
+        maxEntries: 100,
+        minScore: 0,
+        maxScore: 9999,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('asc');
+
+      const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+      expect(body.sortOrder).toBe('asc');
+      expect(body.maxEntries).toBe(100);
+      expect(body.minScore).toBe(0);
+      expect(body.maxScore).toBe(9999);
+    });
+
+    it('returns error on API failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Game not found' }), { status: 404 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'missing',
+        name: 'Scores',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Game not found');
+    });
+
+    it('handles non-JSON error response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response('Internal Server Error', { status: 500 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('HTTP 500');
+    });
+
+    it('rejects missing gameId', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        name: 'Scores',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects missing name', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects maxEntries out of range', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+        maxEntries: 5000,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects invalid sortOrder', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'create_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+        sortOrder: 'random',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // list_leaderboards
+  // ---------------------------------------------------------------------------
+
+  describe('list_leaderboards', () => {
+    it('returns leaderboards for a game', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ leaderboards: [{ name: 'Scores' }, { name: 'Times' }] }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'list_leaderboards', {
+        gameId: 'game_1',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('2 leaderboard(s)');
+      expect((result.result as { leaderboards: unknown[] }).leaderboards).toHaveLength(2);
+    });
+
+    it('returns error on API failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'list_leaderboards', {
+        gameId: 'game_1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Forbidden');
+    });
+
+    it('rejects empty gameId', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'list_leaderboards', {
+        gameId: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // configure_leaderboard
+  // ---------------------------------------------------------------------------
+
+  describe('configure_leaderboard', () => {
+    it('updates leaderboard configuration', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'configure_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+        sortOrder: 'asc',
+        maxEntries: 50,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('Scores');
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[0]).toBe('/api/publish/game_1/leaderboards/Scores');
+      expect(call[1]?.method).toBe('PATCH');
+    });
+
+    it('allows nullable minScore and maxScore', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'configure_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+        minScore: null,
+        maxScore: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('returns error on API failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'configure_leaderboard', {
+        gameId: 'game_1',
+        name: 'Missing',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Not found');
+    });
+
+    it('URL-encodes special characters in gameId and name', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      await invokeHandler(leaderboardHandlers, 'configure_leaderboard', {
+        gameId: 'game/special',
+        name: 'top scores',
+      });
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[0]).toBe('/api/publish/game%2Fspecial/leaderboards/top%20scores');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // delete_leaderboard
+  // ---------------------------------------------------------------------------
+
+  describe('delete_leaderboard', () => {
+    it('deletes a leaderboard', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'delete_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('deleted');
+      expect(result.message).toContain('Scores');
+
+      const call = vi.mocked(fetch).mock.calls[0];
+      expect(call[0]).toBe('/api/publish/game_1/leaderboards/Scores');
+      expect(call[1]?.method).toBe('DELETE');
+    });
+
+    it('returns error on API failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 })
+      );
+
+      const { result } = await invokeHandler(leaderboardHandlers, 'delete_leaderboard', {
+        gameId: 'game_1',
+        name: 'Scores',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unauthorized');
+    });
+
+    it('rejects missing name', async () => {
+      const { result } = await invokeHandler(leaderboardHandlers, 'delete_leaderboard', {
+        gameId: 'game_1',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+});

--- a/web/src/lib/chat/handlers/__tests__/performanceHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/performanceHandlers.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for performanceHandlers — LOD, performance budget, scene optimization.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invokeHandler } from './handlerTestUtils';
+import { performanceHandlers } from '../performanceHandlers';
+
+// ---------------------------------------------------------------------------
+// Mock performanceStore
+// ---------------------------------------------------------------------------
+
+const mockSetBudget = vi.fn();
+const mockStats = { triangles: 50000, drawCalls: 80, fps: 60 };
+
+vi.mock('@/stores/performanceStore', () => ({
+  usePerformanceStore: {
+    getState: () => ({
+      setBudget: mockSetBudget,
+      stats: mockStats,
+    }),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('performanceHandlers', () => {
+  // ---------------------------------------------------------------------------
+  // set_entity_lod
+  // ---------------------------------------------------------------------------
+
+  describe('set_entity_lod', () => {
+    it('dispatches set_lod with default distances and ratios', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_entity_lod', {
+        entityId: 'e1',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ message: 'LOD configured for entity e1' });
+    });
+
+    it('dispatches set_lod with custom distances', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_entity_lod', {
+        entityId: 'e1',
+        lodDistances: [10, 30, 60],
+        autoGenerate: true,
+        lodRatios: [0.75, 0.5, 0.25],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing entityId', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_entity_lod', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // generate_lods
+  // ---------------------------------------------------------------------------
+
+  describe('generate_lods', () => {
+    it('dispatches generate_lods command', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'generate_lods', {
+        entityId: 'e2',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ message: 'LOD generation triggered for entity e2' });
+    });
+
+    it('rejects empty entityId', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'generate_lods', {
+        entityId: '',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // set_performance_budget
+  // ---------------------------------------------------------------------------
+
+  describe('set_performance_budget', () => {
+    it('sets budget with defaults', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_performance_budget', {});
+
+      expect(result.success).toBe(true);
+      expect(mockSetBudget).toHaveBeenCalledWith({
+        maxTriangles: 500_000,
+        maxDrawCalls: 200,
+        targetFps: 60,
+        warningThreshold: 0.8,
+      });
+      const budget = (result.result as { budget: Record<string, number> }).budget;
+      expect(budget.maxTriangles).toBe(500_000);
+    });
+
+    it('sets budget with custom values', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_performance_budget', {
+        maxTriangles: 100_000,
+        maxDrawCalls: 50,
+        targetFps: 30,
+        warningThreshold: 0.9,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockSetBudget).toHaveBeenCalledWith({
+        maxTriangles: 100_000,
+        maxDrawCalls: 50,
+        targetFps: 30,
+        warningThreshold: 0.9,
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // get_performance_stats
+  // ---------------------------------------------------------------------------
+
+  describe('get_performance_stats', () => {
+    it('returns current performance stats', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'get_performance_stats', {});
+
+      expect(result.success).toBe(true);
+      const stats = (result.result as { stats: typeof mockStats }).stats;
+      expect(stats.triangles).toBe(50000);
+      expect(stats.drawCalls).toBe(80);
+      expect(stats.fps).toBe(60);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // optimize_scene
+  // ---------------------------------------------------------------------------
+
+  describe('optimize_scene', () => {
+    it('dispatches optimize_scene command', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'optimize_scene', {});
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({
+        message: 'Scene optimization applied — LOD configuration added to all entities',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // set_lod_distances
+  // ---------------------------------------------------------------------------
+
+  describe('set_lod_distances', () => {
+    it('sets global LOD distances with defaults', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_lod_distances', {});
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ message: 'Global LOD distances updated' });
+    });
+
+    it('sets custom LOD distances', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_lod_distances', {
+        distances: [5, 15, 30],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // set_simplification_backend
+  // ---------------------------------------------------------------------------
+
+  describe('set_simplification_backend', () => {
+    it('sets qem backend', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_simplification_backend', {
+        backend: 'qem',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ message: 'Simplification backend set to qem' });
+    });
+
+    it('sets fast backend', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_simplification_backend', {
+        backend: 'fast',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.result).toEqual({ message: 'Simplification backend set to fast' });
+    });
+
+    it('rejects invalid backend', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_simplification_backend', {
+        backend: 'slow',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('rejects missing backend', async () => {
+      const { result } = await invokeHandler(performanceHandlers, 'set_simplification_backend', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/physicsProfileExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/physicsProfileExecutor.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for physicsProfileExecutor — physics feel to preset mapping.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { physicsProfileExecutor } from '../physicsProfileExecutor';
+import type { ExecutorContext } from '../../types';
+
+// Mock the physics module
+const mockApplyPhysicsProfile = vi.fn();
+vi.mock('@/lib/ai/physicsFeel', () => ({
+  PHYSICS_PRESETS: {
+    space_zero_g: { gravity: 0, moveSpeed: 2 },
+    platformer_floaty: { gravity: 5, moveSpeed: 6 },
+    platformer_snappy: { gravity: 15, moveSpeed: 8 },
+    underwater: { gravity: 3, moveSpeed: 3 },
+    puzzle_precise: { gravity: 10, moveSpeed: 4 },
+    arcade_classic: { gravity: 10, moveSpeed: 7 },
+    rpg_weighty: { gravity: 12, moveSpeed: 5 },
+  },
+  applyPhysicsProfile: (...args: unknown[]) => mockApplyPhysicsProfile(...args),
+}));
+
+function makeCtx(overrides: Partial<ExecutorContext> = {}): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: {
+      sceneGraph: { nodes: {}, rootIds: [] },
+    } as unknown as ExecutorContext['store'],
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeNode(entityId: string, name: string, components: string[] = []) {
+  return { entityId, name, components, children: [] };
+}
+
+function makeFeelDirective(overrides: Record<string, unknown> = {}) {
+  return {
+    mood: 'energetic',
+    pacing: 'medium',
+    weight: 'medium',
+    referenceGames: ['Super Mario Bros'],
+    oneLiner: 'A fast-paced platformer',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('physicsProfileExecutor', () => {
+  it('has correct metadata', () => {
+    expect(physicsProfileExecutor.name).toBe('physics_profile');
+    expect(physicsProfileExecutor.userFacingErrorMessage).toBeDefined();
+  });
+
+  it('maps floaty+slow to space_zero_g', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective({ weight: 'floaty', pacing: 'slow' }),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { presetUsed: string };
+    expect(output.presetUsed).toBe('space_zero_g');
+  });
+
+  it('maps heavy+medium to rpg_weighty', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective({ weight: 'heavy', pacing: 'medium' }),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { presetUsed: string };
+    expect(output.presetUsed).toBe('rpg_weighty');
+  });
+
+  it('maps light+slow to underwater', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective({ weight: 'light', pacing: 'slow' }),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { presetUsed: string };
+    expect(output.presetUsed).toBe('underwater');
+  });
+
+  it('defaults to arcade_classic for medium+medium', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective({ weight: 'medium', pacing: 'medium' }),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { presetUsed: string };
+    expect(output.presetUsed).toBe('arcade_classic');
+  });
+
+  it('applies to specified entityIds', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+      projectType: '3d',
+      entityIds: ['e1', 'e2'],
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockApplyPhysicsProfile).toHaveBeenCalledWith(
+      expect.any(Object),
+      ctx.dispatchCommand,
+      ['e1', 'e2'],
+    );
+    const output = result.output as { entityCount: number };
+    expect(output.entityCount).toBe(2);
+  });
+
+  it('falls back to store physics nodes when no entityIds', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player', ['PhysicsData']),
+            e2: makeNode('e2', 'Enemy', ['RigidBody']),
+            e3: makeNode('e3', 'Ground', []),
+          },
+          rootIds: ['e1', 'e2', 'e3'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockApplyPhysicsProfile).toHaveBeenCalledWith(
+      expect.any(Object),
+      ctx.dispatchCommand,
+      ['e1', 'e2'],
+    );
+    const output = result.output as { entityCount: number };
+    expect(output.entityCount).toBe(2);
+  });
+
+  it('returns entityCount 0 when no physics nodes and no entityIds', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockApplyPhysicsProfile).not.toHaveBeenCalled();
+    const output = result.output as { entityCount: number };
+    expect(output.entityCount).toBe(0);
+  });
+
+  it('allows safe config overrides for moveSpeed and jumpForce', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: { e1: makeNode('e1', 'Player', ['PhysicsData']) },
+          rootIds: ['e1'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+      projectType: '3d',
+      config: { moveSpeed: 15, jumpForce: 20 },
+    }, ctx);
+
+    const appliedProfile = mockApplyPhysicsProfile.mock.calls[0][0];
+    expect(appliedProfile.moveSpeed).toBe(15);
+    expect(appliedProfile.jumpForce).toBe(20);
+  });
+
+  it('ignores non-numeric config overrides', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: { e1: makeNode('e1', 'Player', ['PhysicsData']) },
+          rootIds: ['e1'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+      projectType: '3d',
+      config: { moveSpeed: 'fast', jumpForce: NaN },
+    }, ctx);
+
+    const appliedProfile = mockApplyPhysicsProfile.mock.calls[0][0];
+    // Should use preset value, not the invalid overrides
+    expect(typeof appliedProfile.moveSpeed).toBe('number');
+    expect(Number.isFinite(appliedProfile.moveSpeed)).toBe(true);
+  });
+
+  it('rejects invalid feel directive', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: { mood: 'happy' }, // missing required fields
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects missing projectType', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective(),
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects invalid pacing enum', async () => {
+    const ctx = makeCtx();
+    const result = await physicsProfileExecutor.execute({
+      feelDirective: makeFeelDirective({ pacing: 'turbo' }),
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/verifyExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/verifyExecutor.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for verifyExecutor — scene verification checks.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { verifyExecutor } from '../verifyExecutor';
+import type { ExecutorContext } from '../../types';
+
+function makeCtx(overrides: Partial<ExecutorContext> = {}): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: {
+      sceneGraph: { nodes: {}, rootIds: [] },
+    } as unknown as ExecutorContext['store'],
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeNode(entityId: string, name: string, components: string[] = []) {
+  return { entityId, name, components, children: [] };
+}
+
+describe('verifyExecutor', () => {
+  it('has correct metadata', () => {
+    expect(verifyExecutor.name).toBe('verify_all_scenes');
+    expect(verifyExecutor.userFacingErrorMessage).toBeDefined();
+  });
+
+  it('reports empty scene', async () => {
+    const ctx = makeCtx();
+    const result = await verifyExecutor.execute({}, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { warnings: string[]; issues: string[]; passed: boolean; entityCount: number };
+    expect(output.warnings).toContain('Scene has no entities');
+    expect(output.issues).toContain('empty_scene');
+    expect(output.entityCount).toBe(0);
+    expect(output.passed).toBe(false);
+  });
+
+  it('passes when scene has camera, light, and ground', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player'),
+            e2: makeNode('e2', 'MainCamera'),
+            e3: makeNode('e3', 'DirectionalLight'),
+            e4: makeNode('e4', 'Ground'),
+          },
+          rootIds: ['e1', 'e2', 'e3', 'e4'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    expect(result.success).toBe(true);
+    const output = result.output as { warnings: string[]; issues: string[]; passed: boolean };
+    expect(output.passed).toBe(true);
+    expect(output.warnings).toHaveLength(0);
+    expect(output.issues).toHaveLength(0);
+  });
+
+  it('detects missing camera', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player'),
+            e2: makeNode('e2', 'AmbientLight'),
+            e3: makeNode('e3', 'Ground'),
+          },
+          rootIds: ['e1', 'e2', 'e3'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    const output = result.output as { issues: string[] };
+    expect(output.issues).toContain('no_camera_on_player');
+  });
+
+  it('detects missing light', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player'),
+            e2: makeNode('e2', 'Camera'),
+            e3: makeNode('e3', 'Ground'),
+          },
+          rootIds: ['e1', 'e2', 'e3'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    const output = result.output as { issues: string[] };
+    expect(output.issues).toContain('no_ambient_light');
+  });
+
+  it('detects missing ground plane in 3D projects', async () => {
+    const ctx = makeCtx({
+      projectType: '3d',
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player'),
+            e2: makeNode('e2', 'Camera'),
+            e3: makeNode('e3', 'SunLight'),
+          },
+          rootIds: ['e1', 'e2', 'e3'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    const output = result.output as { issues: string[] };
+    expect(output.issues).toContain('no_ground_plane');
+  });
+
+  it('does not check ground plane for 2D projects', async () => {
+    const ctx = makeCtx({
+      projectType: '2d',
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Player'),
+            e2: makeNode('e2', 'Camera'),
+            e3: makeNode('e3', 'AmbientLight'),
+          },
+          rootIds: ['e1', 'e2', 'e3'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    const output = result.output as { issues: string[] };
+    expect(output.issues).not.toContain('no_ground_plane');
+  });
+
+  it('recognizes camera naming variants', async () => {
+    for (const name of ['Camera', 'camera', 'MainCamera', 'player_cam']) {
+      const ctx = makeCtx({
+        store: {
+          sceneGraph: {
+            nodes: {
+              e1: makeNode('e1', name),
+              e2: makeNode('e2', 'SunLight'),
+              e3: makeNode('e3', 'Ground'),
+            },
+            rootIds: ['e1', 'e2', 'e3'],
+          },
+        } as unknown as ExecutorContext['store'],
+      });
+
+      const result = await verifyExecutor.execute({}, ctx);
+      const output = result.output as { issues: string[] };
+      expect(output.issues).not.toContain('no_camera_on_player');
+    }
+  });
+
+  it('recognizes light naming variants', async () => {
+    for (const name of ['DirectionalLight', 'ambient', 'Sun', 'sunlight']) {
+      const ctx = makeCtx({
+        store: {
+          sceneGraph: {
+            nodes: {
+              e1: makeNode('e1', 'Camera'),
+              e2: makeNode('e2', name),
+              e3: makeNode('e3', 'Ground'),
+            },
+            rootIds: ['e1', 'e2', 'e3'],
+          },
+        } as unknown as ExecutorContext['store'],
+      });
+
+      const result = await verifyExecutor.execute({}, ctx);
+      const output = result.output as { issues: string[] };
+      expect(output.issues).not.toContain('no_ambient_light');
+    }
+  });
+
+  it('recognizes ground naming variants', async () => {
+    for (const name of ['Ground', 'floor', 'Plane', 'background_ground']) {
+      const ctx = makeCtx({
+        projectType: '3d',
+        store: {
+          sceneGraph: {
+            nodes: {
+              e1: makeNode('e1', 'Camera'),
+              e2: makeNode('e2', 'Light'),
+              e3: makeNode('e3', name),
+            },
+            rootIds: ['e1', 'e2', 'e3'],
+          },
+        } as unknown as ExecutorContext['store'],
+      });
+
+      const result = await verifyExecutor.execute({}, ctx);
+      const output = result.output as { issues: string[] };
+      expect(output.issues).not.toContain('no_ground_plane');
+    }
+  });
+
+  it('returns entity count', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            e1: makeNode('e1', 'Camera'),
+            e2: makeNode('e2', 'Light'),
+            e3: makeNode('e3', 'Ground'),
+            e4: makeNode('e4', 'Enemy'),
+            e5: makeNode('e5', 'Coin'),
+          },
+          rootIds: ['e1', 'e2', 'e3', 'e4', 'e5'],
+        },
+      } as unknown as ExecutorContext['store'],
+    });
+
+    const result = await verifyExecutor.execute({}, ctx);
+    const output = result.output as { entityCount: number };
+    expect(output.entityCount).toBe(5);
+  });
+
+  it('returns failure when aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const ctx = makeCtx({ signal: controller.signal });
+
+    const result = await verifyExecutor.execute({}, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('ABORTED');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 50 tests for 3 untested chat handler modules (leaderboard, performance, export)
- Add 25 tests for 2 untested game-creation executors (verify, physicsProfile)
- Covers Zod validation, API error handling, preset mapping, scene verification checks

Closes #8258

## Test plan
- [x] All 75 new tests pass locally
- [x] ESLint zero warnings
- [x] TypeScript clean (only pre-existing baseUrl deprecation)
- [x] No changes to production code — test-only PR