### PR TITLE
fix: correct 27 changeset package names to unblock Release workflow

### DIFF
--- a/.changeset/accessibility-keybinding-cleanup.md
+++ b/.changeset/accessibility-keybinding-cleanup.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Fix AccessibilityPanel keybinding cleanup to use ref-based tracking instead of closure values, ensuring stale bindings are always removed when profiles are regenerated

--- a/.changeset/api-contract-tests.md
+++ b/.changeset/api-contract-tests.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add OpenAPI schema validation and auth-gated route contract tests to API test suite (35 total tests)

--- a/.changeset/api-route-test-coverage.md
+++ b/.changeset/api-route-test-coverage.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add test coverage for vitals and capabilities API routes (20 tests)

--- a/.changeset/chatstore-debounce-save.md
+++ b/.changeset/chatstore-debounce-save.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Debounce chatStore.saveConversation localStorage writes to prevent main thread blocking during streaming

--- a/.changeset/dep-upgrades-egui-react.md
+++ b/.changeset/dep-upgrades-egui-react.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Upgrade egui ecosystem 0.33→0.34 in transform-gizmo fork, bump portless 0.9→0.10, React 19.2.4→19.2.5

--- a/.changeset/e2-community-viral-growth.md
+++ b/.changeset/e2-community-viral-growth.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": minor
+"web": minor
 ---
 
 Add community & viral growth features (E2): dynamic OG images for published games, social sharing buttons (X, Reddit, copy link), "Made with SpawnForge" branding in exported games, and "Remix this game" button with auth gate.

--- a/.changeset/e2e-timeout-constants.md
+++ b/.changeset/e2e-timeout-constants.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Replace all inline timeout literals across 11 E2E files with named constants from e2e/constants.ts

--- a/.changeset/executor-coverage.md
+++ b/.changeset/executor-coverage.md
@@ -1,5 +1,5 @@
 ---
-"@spawnforge/web": patch
+"web": patch
 ---
 
 Add test coverage for 5 game-creation executors and system registry (67 tests)

--- a/.changeset/handler-coverage-2.md
+++ b/.changeset/handler-coverage-2.md
@@ -1,5 +1,5 @@
 ---
-"@spawnforge/web": patch
+"web": patch
 ---
 
 Add test coverage for asset handlers, security handlers, and safeLocalStorage (29 tests)

--- a/.changeset/handler-executor-test-coverage.md
+++ b/.changeset/handler-executor-test-coverage.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add test coverage for 5 previously untested modules: leaderboard, performance, and export chat handlers plus verify and physics profile game-creation executors (75 tests)

--- a/.changeset/inspector-touch-targets.md
+++ b/.changeset/inspector-touch-targets.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': patch
+'web': patch
 ---
 
 Inspector transform buttons now meet WCAG AA 44px minimum touch target size on mobile

--- a/.changeset/load-testing-scripts.md
+++ b/.changeset/load-testing-scripts.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge-web": patch
+"web": patch
 ---
 
 Add k6 load test scripts for chat API, generation routes, and Stripe webhook storm

--- a/.changeset/loop-guards-acorn-tokenizer.md
+++ b/.changeset/loop-guards-acorn-tokenizer.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': patch
+'web': patch
 ---
 
 Loop guard injection now uses acorn tokenizer for accurate keyword detection in template literals

--- a/.changeset/negative-test-suite.md
+++ b/.changeset/negative-test-suite.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge-web": patch
+"web": patch
 ---
 
 Add comprehensive negative/error case test suite for 4 API routes (52 tests)

--- a/.changeset/orbit-camera-keyboard.md
+++ b/.changeset/orbit-camera-keyboard.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add `orbit_camera` engine command and Arrow-key / `=` / `-` viewport navigation. Keyboard-only users can now orbit and zoom the editor camera without a mouse.

--- a/.changeset/pf-686-auth-edge-cases.md
+++ b/.changeset/pf-686-auth-edge-cases.md
@@ -1,5 +1,5 @@
 ---
-'@spawnforge/web': patch
+'web': patch
 ---
 
 fix(auth): catch Clerk token throws and enforce banned flag

--- a/.changeset/pf-8341-chat-integration-broad.md
+++ b/.changeset/pf-8341-chat-integration-broad.md
@@ -1,5 +1,5 @@
 ---
-'@spawnforge/web': patch
+'web': patch
 ---
 
 test(chat): broaden chat executor integration coverage to all 29 handler domains

--- a/.changeset/rate-limiter-lua-atomic.md
+++ b/.changeset/rate-limiter-lua-atomic.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Replace pipeline+ZREM with atomic Lua EVAL in distributed rate limiter to eliminate phantom entries on deny cleanup failures

--- a/.changeset/s1-test-coverage-batch-1.md
+++ b/.changeset/s1-test-coverage-batch-1.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Expand SceneHierarchy and PlayControls test suites with 35 new tests covering drag-drop, keyboard navigation, context menu, filtering, lifecycle flows, stop validation, and edge cases

--- a/.changeset/server-analytics-tests.md
+++ b/.changeset/server-analytics-tests.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add unit tests for server-side analytics event wrappers (events.server.ts)

--- a/.changeset/streaming-r2-upload.md
+++ b/.changeset/streaming-r2-upload.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': patch
+'web': patch
 ---
 
 Asset uploads now stream directly to R2 instead of buffering up to 100MB in memory

--- a/.changeset/stripe-v22-audit.md
+++ b/.changeset/stripe-v22-audit.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': patch
+'web': patch
 ---
 
 Add Stripe v21/v22 upgrade audit document with migration checklist and breaking change analysis.

--- a/.changeset/stripe-v22-upgrade.md
+++ b/.changeset/stripe-v22-upgrade.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': patch
+'web': patch
 ---
 
 Upgrade Stripe SDK from 20.4.1 to 22.0.1 with API version 2026-03-25.dahlia. No code changes required — all monetary amounts already use integer cents, no decimal_string fields accessed.

--- a/.changeset/taskboard-sync-portless.md
+++ b/.changeset/taskboard-sync-portless.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Fix GitHub project sync hook: route all taskboard traffic through Portless HTTPS (urllib's 302 downgrade was silently turning POST into GET), accept legacy project IDs in the import filter, and fall back to the configured team when a parsed `teamId` points at a stale team.

--- a/.changeset/vi-reset-modules-test-isolation.md
+++ b/.changeset/vi-reset-modules-test-isolation.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": patch
+"web": patch
 ---
 
 Add vi.resetModules() to 81 test files using dynamic imports to prevent module cache contamination between tests

--- a/.changeset/wasm-cdn-version-integrity.md
+++ b/.changeset/wasm-cdn-version-integrity.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge-web": patch
+"web": patch
 ---
 
 Add WASM manifest version integrity checking between JS glue and WASM binary, populate same-origin fallback in CD pipeline, and add Sentry breadcrumbs for CDN fallback monitoring.

--- a/.changeset/wasm-command-batching.md
+++ b/.changeset/wasm-command-batching.md
@@ -1,5 +1,5 @@
 ---
-'spawnforge': minor
+'web': minor
 ---
 
 Expose WASM command batching to JS: `sendCommandBatch` on useEngine hook, `dispatchCommandBatch` on store/context interfaces. Migrated entitySetupExecutor and autoPolishExecutor to batch dispatch with sequential fallback.


### PR DESCRIPTION
## Summary
- Fix 27 changeset files that referenced invalid package names (`"spawnforge"`, `"@spawnforge/web"`, `"spawnforge-web"`)
- All corrected to `"web"` which is the actual workspace package name in `web/package.json`
- `npx changeset status` now resolves cleanly — Release workflow unblocked

Closes #8396

## Test plan
- [x] `npx changeset status` runs without errors
- [x] ESLint passes
- [x] tsc passes
- [x] No remaining invalid package name references in `.changeset/*.md`