### PR TITLE
test: add game-creation executor and registry test coverage (67 tests)

### DIFF
--- a/.changeset/executor-coverage.md
+++ b/.changeset/executor-coverage.md
@@ -1,0 +1,5 @@
+---
+"@spawnforge/web": patch
+---
+
+Add test coverage for 5 game-creation executors and system registry (67 tests)

--- a/web/src/lib/game-creation/executors/__tests__/assetGenerateExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/assetGenerateExecutor.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest';
+import { assetGenerateExecutor } from '../assetGenerateExecutor';
+import type { ExecutorContext } from '../../types';
+
+function makeCtx(overrides?: Partial<ExecutorContext>): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: { sceneGraph: { nodes: {} } } as never,
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('assetGenerateExecutor', () => {
+  it('has correct name and error message', () => {
+    expect(assetGenerateExecutor.name).toBe('asset_generate');
+    expect(assetGenerateExecutor.userFacingErrorMessage).toContain('placeholder');
+  });
+
+  it('generates an asset successfully', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: '3d-model',
+      description: 'a medieval sword',
+      styleDirective: 'low-poly fantasy',
+      priority: 'required',
+      fallback: 'primitive:cube',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.usedFallback).toBe(false);
+    expect(typeof result.output?.assetId).toBe('string');
+    expect((result.output?.assetId as string).startsWith('asset_')).toBe(true);
+  });
+
+  it('uses fallback when signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const ctx = makeCtx({ signal: ac.signal });
+
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: 'stone texture',
+      styleDirective: 'realistic',
+      priority: 'nice-to-have',
+      fallback: 'builtin:stone',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.usedFallback).toBe(true);
+    expect(result.output?.assetId).toBe('builtin:stone');
+  });
+
+  it('accepts all valid asset types', async () => {
+    const types = ['3d-model', 'texture', 'sound', 'music', 'voice', 'sprite'] as const;
+
+    for (const type of types) {
+      const ctx = makeCtx();
+      const result = await assetGenerateExecutor.execute({
+        type,
+        description: `test ${type}`,
+        styleDirective: 'default',
+        priority: 'required',
+        fallback: 'primitive:default',
+      }, ctx);
+
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid asset type', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'video',
+      description: 'a cutscene',
+      styleDirective: 'cinematic',
+      priority: 'required',
+      fallback: 'primitive:cube',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects empty description', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: '',
+      styleDirective: 'pixel',
+      priority: 'required',
+      fallback: 'primitive:cube',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects description over 500 characters', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: 'x'.repeat(501),
+      styleDirective: 'pixel',
+      priority: 'required',
+      fallback: 'primitive:cube',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects invalid priority', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'sound',
+      description: 'explosion',
+      styleDirective: '8-bit',
+      priority: 'critical',
+      fallback: 'primitive:default',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects invalid fallback format', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: 'stone',
+      styleDirective: 'realistic',
+      priority: 'required',
+      fallback: 'invalid-fallback',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_FALLBACK');
+  });
+
+  it('rejects fallback with uppercase letters', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: 'stone',
+      styleDirective: 'realistic',
+      priority: 'required',
+      fallback: 'primitive:Stone',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_FALLBACK');
+  });
+
+  it('accepts builtin: prefix in fallback', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'sound',
+      description: 'footstep',
+      styleDirective: 'realistic',
+      priority: 'nice-to-have',
+      fallback: 'builtin:footstep-default',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('generates unique asset IDs across calls', async () => {
+    const ctx = makeCtx();
+    const input = {
+      type: 'texture' as const,
+      description: 'test',
+      styleDirective: 'default',
+      priority: 'required' as const,
+      fallback: 'primitive:cube',
+    };
+
+    const result1 = await assetGenerateExecutor.execute(input, ctx);
+    const result2 = await assetGenerateExecutor.execute(input, ctx);
+
+    expect(result1.success).toBe(true);
+    expect(result2.success).toBe(true);
+    expect(result1.output?.assetId).not.toBe(result2.output?.assetId);
+  });
+
+  it('rejects styleDirective over 500 characters', async () => {
+    const ctx = makeCtx();
+    const result = await assetGenerateExecutor.execute({
+      type: 'texture',
+      description: 'stone',
+      styleDirective: 'x'.repeat(501),
+      priority: 'required',
+      fallback: 'primitive:cube',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/autoPolishExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/autoPolishExecutor.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from 'vitest';
+import { autoPolishExecutor } from '../autoPolishExecutor';
+import type { ExecutorContext } from '../../types';
+
+const FEEL_DIRECTIVE = {
+  mood: 'adventurous',
+  pacing: 'medium' as const,
+  weight: 'medium' as const,
+  referenceGames: ['Mario'],
+  oneLiner: 'A platformer adventure',
+};
+
+function makeCtx(overrides?: Partial<ExecutorContext>): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: { sceneGraph: { nodes: {} } } as never,
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn().mockReturnValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('autoPolishExecutor', () => {
+  it('has correct name and error message', () => {
+    expect(autoPolishExecutor.name).toBe('auto_polish');
+    expect(autoPolishExecutor.userFacingErrorMessage).toContain('ready as-is');
+  });
+
+  it('applies no fixes when no issues found', async () => {
+    const ctx = makeCtx();
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixCount).toBe(0);
+    expect(result.output?.fixesApplied).toEqual([]);
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('adds ambient light when no_ambient_light issue present', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_ambient_light'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Added ambient lighting');
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('update_ambient_light', {
+      color: [1, 1, 1],
+      brightness: 0.3,
+    });
+  });
+
+  it('adds ground plane when no_ground_plane issue present', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_ground_plane'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Added ground plane');
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('spawn_entity', {
+      entityType: 'plane',
+      name: 'Ground',
+      position: [0, 0, 0],
+    });
+  });
+
+  it('configures camera as thirdPersonFollow in 3D when no_camera_on_player', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_camera_on_player'] }),
+      store: {
+        sceneGraph: {
+          nodes: {
+            n1: { entityId: 'cam_id', name: 'MainCamera' },
+          },
+        },
+      } as never,
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Configured camera as thirdPersonFollow');
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('set_game_camera', {
+      entityId: 'cam_id',
+      mode: 'thirdPersonFollow',
+      followSmoothing: 0.8,
+    });
+  });
+
+  it('configures camera as sideScroller in 2D', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_camera_on_player'] }),
+      store: {
+        sceneGraph: {
+          nodes: {
+            n1: { entityId: 'cam2d', name: 'game_cam' },
+          },
+        },
+      } as never,
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '2d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Configured camera as sideScroller');
+  });
+
+  it('warns when no camera entity exists for no_camera_on_player', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_camera_on_player'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Warning: no camera entity found to configure');
+    // No command dispatched since no camera found
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('warns about physics_without_collider without dispatching commands', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['physics_without_collider'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixesApplied).toContain('Warning: entity has physics without collider — manual fix needed');
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('applies multiple fixes for multiple issues', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({
+        issues: ['no_ambient_light', 'no_ground_plane', 'physics_without_collider'],
+      }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.fixCount).toBe(3);
+    const fixes = result.output?.fixesApplied as string[];
+    expect(fixes).toContain('Added ambient lighting');
+    expect(fixes).toContain('Added ground plane');
+  });
+
+  it('uses dispatchCommandBatch when available', async () => {
+    const batch = vi.fn().mockReturnValue({ success: true });
+    const ctx = makeCtx({
+      dispatchCommandBatch: batch,
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_ambient_light', 'no_ground_plane'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(batch).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ command: 'update_ambient_light' }),
+      expect.objectContaining({ command: 'spawn_entity' }),
+    ]));
+  });
+
+  it('returns failure when batch command fails', async () => {
+    const batch = vi.fn().mockReturnValue({ success: false });
+    const ctx = makeCtx({
+      dispatchCommandBatch: batch,
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_ambient_light'] }),
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('COMMAND_FAILED');
+  });
+
+  it('rejects invalid projectType', async () => {
+    const ctx = makeCtx();
+    const result = await autoPolishExecutor.execute({
+      projectType: 'vr',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects invalid pacing in feelDirective', async () => {
+    const ctx = makeCtx();
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: { ...FEEL_DIRECTIVE, pacing: 'turbo' },
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('finds camera by _cam suffix', async () => {
+    const ctx = makeCtx({
+      resolveStepOutput: vi.fn().mockReturnValue({ issues: ['no_camera_on_player'] }),
+      store: {
+        sceneGraph: {
+          nodes: {
+            n1: { entityId: 'follow_cam_id', name: 'follow_cam' },
+          },
+        },
+      } as never,
+    });
+
+    const result = await autoPolishExecutor.execute({
+      projectType: '3d',
+      feelDirective: FEEL_DIRECTIVE,
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('set_game_camera', expect.objectContaining({
+      entityId: 'follow_cam_id',
+    }));
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/characterSetupExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/characterSetupExecutor.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { characterSetupExecutor } from '../characterSetupExecutor';
+import type { ExecutorContext } from '../../types';
+
+function makeCtx(overrides?: Partial<ExecutorContext>): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: { sceneGraph: { nodes: {} } } as never,
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('characterSetupExecutor', () => {
+  it('has correct name and error message', () => {
+    expect(characterSetupExecutor.name).toBe('character_setup');
+    expect(characterSetupExecutor.userFacingErrorMessage).toContain('character rig');
+  });
+
+  it('adds CharacterController game component for 3D', async () => {
+    const ctx = makeCtx();
+    const result = await characterSetupExecutor.execute({
+      entity: { name: 'Hero', role: 'player', appearance: 'knight', behaviors: ['move', 'jump'] },
+      projectType: '3d',
+      entityId: 'ent_123',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({
+      entityId: 'ent_123',
+      entityName: 'Hero',
+      projectType: '3d',
+      rigApplied: false,
+    });
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('add_game_component', {
+      entityId: 'ent_123',
+      componentType: 'character_controller',
+      properties: { speed: 5, jumpHeight: 2, gravityScale: 1 },
+    });
+  });
+
+  it('dispatches set_skeleton_2d for 2D projects', async () => {
+    const ctx = makeCtx();
+    const result = await characterSetupExecutor.execute({
+      entity: { name: 'Sprite', role: 'player', appearance: 'pixel', behaviors: ['move'] },
+      projectType: '2d',
+      entityId: 'ent_456',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.rigApplied).toBe(true);
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('set_skeleton_2d', {
+      entityId: 'ent_456',
+      bones: [],
+    });
+  });
+
+  it('uses default entity when none provided', async () => {
+    const ctx = makeCtx();
+    const result = await characterSetupExecutor.execute({
+      projectType: '3d',
+      entityId: 'ent_default',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityName).toBe('Player');
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('add_game_component', expect.objectContaining({
+      entityId: 'ent_default',
+      componentType: 'character_controller',
+    }));
+  });
+
+  it('looks up entity by name in scene graph when no entityId', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            n1: { entityId: 'resolved_id', name: 'Player' },
+          },
+        },
+      } as never,
+    });
+
+    const result = await characterSetupExecutor.execute({
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityId).toBe('resolved_id');
+  });
+
+  it('falls back to entity name as ID when not found in scene graph', async () => {
+    const ctx = makeCtx({
+      store: {
+        sceneGraph: {
+          nodes: {
+            n1: { entityId: 'other_id', name: 'Enemy' },
+          },
+        },
+      } as never,
+    });
+
+    const result = await characterSetupExecutor.execute({
+      entity: { name: 'Ghost', role: 'npc', appearance: 'ghost', behaviors: [] },
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityId).toBe('Ghost');
+  });
+
+  it('rejects invalid projectType', async () => {
+    const ctx = makeCtx();
+    const result = await characterSetupExecutor.execute({
+      projectType: 'vr',
+      entityId: 'ent_1',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('accepts custom entity with all fields', async () => {
+    const ctx = makeCtx();
+    const result = await characterSetupExecutor.execute({
+      entity: { name: 'Wizard', role: 'mage', appearance: 'robed', behaviors: ['cast', 'teleport'] },
+      projectType: '3d',
+      entityId: 'wizard_1',
+      movementType: 'flying',
+      systemConfig: { gravity: false },
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityName).toBe('Wizard');
+  });
+
+  it('does not dispatch duplicate commands when entityId is provided', async () => {
+    const ctx = makeCtx();
+    await characterSetupExecutor.execute({
+      projectType: '3d',
+      entityId: 'explicit_id',
+    }, ctx);
+
+    // Should only dispatch one command (add_game_component), not spawn
+    expect(ctx.dispatchCommand).toHaveBeenCalledTimes(1);
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('add_game_component', expect.anything());
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/entitySetupExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/entitySetupExecutor.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest';
+import { entitySetupExecutor } from '../entitySetupExecutor';
+import type { ExecutorContext } from '../../types';
+
+function makeCtx(overrides?: Partial<ExecutorContext>): ExecutorContext {
+  return {
+    dispatchCommand: vi.fn(),
+    store: { sceneGraph: { nodes: {} } } as never,
+    projectType: '3d',
+    userTier: 'creator',
+    signal: new AbortController().signal,
+    resolveStepOutput: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('entitySetupExecutor', () => {
+  it('has correct name and error message', () => {
+    expect(entitySetupExecutor.name).toBe('entity_setup');
+    expect(entitySetupExecutor.userFacingErrorMessage).toContain('Could not create an entity');
+  });
+
+  it('spawns a capsule for player role in 3D', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Hero', role: 'player' },
+      scene: 'MainScene',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toEqual({
+      entityName: 'Hero',
+      role: 'player',
+      entityType: 'capsule',
+    });
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('switch_scene', { sceneId: 'MainScene' });
+    expect(ctx.dispatchCommand).toHaveBeenCalledWith('spawn_entity', { entityType: 'capsule', name: 'Hero' });
+  });
+
+  it('spawns a sphere for projectile role in 3D', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Bullet', role: 'projectile' },
+      scene: 'Level1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityType).toBe('sphere');
+  });
+
+  it('spawns a cube for enemy role in 3D', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Goblin', role: 'enemy' },
+      scene: 'Level1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityType).toBe('cube');
+  });
+
+  it('always spawns a plane for 2D projects regardless of role', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Player', role: 'player' },
+      scene: 'Scene1',
+      projectType: '2d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.entityType).toBe('plane');
+  });
+
+  it('uses dispatchCommandBatch when available', async () => {
+    const batch = vi.fn().mockReturnValue({ success: true });
+    const ctx = makeCtx({ dispatchCommandBatch: batch });
+
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Deco', role: 'decoration' },
+      scene: 'S1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(true);
+    expect(batch).toHaveBeenCalledWith([
+      { command: 'switch_scene', payload: { sceneId: 'S1' } },
+      { command: 'spawn_entity', payload: { entityType: 'cube', name: 'Deco' } },
+    ]);
+    expect(ctx.dispatchCommand).not.toHaveBeenCalled();
+  });
+
+  it('returns failure when batch command fails', async () => {
+    const batch = vi.fn().mockReturnValue({ success: false });
+    const ctx = makeCtx({ dispatchCommandBatch: batch });
+
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'NPC', role: 'npc' },
+      scene: 'S1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('COMMAND_FAILED');
+  });
+
+  it('rejects missing entity name', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: '', role: 'player' },
+      scene: 'S1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects invalid role', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Test', role: 'boss' },
+      scene: 'S1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects missing scene', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Test', role: 'player' },
+      scene: '',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('rejects missing projectType', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'Test', role: 'player' },
+      scene: 'S1',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+
+  it('handles all role-to-entity-type mappings', async () => {
+    const mappings: Record<string, string> = {
+      player: 'capsule',
+      enemy: 'cube',
+      npc: 'cube',
+      decoration: 'cube',
+      trigger: 'cube',
+      interactable: 'cube',
+      projectile: 'sphere',
+    };
+
+    for (const [role, expectedType] of Object.entries(mappings)) {
+      const ctx = makeCtx();
+      const result = await entitySetupExecutor.execute({
+        entity: { name: `${role}_entity`, role },
+        scene: 'S1',
+        projectType: '3d',
+      }, ctx);
+
+      expect(result.success).toBe(true);
+      expect(result.output?.entityType).toBe(expectedType);
+    }
+  });
+
+  it('clamps entity name to 200 characters', async () => {
+    const ctx = makeCtx();
+    const result = await entitySetupExecutor.execute({
+      entity: { name: 'A'.repeat(201), role: 'player' },
+      scene: 'S1',
+      projectType: '3d',
+    }, ctx);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_INPUT');
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/index.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { EXECUTOR_REGISTRY, registerExecutor } from '../index';
+
+describe('EXECUTOR_REGISTRY', () => {
+  it('contains all 9 built-in executors', () => {
+    const expected = [
+      'plan_present',
+      'scene_create',
+      'physics_profile',
+      'character_setup',
+      'entity_setup',
+      'asset_generate',
+      'custom_script_generate',
+      'verify_all_scenes',
+      'auto_polish',
+    ];
+
+    for (const name of expected) {
+      expect(EXECUTOR_REGISTRY.has(name as never)).toBe(true);
+    }
+    expect(EXECUTOR_REGISTRY.size).toBe(9);
+  });
+
+  it('each executor has name, inputSchema, execute, and userFacingErrorMessage', () => {
+    for (const [name, def] of EXECUTOR_REGISTRY) {
+      expect(def.name).toBe(name);
+      expect(def.inputSchema).toBeDefined();
+      expect(typeof def.execute).toBe('function');
+      expect(typeof def.userFacingErrorMessage).toBe('string');
+      expect(def.userFacingErrorMessage.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('registerExecutor', () => {
+  it('adds a custom executor to the registry', () => {
+    const testName = '_test_executor' as never;
+
+    registerExecutor({
+      name: testName,
+      inputSchema: {} as never,
+      execute: async () => ({ success: true }),
+      userFacingErrorMessage: 'Test failed.',
+    });
+
+    expect(EXECUTOR_REGISTRY.has(testName)).toBe(true);
+
+    // Clean up
+    EXECUTOR_REGISTRY.delete(testName);
+  });
+});

--- a/web/src/lib/game-creation/executors/__tests__/planPresentExecutor.test.ts
+++ b/web/src/lib/game-creation/executors/__tests__/planPresentExecutor.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { planPresentExecutor } from '../planPresentExecutor';
+
+describe('planPresentExecutor', () => {
+  it('has correct name and error message', () => {
+    expect(planPresentExecutor.name).toBe('plan_present');
+    expect(planPresentExecutor.userFacingErrorMessage).toContain('plan summary');
+  });
+
+  it('passes through valid plan summary data', async () => {
+    const input = {
+      sceneCount: 3,
+      systemCount: 7,
+      entityCount: 12,
+    };
+
+    const result = await planPresentExecutor.execute(input, {} as never);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.sceneCount).toBe(3);
+    expect(result.output?.systemCount).toBe(7);
+    expect(result.output?.entityCount).toBe(12);
+  });
+
+  it('preserves extra fields via passthrough', async () => {
+    const input = {
+      sceneCount: 1,
+      systemCount: 2,
+      entityCount: 5,
+      title: 'My Game',
+      estimatedTokens: 500,
+    };
+
+    const result = await planPresentExecutor.execute(input, {} as never);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.title).toBe('My Game');
+    expect(result.output?.estimatedTokens).toBe(500);
+  });
+
+  it('returns input as-is when validation fails', async () => {
+    const input = {
+      sceneCount: 'not a number',
+      systemCount: 2,
+      entityCount: 5,
+    };
+
+    const result = await planPresentExecutor.execute(input, {} as never);
+
+    // planPresentExecutor always returns success, even on invalid input
+    expect(result.success).toBe(true);
+    expect(result.output?.sceneCount).toBe('not a number');
+  });
+
+  it('handles empty input', async () => {
+    const result = await planPresentExecutor.execute({}, {} as never);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('handles zero counts', async () => {
+    const input = {
+      sceneCount: 0,
+      systemCount: 0,
+      entityCount: 0,
+    };
+
+    const result = await planPresentExecutor.execute(input, {} as never);
+
+    expect(result.success).toBe(true);
+    expect(result.output?.sceneCount).toBe(0);
+  });
+});

--- a/web/src/lib/game-creation/systems/__tests__/registry.test.ts
+++ b/web/src/lib/game-creation/systems/__tests__/registry.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { SYSTEM_REGISTRY, registerSystem } from '../index';
+import type { GameSystem, OrchestratorGDD } from '../../types';
+
+function makeSystem(overrides?: Partial<GameSystem>): GameSystem {
+  return {
+    category: 'movement',
+    type: 'platformer',
+    config: {},
+    priority: 'core',
+    dependsOn: [],
+    ...overrides,
+  };
+}
+
+function makeGDD(overrides?: Partial<OrchestratorGDD>): OrchestratorGDD {
+  return {
+    id: 'gdd_1',
+    title: 'Test Game',
+    description: 'A test game',
+    systems: [],
+    scenes: [],
+    assetManifest: [],
+    estimatedScope: 'small' as never,
+    styleDirective: 'pixel-art',
+    feelDirective: {
+      mood: 'fun',
+      pacing: 'medium',
+      weight: 'medium',
+      referenceGames: [],
+      oneLiner: 'A fun game',
+    },
+    constraints: [],
+    projectType: '3d',
+    ...overrides,
+  };
+}
+
+describe('SYSTEM_REGISTRY', () => {
+  it('has movement system registered', () => {
+    expect(SYSTEM_REGISTRY.has('movement')).toBe(true);
+  });
+
+  it('has camera system registered', () => {
+    expect(SYSTEM_REGISTRY.has('camera')).toBe(true);
+  });
+
+  it('has world system registered', () => {
+    expect(SYSTEM_REGISTRY.has('world')).toBe(true);
+  });
+
+  it('does not have entities system registered (handled by planBuilder)', () => {
+    expect(SYSTEM_REGISTRY.has('entities')).toBe(false);
+  });
+});
+
+describe('movement system', () => {
+  it('produces physics_profile and character_setup steps', () => {
+    const def = SYSTEM_REGISTRY.get('movement')!;
+    const system = makeSystem({ type: 'topdown', config: { speed: 5 } });
+    const gdd = makeGDD();
+
+    const steps = def.setupSteps(system, gdd);
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0].executor).toBe('physics_profile');
+    expect(steps[0].input).toEqual({ config: { speed: 5 }, systemType: 'topdown' });
+    expect(steps[1].executor).toBe('character_setup');
+    expect(steps[1].input).toEqual({ movementType: 'topdown', systemConfig: { speed: 5 } });
+  });
+});
+
+describe('camera system', () => {
+  it('produces scene_create step with camera config', () => {
+    const def = SYSTEM_REGISTRY.get('camera')!;
+    const system = makeSystem({ category: 'camera', type: 'follow', config: { smoothing: 0.8 } });
+    const gdd = makeGDD();
+
+    const steps = def.setupSteps(system, gdd);
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].executor).toBe('scene_create');
+    expect(steps[0].input).toEqual({ cameraMode: 'follow', cameraConfig: { smoothing: 0.8 } });
+  });
+});
+
+describe('world system', () => {
+  it('produces scene_create step with world config', () => {
+    const def = SYSTEM_REGISTRY.get('world')!;
+    const system = makeSystem({ category: 'world', type: 'procedural', config: { biome: 'forest' } });
+    const gdd = makeGDD();
+
+    const steps = def.setupSteps(system, gdd);
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0].executor).toBe('scene_create');
+    expect(steps[0].input).toEqual({ worldType: 'procedural', worldConfig: { biome: 'forest' } });
+  });
+});
+
+describe('registerSystem', () => {
+  it('adds a new system to the registry', () => {
+    const testCategory = `_test_${Date.now()}`;
+
+    registerSystem({
+      category: testCategory,
+      setupSteps: () => [{ executor: 'verify_all_scenes', input: {} }],
+    });
+
+    expect(SYSTEM_REGISTRY.has(testCategory)).toBe(true);
+    const def = SYSTEM_REGISTRY.get(testCategory)!;
+    const steps = def.setupSteps(makeSystem(), makeGDD());
+    expect(steps[0].executor).toBe('verify_all_scenes');
+
+    // Clean up
+    SYSTEM_REGISTRY.delete(testCategory);
+  });
+
+  it('overwrites existing system definition', () => {
+    const testCategory = `_test_overwrite_${Date.now()}`;
+
+    registerSystem({
+      category: testCategory,
+      setupSteps: () => [{ executor: 'plan_present', input: {} }],
+    });
+
+    registerSystem({
+      category: testCategory,
+      setupSteps: () => [{ executor: 'auto_polish', input: {} }],
+    });
+
+    const def = SYSTEM_REGISTRY.get(testCategory)!;
+    const steps = def.setupSteps(makeSystem(), makeGDD());
+    expect(steps[0].executor).toBe('auto_polish');
+
+    SYSTEM_REGISTRY.delete(testCategory);
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive tests for 5 game-creation executors: entitySetupExecutor, characterSetupExecutor, assetGenerateExecutor, autoPolishExecutor, planPresentExecutor (55 tests)
- Add tests for SYSTEM_REGISTRY (movement, camera, world) and EXECUTOR_REGISTRY (9 executors) (12 tests)
- Covers validation, command dispatch, batch handling, scene graph lookup, fallback logic, and edge cases

Closes #8258

## Test plan
- [x] All 67 new tests pass locally
- [x] Full game-creation module suite passes (264 tests across 17 files)
- [x] ESLint clean (zero warnings)
- [x] TypeScript clean (tsc --noEmit)