### PR TITLE
test: add vitals and capabilities API route tests (20 tests)

### DIFF
--- a/.changeset/api-route-test-coverage.md
+++ b/.changeset/api-route-test-coverage.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add test coverage for vitals and capabilities API routes (20 tests)

--- a/web/src/app/api/capabilities/route.test.ts
+++ b/web/src/app/api/capabilities/route.test.ts
@@ -1,0 +1,145 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimitPublicRoute: vi.fn().mockResolvedValue(null),
+}));
+
+import { rateLimitPublicRoute } from '@/lib/rateLimit';
+
+const BASE_URL = 'http://localhost:3000/api/capabilities';
+
+describe('GET /api/capabilities', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(null);
+    // Reset env to original state
+    for (const key of Object.keys(process.env)) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('returns all capabilities with available/unavailable arrays', async () => {
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.capabilities).toBeInstanceOf(Array);
+    expect(body.available).toBeInstanceOf(Array);
+    expect(body.unavailable).toBeInstanceOf(Array);
+    expect(body.capabilities.length).toBe(10);
+  });
+
+  it('includes all expected capability types', async () => {
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const capNames = body.capabilities.map((c: { capability: string }) => c.capability);
+    expect(capNames).toContain('chat');
+    expect(capNames).toContain('embedding');
+    expect(capNames).toContain('image');
+    expect(capNames).toContain('model3d');
+    expect(capNames).toContain('sfx');
+    expect(capNames).toContain('music');
+    expect(capNames).toContain('sprite');
+  });
+
+  it('marks chat as available when ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const chat = body.capabilities.find((c: { capability: string }) => c.capability === 'chat');
+    expect(chat.available).toBe(true);
+    expect(body.available).toContain('chat');
+  });
+
+  it('marks capability as unavailable when no env vars set', async () => {
+    // Ensure no relevant env vars are set
+    delete process.env.PLATFORM_SUNO_KEY;
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const music = body.capabilities.find((c: { capability: string }) => c.capability === 'music');
+    expect(music.available).toBe(false);
+    expect(music.requiredProviders).toBeDefined();
+    expect(music.hint).toContain('Suno');
+    expect(body.unavailable).toContain('music');
+  });
+
+  it('includes human-readable labels', async () => {
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const chat = body.capabilities.find((c: { capability: string }) => c.capability === 'chat');
+    expect(chat.label).toBe('AI Chat');
+
+    const sprite = body.capabilities.find((c: { capability: string }) => c.capability === 'sprite');
+    expect(sprite.label).toBe('Sprite Generation');
+  });
+
+  it('sets cache control headers', async () => {
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+
+    expect(res.headers.get('Cache-Control')).toContain('max-age=60');
+  });
+
+  it('returns rate limit response when limited', async () => {
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Rate limited' }), { status: 429 }) as never
+    );
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+
+    expect(res.status).toBe(429);
+  });
+
+  it('marks chat available via AI Gateway on Vercel', async () => {
+    process.env.VERCEL = '1';
+    // No explicit AI_GATEWAY_API_KEY needed — OIDC auto-auth
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const chat = body.capabilities.find((c: { capability: string }) => c.capability === 'chat');
+    expect(chat.available).toBe(true);
+  });
+
+  it('does not include requiredProviders for available capabilities', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+
+    const { GET } = await import('./route');
+    const req = new NextRequest(BASE_URL);
+    const res = await GET(req);
+    const body = await res.json();
+
+    const chat = body.capabilities.find((c: { capability: string }) => c.capability === 'chat');
+    expect(chat.requiredProviders).toBeUndefined();
+    expect(chat.hint).toBeUndefined();
+  });
+});

--- a/web/src/app/api/vitals/route.test.ts
+++ b/web/src/app/api/vitals/route.test.ts
@@ -1,0 +1,137 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimitPublicRoute: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock next/server's `after` — no-op since it's fire-and-forget
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual('next/server');
+  return { ...actual, after: () => {} };
+});
+
+import { rateLimitPublicRoute } from '@/lib/rateLimit';
+
+const BASE_URL = 'http://localhost:3000/api/vitals';
+
+function makeReq(body: unknown) {
+  return new NextRequest(BASE_URL, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/vitals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(null);
+  });
+
+  it('returns 204 for valid LCP metric', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: 2500, id: 'v1-abc', delta: 100 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 204 for valid CLS metric', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'CLS', value: 0.1, id: 'v1-cls', delta: 0.05 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('accepts all valid metric names', async () => {
+    const { POST } = await import('./route');
+    for (const name of ['LCP', 'FCP', 'CLS', 'INP', 'TTFB']) {
+      const req = makeReq({ name, value: 100, id: `v1-${name}`, delta: 10 });
+      const res = await POST(req);
+      expect(res.status).toBe(204);
+    }
+  });
+
+  it('returns 400 for invalid metric name', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'INVALID', value: 100, id: 'v1', delta: 10 });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Invalid metric name');
+    expect(body.error).toContain('LCP');
+  });
+
+  it('returns 400 for missing required fields', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP' }); // missing value, id, delta
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Missing or invalid required fields');
+  });
+
+  it('returns 400 for non-finite value', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: Infinity, id: 'v1', delta: 10 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for non-finite delta', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: 100, id: 'v1', delta: NaN });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for malformed JSON', async () => {
+    const { POST } = await import('./route');
+    const req = new NextRequest(BASE_URL, {
+      method: 'POST',
+      body: 'not json',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain('Invalid JSON');
+  });
+
+  it('returns 400 for empty id string', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: 100, id: '', delta: 10 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns rate limit response when limited', async () => {
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Rate limited' }), { status: 429 }) as never
+    );
+
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: 100, id: 'v1', delta: 10 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(429);
+  });
+
+  it('returns 400 for id exceeding max length', async () => {
+    const { POST } = await import('./route');
+    const req = makeReq({ name: 'LCP', value: 100, id: 'x'.repeat(201), delta: 10 });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 11 tests for vitals POST route (metric validation, Zod schema, rate limiting)
- Add 9 tests for capabilities GET route (env var detection, provider mapping, cache headers)
- Both routes were previously untested

Closes #7576

## Test plan
- [x] All 20 new tests pass locally
- [x] ESLint zero warnings
- [x] TypeScript clean
- [x] No changes to production code — test-only PR