### PR TITLE
fix: add /api/health and /api/status to proxy public routes

### DIFF
--- a/.changeset/fix-health-api-proxy.md
+++ b/.changeset/fix-health-api-proxy.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix /api/health and /api/status returning 404 in production by adding them to the Clerk proxy public routes list

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for proxy.ts — public route configuration.
+ *
+ * Verifies that unauthenticated routes (health, status, webhooks, etc.)
+ * are included in the public routes list so Clerk auth doesn't block them.
+ *
+ * proxy.ts uses dynamic require() for Clerk at module scope, making it
+ * difficult to mock. We validate the route configuration by reading the
+ * source file and checking for the expected route patterns.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const proxySource = fs.readFileSync(
+  path.resolve(__dirname, '../proxy.ts'),
+  'utf-8',
+);
+
+describe('proxy public route configuration', () => {
+  it('includes /api/health in public routes', () => {
+    expect(proxySource).toContain('/api/health');
+  });
+
+  it('includes /api/status in public routes', () => {
+    expect(proxySource).toContain('/api/status');
+  });
+
+  it('includes webhook routes in public routes', () => {
+    expect(proxySource).toContain('/api/auth/webhook');
+    expect(proxySource).toContain('/api/stripe/webhook');
+  });
+
+  it('includes sign-in and sign-up in public routes', () => {
+    expect(proxySource).toContain('/sign-in');
+    expect(proxySource).toContain('/sign-up');
+  });
+
+  it('includes community routes in public routes', () => {
+    expect(proxySource).toContain('/api/community');
+  });
+
+  it('does not expose /api/generate as a public route', () => {
+    // Generate endpoints require authentication — they should NOT be in publicRoutes
+    expect(proxySource).not.toMatch(/['"]\/api\/generate/);
+  });
+});

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -125,6 +125,8 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     '/api/docs(.*)',
     '/api-docs(.*)',
     '/api/openapi(.*)',
+    '/api/health(.*)',
+    '/api/status(.*)',
     '/api/sentry(.*)',
     '/monitoring(.*)',
   ];


### PR DESCRIPTION
## Summary
- Add `/api/health(.*)` and `/api/status(.*)` to the Clerk proxy public routes list
- Both endpoints are designed as unauthenticated health check endpoints but were missing from `publicRoutes` in `proxy.ts`
- In production, Clerk's `auth.protect()` intercepted these requests and returned 404 (`x-matched-path: /404`)
- Add proxy configuration test to prevent regression (6 assertions)

Closes #8397

## Test plan
- [x] New proxy.test.ts verifies both routes are in public routes config (6 tests pass)
- [x] Existing health route tests pass (58 tests)
- [x] ESLint zero warnings
- [x] TypeScript clean