### PR TITLE
docs: update stale skill reference data and dependency versions

### DIFF
--- a/.claude/skills/changelog-review/SKILL.md
+++ b/.claude/skills/changelog-review/SKILL.md
@@ -21,8 +21,8 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 | System | Changelog Source | Current Version |
 |--------|-----------------|-----------------|
 | Vercel Platform | https://vercel.com/changelog | N/A (platform) |
-| Sentry | https://github.com/getsentry/sentry-javascript/releases | @sentry/nextjs ^10.45.0 |
-| PostHog | https://github.com/PostHog/posthog-js/releases | posthog-js ^1.363.3 |
+| Sentry | https://github.com/getsentry/sentry-javascript/releases | @sentry/nextjs ^10.48.0 |
+| PostHog | https://github.com/PostHog/posthog-js/releases | posthog-js ^1.367.0 |
 | Anthropic (Claude API) | https://docs.anthropic.com/en/docs/about-claude/models | AI SDK provider |
 | Cloudflare | https://developers.cloudflare.com/changelog/ | R2 + Workers |
 | Upstash | https://github.com/upstash/redis-js/releases | @upstash/redis ^1.37.0 |
@@ -34,11 +34,11 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 
 | Library | Changelog Source | Current Version |
 |---------|-----------------|-----------------|
-| Next.js | https://github.com/vercel/next.js/releases | 16.2.1 |
-| Clerk | https://github.com/clerk/javascript/releases | @clerk/nextjs ^7.0.7 |
-| Stripe | https://github.com/stripe/stripe-node/releases | stripe ^20.4.1 |
-| AI SDK | https://github.com/vercel/ai/releases | ai ^6.0.134 |
-| Drizzle ORM | https://github.com/drizzle-team/drizzle-orm/releases | drizzle-orm ^0.45.1 |
+| Next.js | https://github.com/vercel/next.js/releases | ^16.2.3 |
+| Clerk | https://github.com/clerk/javascript/releases | @clerk/nextjs ^7.0.12 |
+| Stripe | https://github.com/stripe/stripe-node/releases | stripe ^22.0.1 |
+| AI SDK | https://github.com/vercel/ai/releases | ai ^6.0.158 |
+| Drizzle ORM | https://github.com/drizzle-team/drizzle-orm/releases | drizzle-orm 0.45.2 |
 | Neon Serverless | https://github.com/neondatabase/serverless/releases | @neondatabase/serverless ^1.0.2 |
 | Zod | https://github.com/colinhacks/zod/releases | zod ^4.3.6 |
 | Zustand | https://github.com/pmndrs/zustand/releases | zustand ^5.0.12 |
@@ -48,8 +48,8 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 | Library | Changelog Source | Current Version |
 |---------|-----------------|-----------------|
 | TypeScript | https://github.com/microsoft/TypeScript/releases | typescript ^6 |
-| Vitest | https://github.com/vitest-dev/vitest/releases | vitest 4.1.1 |
-| Playwright | https://github.com/microsoft/playwright/releases | @playwright/test ^1.58.2 |
+| Vitest | https://github.com/vitest-dev/vitest/releases | vitest ^4.1.4 |
+| Playwright | https://github.com/microsoft/playwright/releases | @playwright/test ^1.59.1 |
 | ESLint | https://github.com/eslint/eslint/releases | eslint ^9 |
 | Tailwind CSS | https://github.com/tailwindlabs/tailwindcss/releases | tailwindcss ^4 |
 | Turborepo | https://github.com/vercel/turborepo/releases | turbo ^2.5.4 |

--- a/.claude/skills/changelog-review/references/version-pins.md
+++ b/.claude/skills/changelog-review/references/version-pins.md
@@ -86,9 +86,9 @@ Documenting why specific dependencies are pinned and what must be audited before
 | `wasm-bindgen` | =0.2.108 | HIGH (CLI must match) | Only upgrade as a coordinated Rust+CLI change |
 | `next` | 16.x | MEDIUM | Check migration guide, test E2E |
 | `bevy` | 0.18 | HIGH (API churn) | Only on planned engine upgrade sprint |
-| `@clerk/nextjs` | ^7.0.7 | LOW-MEDIUM | Check for auth() API changes |
-| `drizzle-orm` | ^0.45.1 | LOW | Check migration query syntax |
-| `vitest` | 4.1.1 | LOW | Check for workspace config changes |
+| `@clerk/nextjs` | ^7.0.12 | LOW-MEDIUM | Check for auth() API changes |
+| `drizzle-orm` | 0.45.2 | LOW | Check migration query syntax |
+| `vitest` | ^4.1.4 | LOW | Check for workspace config changes |
 | `zod` | ^4.3.6 | LOW | Already on v4 |
 
 ---

--- a/.claude/skills/claude-platform-reference/SKILL.md
+++ b/.claude/skills/claude-platform-reference/SKILL.md
@@ -5,32 +5,34 @@ description: "Use when you need details about SpawnForge's Claude Code platform 
 
 # Claude Code Platform Reference
 
-## Skills (~28 custom + 19 marketplace)
+## Skills (53 total)
 
 **Orchestration:** `/planner`, `/builder`, `/cycle`
 **Engine:** `/rust-engine`, `/build`, `/arch-validator`, `/rust-best-practices`
 **Web:** `/frontend`, `/mcp-commands`, `/web-accessibility`, `/shadcn`, `/vercel-react-best-practices`, `/vercel-composition-patterns`, `/vercel-react-view-transitions`
 **Next.js:** `/next-best-practices`, `/next-cache-components`, `/next-upgrade`
 **Testing:** `/testing`, `/playwright-best-practices`, `/tdd`
-**Infrastructure:** `/infra-services`, `/troubleshoot`, `/kanban`, `/babysit-prs`, `/pr-code-review`, `/pr-green-machine`, `/env-health-check`, `/changelog-review`, `/deploy-to-vercel`, `/resolve-pr-comments`, `/api-middleware-migrate`
-**Database:** `/db-migrate`, `/neon-postgres`, `/claimable-postgres`
+**Infrastructure:** `/infra-services`, `/troubleshoot`, `/kanban`, `/babysit-prs`, `/pr-code-review`, `/pr-green-machine`, `/env-health-check`, `/changelog-review`, `/deploy-to-vercel`, `/resolve-pr-comments`, `/resolve-all-pr-comments`, `/api-middleware-migrate`, `/autonomous-sprint`
+**Database:** `/db-migrate`, `/neon-postgres`, `/claimable-postgres`, `/neon-postgres-egress-optimizer`
 **Deployment:** `/deploy-engine` (user-only)
-**Billing:** `stripe-webhooks` (background, auto-loads on billing edits)
-**Features:** `/game-engine`, `/multiplayer-readiness`, `/viewport`
+**Billing:** `/stripe-webhooks` (background, auto-loads on billing edits)
+**Features:** `/game-engine`, `/game-ui-design`, `/multiplayer-readiness`, `/viewport`
 **Workflow:** `/design`, `/architect-flow`, `/docs`, `/developer-experience`
 **Review:** `/review-protocol`, `/component-checklist`
+**Vercel:** `/vercel-cli-with-tokens`, `/vercel-react-native-skills`
 
-Marketplace skills live in `.agents/skills/` with symlinks in `.claude/skills/`. Managed via `npx skills add/ls/update`.
-
-## MCP Servers (`.mcp.json` — 4 servers)
+## MCP Servers (`.mcp.json` — 7 servers)
 - `context7` — live library documentation for all 30+ dependencies
 - `neon` — direct Neon Postgres queries (needs `NEON_API_KEY`)
 - `playwright` — browser automation for E2E verification
 - `github` — GitHub API access for PR/issue/Actions operations
+- `sentry` — error tracking, issue search, event analysis
+- `stripe` — payment processing, webhook debugging, test cards
+- `upstash` — Redis cache operations and rate limiting
 
-## Hooks (`.claude/hooks/` — 40+ scripts, 18 event types)
+## Hooks (`.claude/hooks/` — 52 scripts, 20 event types)
 
-**Event types:** PreToolUse, PostToolUse, SessionStart, SessionEnd, UserPromptSubmit, Stop, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, TeammateIdle, PreCompact, PostCompact, StopFailure, ConfigChange, InstructionsLoaded, WorktreeCreate, CwdChanged, PostToolUseFailure
+**Event types:** PreToolUse, PostToolUse, SessionStart, SessionEnd, UserPromptSubmit, Stop, SubagentStart, SubagentStop, TaskCreated, TaskCompleted, TeammateIdle, PreCompact, PostCompact, StopFailure, ConfigChange, InstructionsLoaded, WorktreeCreate, CwdChanged, PostToolUseFailure, FileChanged
 
 | Hook | Event | Purpose |
 |------|-------|---------|


### PR DESCRIPTION
## Summary
- Sync changelog-review tracked versions to match installed packages (stripe ^22.0.1, next ^16.2.3, clerk ^7.0.12, ai ^6.0.158, drizzle 0.45.2, vitest ^4.1.4, playwright ^1.59.1, sentry ^10.48.0, posthog-js ^1.367.0)
- Update version-pins decision matrix with current versions
- Update claude-platform-reference: 53 skills, 7 MCP servers, 52 hook scripts, 20 event types

Closes #8399

## Test plan
- [ ] Verify changelog-review SKILL.md versions match `web/package.json`
- [ ] Verify version-pins.md decision matrix is consistent
- [ ] Verify claude-platform-reference counts match actual `.claude/` contents