### PR TITLE
perf: migrate MCP tool registration to registerTool API with annotations

### DIFF
--- a/.changeset/mcp-tool-annotations.md
+++ b/.changeset/mcp-tool-annotations.md
@@ -1,0 +1,5 @@
+---
+"@spawnforge/mcp-server": patch
+---
+
+Migrate MCP tool registration to non-deprecated registerTool API with ToolAnnotations for better tool discovery

--- a/mcp-server/src/tools/generated.test.ts
+++ b/mcp-server/src/tools/generated.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { jsonSchemaToZod, buildZodSchema, deriveAnnotations } from './generated.js';
+import { z } from 'zod';
+
+describe('jsonSchemaToZod', () => {
+  it('converts string type', () => {
+    const schema = jsonSchemaToZod({ type: 'string' });
+    expect(schema.parse('hello')).toBe('hello');
+    expect(() => schema.parse(123)).toThrow();
+  });
+
+  it('converts string enum', () => {
+    const schema = jsonSchemaToZod({ type: 'string', enum: ['a', 'b', 'c'] });
+    expect(schema.parse('a')).toBe('a');
+    expect(() => schema.parse('d')).toThrow();
+  });
+
+  it('converts number type', () => {
+    const schema = jsonSchemaToZod({ type: 'number' });
+    expect(schema.parse(3.14)).toBe(3.14);
+    expect(() => schema.parse('abc')).toThrow();
+  });
+
+  it('converts integer type', () => {
+    const schema = jsonSchemaToZod({ type: 'integer' });
+    expect(schema.parse(42)).toBe(42);
+    expect(() => schema.parse(3.14)).toThrow();
+  });
+
+  it('converts boolean type', () => {
+    const schema = jsonSchemaToZod({ type: 'boolean' });
+    expect(schema.parse(true)).toBe(true);
+    expect(() => schema.parse('yes')).toThrow();
+  });
+
+  it('converts array type with items', () => {
+    const schema = jsonSchemaToZod({ type: 'array', items: { type: 'number' } });
+    expect(schema.parse([1, 2, 3])).toEqual([1, 2, 3]);
+    expect(() => schema.parse(['a'])).toThrow();
+  });
+
+  it('converts array type without items', () => {
+    const schema = jsonSchemaToZod({ type: 'array' });
+    expect(schema.parse([1, 'a', true])).toEqual([1, 'a', true]);
+  });
+
+  it('converts object type', () => {
+    const schema = jsonSchemaToZod({ type: 'object' });
+    expect(schema.parse({ foo: 'bar' })).toEqual({ foo: 'bar' });
+  });
+
+  it('returns unknown for unrecognized types', () => {
+    const schema = jsonSchemaToZod({ type: 'custom' });
+    expect(schema.parse('anything')).toBe('anything');
+  });
+});
+
+describe('buildZodSchema', () => {
+  it('builds shape with required and optional fields', () => {
+    const shape = buildZodSchema({
+      properties: {
+        name: { type: 'string', description: 'Entity name' },
+        x: { type: 'number' },
+        y: { type: 'number' },
+        visible: { type: 'boolean' },
+      },
+      required: ['name'],
+    });
+
+    expect(Object.keys(shape)).toEqual(['name', 'x', 'y', 'visible']);
+
+    // Required field
+    const nameSchema = z.object({ name: shape.name });
+    expect(nameSchema.parse({ name: 'test' })).toEqual({ name: 'test' });
+    expect(() => nameSchema.parse({})).toThrow();
+
+    // Optional fields
+    const optSchema = z.object({ x: shape.x });
+    expect(optSchema.parse({})).toEqual({});
+    expect(optSchema.parse({ x: 5 })).toEqual({ x: 5 });
+  });
+
+  it('handles empty properties', () => {
+    const shape = buildZodSchema({ properties: {}, required: [] });
+    expect(Object.keys(shape)).toEqual([]);
+  });
+
+  it('handles missing properties and required', () => {
+    const shape = buildZodSchema({});
+    expect(Object.keys(shape)).toEqual([]);
+  });
+
+  it('preserves descriptions', () => {
+    const shape = buildZodSchema({
+      properties: {
+        name: { type: 'string', description: 'The entity name' },
+      },
+      required: ['name'],
+    });
+    expect(shape.name.description).toBe('The entity name');
+  });
+});
+
+describe('deriveAnnotations', () => {
+  it('marks read scopes as readOnly', () => {
+    const ann = deriveAnnotations('scene:read', 'get_scene_graph');
+    expect(ann.readOnlyHint).toBe(true);
+    expect(ann.destructiveHint).toBe(false);
+  });
+
+  it('marks write scopes as not readOnly', () => {
+    const ann = deriveAnnotations('scene:write', 'update_transform');
+    expect(ann.readOnlyHint).toBe(false);
+    expect(ann.destructiveHint).toBe(false);
+  });
+
+  it('marks despawn commands as destructive', () => {
+    const ann = deriveAnnotations('scene:write', 'despawn_entity');
+    expect(ann.destructiveHint).toBe(true);
+  });
+
+  it('marks delete commands as destructive', () => {
+    const ann = deriveAnnotations('scene:write', 'delete_audio_bus');
+    expect(ann.destructiveHint).toBe(true);
+  });
+
+  it('marks remove commands as destructive', () => {
+    const ann = deriveAnnotations('scene:write', 'remove_script');
+    expect(ann.destructiveHint).toBe(true);
+  });
+
+  it('marks clear_scene as destructive', () => {
+    const ann = deriveAnnotations('scene:write', 'clear_scene');
+    expect(ann.destructiveHint).toBe(true);
+  });
+
+  it('marks undo/redo as destructive', () => {
+    expect(deriveAnnotations('scene:write', 'undo').destructiveHint).toBe(true);
+    expect(deriveAnnotations('scene:write', 'redo').destructiveHint).toBe(true);
+  });
+
+  it('sets openWorldHint to false', () => {
+    const ann = deriveAnnotations('scene:write', 'spawn_entity');
+    expect(ann.openWorldHint).toBe(false);
+  });
+});

--- a/mcp-server/src/tools/generated.ts
+++ b/mcp-server/src/tools/generated.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import manifest from '../../manifest/commands.json' with { type: 'json' };
 import type { EditorBridge } from '../transport/websocket.js';
@@ -7,16 +8,15 @@ import type { EditorBridge } from '../transport/websocket.js';
  * Convert JSON Schema property to a Zod schema.
  * Handles the subset of JSON Schema used in our manifest.
  */
-function jsonSchemaToZod(prop: Record<string, unknown>): z.ZodTypeAny {
+export function jsonSchemaToZod(prop: Record<string, unknown>): z.ZodTypeAny {
   const type = prop.type as string;
 
   switch (type) {
     case 'string': {
-      let schema = z.string();
       if (prop.enum) {
         return z.enum(prop.enum as [string, ...string[]]);
       }
-      return schema;
+      return z.string();
     }
     case 'number':
       return z.number();
@@ -41,7 +41,7 @@ function jsonSchemaToZod(prop: Record<string, unknown>): z.ZodTypeAny {
 /**
  * Build a Zod object schema from JSON Schema properties definition.
  */
-function buildZodSchema(
+export function buildZodSchema(
   parameters: { properties?: Record<string, Record<string, unknown>>; required?: string[] }
 ): Record<string, z.ZodTypeAny> {
   const shape: Record<string, z.ZodTypeAny> = {};
@@ -53,7 +53,6 @@ function buildZodSchema(
     if (!required.has(key)) {
       fieldSchema = fieldSchema.optional();
     }
-    // Add description if available
     if (prop.description) {
       fieldSchema = fieldSchema.describe(prop.description as string);
     }
@@ -64,19 +63,54 @@ function buildZodSchema(
 }
 
 /**
+ * Derive MCP tool annotations from the command's requiredScope.
+ * Read-only scopes get readOnlyHint; write/manage scopes get destructiveHint
+ * for operations that modify or delete scene state.
+ */
+export function deriveAnnotations(
+  scope: string,
+  name: string,
+): ToolAnnotations {
+  const isRead = scope.endsWith(':read');
+  const isDestructive = name.startsWith('despawn_') ||
+    name.startsWith('delete_') ||
+    name.startsWith('remove_') ||
+    name === 'clear_scene' ||
+    name === 'undo' ||
+    name === 'redo';
+
+  return {
+    readOnlyHint: isRead,
+    destructiveHint: isDestructive,
+    openWorldHint: false,
+  };
+}
+
+/**
  * Register all commands from the manifest as MCP tools.
+ *
+ * Uses the registerTool API (non-deprecated) with annotations derived
+ * from each command's requiredScope for better tool discovery by LLM clients.
  */
 export function registerTools(server: McpServer, bridge: EditorBridge): void {
   for (const cmd of manifest.commands) {
-    const zodShape = buildZodSchema(cmd.parameters as unknown as {
+    const inputSchema = buildZodSchema(cmd.parameters as unknown as {
       properties?: Record<string, Record<string, unknown>>;
       required?: string[];
     });
 
-    server.tool(
+    const annotations = deriveAnnotations(
+      cmd.requiredScope,
       cmd.name,
-      cmd.description,
-      zodShape,
+    );
+
+    server.registerTool(
+      cmd.name,
+      {
+        description: cmd.description,
+        inputSchema,
+        annotations,
+      },
       async (args) => {
         try {
           const result = await bridge.executeCommand(cmd.name, args as Record<string, unknown>);
@@ -95,7 +129,7 @@ export function registerTools(server: McpServer, bridge: EditorBridge): void {
             isError: true,
           };
         }
-      }
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Migrate 350 MCP tool registrations from deprecated `server.tool()` to `server.registerTool()` API
- Derive `ToolAnnotations` from each command's `requiredScope` — read-only scopes get `readOnlyHint=true`, destructive commands (despawn, delete, remove, clear, undo, redo) get `destructiveHint=true`
- Export `jsonSchemaToZod`, `buildZodSchema`, and `deriveAnnotations` for testability
- Add 21 unit tests covering schema conversion, shape building, and annotation derivation

Closes #8225

## Test plan
- [x] All 421 MCP server tests pass (including 21 new)
- [x] ESLint clean (zero warnings)
- [x] TypeScript clean