### PR TITLE
fix: stabilize flaky exportAbortSignal test

### DIFF
--- a/.changeset/fix-flaky-export-abort-test.md
+++ b/.changeset/fix-flaky-export-abort-test.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix flaky exportAbortSignal test that intermittently reported unhandled rejection errors in CI by attaching promise rejection handlers before advancing fake timers

--- a/web/src/lib/export/__tests__/exportAbortSignal.test.ts
+++ b/web/src/lib/export/__tests__/exportAbortSignal.test.ts
@@ -91,12 +91,19 @@ describe('exportGame AbortSignal', () => {
         signal: controller.signal,
       });
 
+      // Attach rejection handler BEFORE advancing timers to prevent
+      // unhandled rejection when the abort fires during advanceTimersByTimeAsync.
+      const rejection = result.catch((err: Error) => err);
+
       // Abort after 100ms — well before the 5s timeout
       await vi.advanceTimersByTimeAsync(100);
       controller.abort();
 
-      // Should reject with AbortError, not wait for the 5s timeout
-      await expect(result).rejects.toThrow('Export cancelled');
+      const err = await rejection;
+      expect(err).toBeInstanceOf(DOMException);
+      expect(err.message).toBe('Export cancelled');
+
+      vi.clearAllTimers();
     } finally {
       vi.useRealTimers();
     }
@@ -116,12 +123,18 @@ describe('exportGame AbortSignal', () => {
         includeDebug: false,
       });
 
-      // Advance past the 5s scene data timeout
+      // Attach rejection handler BEFORE advancing timers to prevent
+      // unhandled rejection when the 5s engine timeout fires.
+      const settledPromise = result.then(() => 'resolved').catch(() => 'rejected');
+
+      // Advance past the 5s scene data timeout so getSceneData rejects
       await vi.advanceTimersByTimeAsync(6000);
 
-      // Export will reject (empty WASM) or resolve — either way, no TypeError from missing signal
-      const settled = await result.then(() => 'resolved').catch(() => 'rejected');
+      // Export will reject (engine timeout, no WASM) — either way, no TypeError from missing signal
+      const settled = await settledPromise;
       expect(['resolved', 'rejected']).toContain(settled);
+
+      vi.clearAllTimers();
     } finally {
       vi.useRealTimers();
     }

--- a/web/src/lib/export/__tests__/exportAbortSignal.test.ts
+++ b/web/src/lib/export/__tests__/exportAbortSignal.test.ts
@@ -93,7 +93,10 @@ describe('exportGame AbortSignal', () => {
 
       // Attach rejection handler BEFORE advancing timers to prevent
       // unhandled rejection when the abort fires during advanceTimersByTimeAsync.
-      const rejection = result.catch((err: Error) => err);
+      const rejection = result.then(
+        () => { throw new Error('Should have rejected'); },
+        (err: unknown) => err as DOMException,
+      );
 
       // Abort after 100ms — well before the 5s timeout
       await vi.advanceTimersByTimeAsync(100);


### PR DESCRIPTION
## Summary
- Fix flaky `exportAbortSignal.test.ts` that intermittently reported 1 error in CI despite all tests passing
- Root cause: promise rejection handlers were attached AFTER `vi.advanceTimersByTimeAsync()`, which could fire timer callbacks (rejecting the export promise) before `.catch()` was wired up — causing an unhandled rejection
- Fix: attach `.catch()` synchronously before advancing fake timers, add `vi.clearAllTimers()` before restoring real timers
- Verified stable across 3+ consecutive runs locally

Closes #8400

## Test plan
- [x] All 4 export abort signal tests pass
- [x] No unhandled rejection errors
- [x] Stable across 3 consecutive runs
- [x] ESLint zero warnings