### PR TITLE
feat: add AI response caching with prompt deduplication

### DIFF
--- a/.changeset/ai-response-cache.md
+++ b/.changeset/ai-response-cache.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add AI response caching layer with prompt deduplication. Identical generation requests (SFX, voice, localize) now return cached results instantly without deducting tokens. Uses Upstash Redis in production with in-memory LRU fallback for development.

--- a/web/src/app/api/generate/localize/route.test.ts
+++ b/web/src/app/api/generate/localize/route.test.ts
@@ -9,6 +9,7 @@ import { distributedRateLimit, aggregateGenerationRateLimit } from '@/lib/rateLi
 import { resolveApiKey } from '@/lib/keys/resolver';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { refundTokens } from '@/lib/tokens/service';
+import { _memoryCache, _inFlight } from '@/lib/api/responseCache';
 
 const mockGenerateText = vi.hoisted(() => vi.fn());
 const mockAnthropicModel = vi.hoisted(() => vi.fn(() => 'model-stub'));
@@ -74,6 +75,8 @@ describe('POST /api/generate/localize', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    _memoryCache.clear();
+    _inFlight.clear();
 
     vi.mocked(authenticateRequest).mockResolvedValue({
       ok: true,
@@ -285,9 +288,13 @@ describe('POST /api/generate/localize', () => {
     expect(refundTokens).not.toHaveBeenCalled();
   });
 
-  it('rethrows non-ApiKeyError during key resolution', async () => {
+  it('returns 500 for non-ApiKeyError during key resolution', async () => {
     vi.mocked(resolveApiKey).mockRejectedValue(new Error('DB connection failed'));
 
-    await expect(POST(makeRequest(validBody))).rejects.toThrow('DB connection failed');
+    const res = await POST(makeRequest(validBody));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('DB connection failed');
   });
 });

--- a/web/src/app/api/generate/localize/route.ts
+++ b/web/src/app/api/generate/localize/route.ts
@@ -110,6 +110,11 @@ export const POST = createGenerationHandler<
       },
     };
   },
+  cacheKeyParams: (params) => ({
+    strings: params.strings,
+    sourceLocale: params.sourceLocale,
+    targetLocales: params.targetLocales,
+  }),
   execute: async (params, apiKey) => {
     const anthropicProvider = createAnthropic({ apiKey });
     const result: Record<string, LocaleBundle> = {};

--- a/web/src/app/api/generate/sfx/__tests__/route.test.ts
+++ b/web/src/app/api/generate/sfx/__tests__/route.test.ts
@@ -223,13 +223,15 @@ describe('POST /api/generate/sfx', () => {
       expect(body.code).toBe('INSUFFICIENT_TOKENS');
     });
 
-    it('rethrows non-ApiKeyError exceptions', async () => {
+    it('returns 500 for non-ApiKeyError exceptions', async () => {
       vi.mocked(resolveApiKey).mockRejectedValue(new Error('DB error'));
 
       const { POST } = await import('../route');
-      await expect(
-        POST(makeRequest({ prompt: 'thunder', durationSeconds: 5 }))
-      ).rejects.toThrow('DB error');
+      const res = await POST(makeRequest({ prompt: 'thunder', durationSeconds: 5 }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('DB error');
     });
   });
 

--- a/web/src/app/api/generate/sfx/route.ts
+++ b/web/src/app/api/generate/sfx/route.ts
@@ -28,6 +28,10 @@ export const POST = createGenerationHandler<
 
     return { ok: true, params: { prompt: prompt as string, durationSeconds: durationSeconds as number } };
   },
+  cacheKeyParams: (params) => ({
+    prompt: params.prompt,
+    durationSeconds: params.durationSeconds,
+  }),
   execute: async (params, apiKey) => {
     const client = new ElevenLabsClient({ apiKey });
     const result = await client.generateSfx({

--- a/web/src/app/api/generate/voice/__tests__/route.test.ts
+++ b/web/src/app/api/generate/voice/__tests__/route.test.ts
@@ -302,11 +302,15 @@ describe('POST /api/generate/voice', () => {
       expect(body.code).toBe('TIER_NOT_ALLOWED');
     });
 
-    it('rethrows non-ApiKeyError exceptions', async () => {
+    it('returns 500 for non-ApiKeyError exceptions', async () => {
       vi.mocked(resolveApiKey).mockRejectedValue(new Error('Network failure'));
 
       const { POST } = await import('../route');
-      await expect(POST(makeRequest({ text: 'Hi' }))).rejects.toThrow('Network failure');
+      const res = await POST(makeRequest({ text: 'Hi' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Network failure');
     });
   });
 

--- a/web/src/app/api/generate/voice/route.test.ts
+++ b/web/src/app/api/generate/voice/route.test.ts
@@ -9,6 +9,7 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 import { rateLimit } from '@/lib/rateLimit';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { refundTokens } from '@/lib/tokens/service';
+import { _memoryCache, _inFlight } from '@/lib/api/responseCache';
 
 const mockGenerateVoice = vi.hoisted(() => vi.fn());
 
@@ -50,6 +51,8 @@ describe('POST /api/generate/voice', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    _memoryCache.clear();
+    _inFlight.clear();
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, remaining: 9, resetAt: Date.now() + 60000 });
   });
 

--- a/web/src/app/api/generate/voice/route.test.ts
+++ b/web/src/app/api/generate/voice/route.test.ts
@@ -159,12 +159,16 @@ describe('POST /api/generate/voice', () => {
     expect(captureException).toHaveBeenCalled();
   });
 
-  it('rethrows non-ApiKeyError during key resolution', async () => {
+  it('returns 500 for non-ApiKeyError during key resolution', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
     vi.mocked(resolveApiKey).mockRejectedValue(new Error('DB connection failed'));
 
-    await expect(POST(makeRequest({ text: 'Hello world' }))).rejects.toThrow('DB connection failed');
+    const res = await POST(makeRequest({ text: 'Hello world' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('DB connection failed');
   });
 
   it('returns 422 when sanitizePrompt returns safe:false', async () => {

--- a/web/src/app/api/generate/voice/route.ts
+++ b/web/src/app/api/generate/voice/route.ts
@@ -87,6 +87,13 @@ export const POST = createGenerationHandler<
       },
     };
   },
+  cacheKeyParams: (params) => ({
+    text: params.text,
+    voiceId: params.voiceId,
+    stability: params.stability,
+    similarityBoost: params.similarityBoost,
+    style: params.style,
+  }),
   execute: async (params, apiKey) => {
     const client = new ElevenLabsClient({ apiKey });
     const result = await client.generateVoice({

--- a/web/src/lib/api/__tests__/responseCache.test.ts
+++ b/web/src/lib/api/__tests__/responseCache.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  cachedGenerate,
+  getCachedResult,
+  invalidateCache,
+  getCacheStats,
+  _generateCacheKey,
+  _memoryCache,
+  _inFlight,
+} from '../responseCache';
+
+// Clear cache and in-flight state between tests
+beforeEach(() => {
+  _memoryCache.clear();
+  _inFlight.clear();
+});
+
+describe('responseCache', () => {
+  describe('generateCacheKey', () => {
+    it('produces consistent keys for same inputs', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'explosion', duration: 3 });
+      const key2 = await _generateCacheKey('sfx', { prompt: 'explosion', duration: 3 });
+      expect(key1).toBe(key2);
+    });
+
+    it('produces different keys for different params', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'explosion' });
+      const key2 = await _generateCacheKey('sfx', { prompt: 'rain' });
+      expect(key1).not.toBe(key2);
+    });
+
+    it('produces different keys for different operations', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'explosion' });
+      const key2 = await _generateCacheKey('texture', { prompt: 'explosion' });
+      expect(key1).not.toBe(key2);
+    });
+
+    it('includes operation prefix in key', async () => {
+      const key = await _generateCacheKey('sfx_generation', { prompt: 'test' });
+      expect(key).toMatch(/^gen-cache:sfx_generation:/);
+    });
+  });
+
+  describe('cachedGenerate', () => {
+    it('executes function on first call', async () => {
+      const executeFn = vi.fn().mockResolvedValue({ audio: 'base64data' });
+
+      const result = await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+
+      expect(executeFn).toHaveBeenCalledTimes(1);
+      expect(result.cached).toBe(false);
+      expect(result.result).toEqual({ audio: 'base64data' });
+    });
+
+    it('returns cached result on second call', async () => {
+      const executeFn = vi.fn().mockResolvedValue({ audio: 'base64data' });
+
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+      const result = await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+
+      expect(executeFn).toHaveBeenCalledTimes(1);
+      expect(result.cached).toBe(true);
+      expect(result.result).toEqual({ audio: 'base64data' });
+    });
+
+    it('executes for different params', async () => {
+      const executeFn = vi.fn()
+        .mockResolvedValueOnce({ audio: 'boom' })
+        .mockResolvedValueOnce({ audio: 'rain' });
+
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+      await cachedGenerate('sfx_generation', { prompt: 'rain' }, executeFn);
+
+      expect(executeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips cache when skipCache is true', async () => {
+      const executeFn = vi.fn().mockResolvedValue({ audio: 'data' });
+
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { skipCache: true });
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { skipCache: true });
+
+      expect(executeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('never caches chat operations', async () => {
+      const executeFn = vi.fn().mockResolvedValue({ message: 'hi' });
+
+      await cachedGenerate('chat', { prompt: 'hello' }, executeFn);
+      await cachedGenerate('chat', { prompt: 'hello' }, executeFn);
+
+      expect(executeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates in-flight requests', async () => {
+      let resolveFirst: (value: { audio: string }) => void;
+      const firstPromise = new Promise<{ audio: string }>((resolve) => {
+        resolveFirst = resolve;
+      });
+
+      const executeFn = vi.fn().mockReturnValue(firstPromise);
+
+      const promise1 = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+      // Let the first call's async key generation settle before starting the second
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(1));
+      const promise2 = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+
+      resolveFirst!({ audio: 'data' });
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(result1.result).toEqual({ audio: 'data' });
+      expect(result2.result).toEqual({ audio: 'data' });
+      expect(result2.cached).toBe(true);
+    });
+
+    it('does not cache on execution failure', async () => {
+      const executeFn = vi.fn()
+        .mockRejectedValueOnce(new Error('provider down'))
+        .mockResolvedValueOnce({ audio: 'data' });
+
+      await expect(
+        cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn)
+      ).rejects.toThrow('provider down');
+
+      // Second call should re-execute (not return cached error)
+      const result = await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn);
+      expect(executeFn).toHaveBeenCalledTimes(2);
+      expect(result.cached).toBe(false);
+    });
+  });
+
+  describe('getCachedResult', () => {
+    it('returns hit:false when nothing is cached', async () => {
+      const result = await getCachedResult('sfx_generation', { prompt: 'boom' });
+      expect(result.hit).toBe(false);
+    });
+
+    it('returns hit:true after cachedGenerate populates the cache', async () => {
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, async () => ({ audio: 'data' }));
+
+      const result = await getCachedResult<{ audio: string }>('sfx_generation', { prompt: 'boom' });
+      expect(result.hit).toBe(true);
+      if (result.hit) {
+        expect(result.result).toEqual({ audio: 'data' });
+      }
+    });
+
+    it('returns hit:false for chat operations', async () => {
+      const result = await getCachedResult('chat', { prompt: 'hello' });
+      expect(result.hit).toBe(false);
+    });
+  });
+
+  describe('invalidateCache', () => {
+    it('clears all entries when no operation specified', async () => {
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, async () => ({ audio: 'a' }));
+      await cachedGenerate('texture_generation', { prompt: 'stone' }, async () => ({ img: 'b' }));
+      expect(_memoryCache.size).toBe(2);
+
+      await invalidateCache();
+      expect(_memoryCache.size).toBe(0);
+    });
+
+    it('clears only matching operation entries', async () => {
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, async () => ({ audio: 'a' }));
+      await cachedGenerate('texture_generation', { prompt: 'stone' }, async () => ({ img: 'b' }));
+
+      await invalidateCache('sfx_generation');
+      expect(_memoryCache.size).toBe(1);
+    });
+  });
+
+  describe('getCacheStats', () => {
+    it('reports memory entries', async () => {
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, async () => ({ audio: 'data' }));
+      const stats = getCacheStats();
+      expect(stats.memoryEntries).toBe(1);
+      expect(stats.memoryMaxEntries).toBe(30);
+      expect(stats.inFlightRequests).toBe(0);
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('evicts oldest entries when at capacity', async () => {
+      // Fill cache to capacity (30 entries)
+      for (let i = 0; i < 30; i++) {
+        await cachedGenerate('sfx_generation', { prompt: `sound_${i}` }, async () => ({ id: i }));
+      }
+      expect(_memoryCache.size).toBe(30);
+
+      // Add one more — should evict the oldest
+      await cachedGenerate('sfx_generation', { prompt: 'sound_30' }, async () => ({ id: 30 }));
+      expect(_memoryCache.size).toBe(30);
+
+      // First entry should be evicted
+      const firstResult = await getCachedResult('sfx_generation', { prompt: 'sound_0' });
+      expect(firstResult.hit).toBe(false);
+
+      // Last entry should still be cached
+      const lastResult = await getCachedResult('sfx_generation', { prompt: 'sound_30' });
+      expect(lastResult.hit).toBe(true);
+    });
+  });
+});

--- a/web/src/lib/api/__tests__/responseCache.test.ts
+++ b/web/src/lib/api/__tests__/responseCache.test.ts
@@ -39,6 +39,24 @@ describe('responseCache', () => {
       const key = await _generateCacheKey('sfx_generation', { prompt: 'test' });
       expect(key).toMatch(/^gen-cache:sfx_generation:/);
     });
+
+    it('produces different keys for different userIds', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'boom' }, 'user_A');
+      const key2 = await _generateCacheKey('sfx', { prompt: 'boom' }, 'user_B');
+      expect(key1).not.toBe(key2);
+    });
+
+    it('treats undefined userId same as no userId', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'boom' });
+      const key2 = await _generateCacheKey('sfx', { prompt: 'boom' }, undefined);
+      expect(key1).toBe(key2);
+    });
+
+    it('handles params with undefined values consistently', async () => {
+      const key1 = await _generateCacheKey('sfx', { prompt: 'boom', extra: undefined });
+      const key2 = await _generateCacheKey('sfx', { prompt: 'boom', extra: undefined });
+      expect(key1).toBe(key2);
+    });
   });
 
   describe('cachedGenerate', () => {
@@ -113,6 +131,19 @@ describe('responseCache', () => {
       expect(result2.cached).toBe(true);
     });
 
+    it('isolates cache entries per userId', async () => {
+      const executeFn = vi.fn()
+        .mockResolvedValueOnce({ audio: 'user_a_result' })
+        .mockResolvedValueOnce({ audio: 'user_b_result' });
+
+      const resultA = await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      const resultB = await cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_B' });
+
+      expect(executeFn).toHaveBeenCalledTimes(2);
+      expect(resultA.result).toEqual({ audio: 'user_a_result' });
+      expect(resultB.result).toEqual({ audio: 'user_b_result' });
+    });
+
     it('does not cache on execution failure', async () => {
       const executeFn = vi.fn()
         .mockRejectedValueOnce(new Error('provider down'))
@@ -177,6 +208,29 @@ describe('responseCache', () => {
       expect(stats.memoryEntries).toBe(1);
       expect(stats.memoryMaxEntries).toBe(30);
       expect(stats.inFlightRequests).toBe(0);
+    });
+  });
+
+  describe('TTL expiry', () => {
+    it('expires cached entries after TTL', async () => {
+      vi.useFakeTimers();
+
+      await cachedGenerate('sfx_generation', { prompt: 'boom' }, async () => ({ audio: 'data' }), {
+        ttlSeconds: 60,
+      });
+
+      // Should be cached
+      const result1 = await getCachedResult('sfx_generation', { prompt: 'boom' });
+      expect(result1.hit).toBe(true);
+
+      // Advance past TTL
+      vi.advanceTimersByTime(61_000);
+
+      // Should be expired
+      const result2 = await getCachedResult('sfx_generation', { prompt: 'boom' });
+      expect(result2.hit).toBe(false);
+
+      vi.useRealTimers();
     });
   });
 

--- a/web/src/lib/api/createGenerationHandler.ts
+++ b/web/src/lib/api/createGenerationHandler.ts
@@ -224,6 +224,7 @@ export function createGenerationHandler<TParams, TResult>(
           resolvedOperation,
           cacheParams,
           async () => {
+            // Cache miss — deduct tokens and execute provider call
             // This runs only on cache miss — deduct tokens and execute
             const metadata = billingMetadataFn ? billingMetadataFn(params) : (params as Record<string, unknown>);
             const resolved = await resolveApiKey(userId, resolvedProvider, tokenCost, resolvedOperation, metadata);
@@ -244,7 +245,7 @@ export function createGenerationHandler<TParams, TResult>(
               throw err;
             }
           },
-          { ttlSeconds: cacheTtlSeconds }
+          { ttlSeconds: cacheTtlSeconds, userId }
         );
 
         const headers: Record<string, string> = {

--- a/web/src/lib/api/createGenerationHandler.ts
+++ b/web/src/lib/api/createGenerationHandler.ts
@@ -26,6 +26,7 @@ import { rateLimitResponse } from '@/lib/rateLimit';
 import { distributedRateLimit, aggregateGenerationRateLimit } from '@/lib/rateLimit/distributed';
 import { sanitizePrompt } from '@/lib/ai/contentSafety';
 import { refundTokens } from '@/lib/tokens/service';
+import { cachedGenerate } from './responseCache';
 
 /** Validation result: either the parsed params or an error response. */
 type ValidateResult<T> =
@@ -91,6 +92,18 @@ export interface GenerationHandlerConfig<TParams, TResult> {
     usageId: string | undefined;
     tokenCost: number;
   }) => Promise<TResult>;
+
+  /**
+   * Extract cache-relevant params from validated params. Only these fields
+   * contribute to the cache key. Omit large binary fields (imageBase64, etc.)
+   * and volatile fields (timestamps, request IDs).
+   *
+   * When omitted, caching is disabled for this route.
+   */
+  cacheKeyParams?: (params: TParams) => Record<string, unknown>;
+
+  /** Override TTL for cached results (in seconds). Uses operation-based defaults if omitted. */
+  cacheTtlSeconds?: number;
 }
 
 /**
@@ -123,6 +136,8 @@ export function createGenerationHandler<TParams, TResult>(
     billingMetadata: billingMetadataFn,
     validate,
     execute,
+    cacheKeyParams,
+    cacheTtlSeconds,
   } = config;
 
   return async (request: NextRequest): Promise<NextResponse> => {
@@ -200,6 +215,53 @@ export function createGenerationHandler<TParams, TResult>(
       captureException(err, { route, action: 'resolve_billing_params' });
       return NextResponse.json({ error: 'Internal pricing error' }, { status: 500 });
     }
+
+    // 6b. Check response cache (before token deduction — cache hits are free)
+    if (cacheKeyParams) {
+      const cacheParams = cacheKeyParams(params);
+      try {
+        const cacheResult = await cachedGenerate<TResult>(
+          resolvedOperation,
+          cacheParams,
+          async () => {
+            // This runs only on cache miss — deduct tokens and execute
+            const metadata = billingMetadataFn ? billingMetadataFn(params) : (params as Record<string, unknown>);
+            const resolved = await resolveApiKey(userId, resolvedProvider, tokenCost, resolvedOperation, metadata);
+            const apiKey = resolved.key;
+            const usageId = resolved.usageId;
+
+            try {
+              return await execute(params, apiKey, { userId, tier, usageId, tokenCost });
+            } catch (err) {
+              // Refund tokens on provider failure
+              if (usageId) {
+                try {
+                  await refundTokens(userId, usageId);
+                } catch (refundErr) {
+                  captureException(refundErr, { route, action: 'refund', usageId });
+                }
+              }
+              throw err;
+            }
+          },
+          { ttlSeconds: cacheTtlSeconds }
+        );
+
+        const headers: Record<string, string> = {
+          'X-Cache': cacheResult.cached ? 'HIT' : 'MISS',
+        };
+        return NextResponse.json(cacheResult.result, { status: successStatus, headers });
+      } catch (err) {
+        if (err instanceof ApiKeyError) {
+          return NextResponse.json({ error: err.message, code: err.code }, { status: 402 });
+        }
+        captureException(err, { route });
+        const message = err instanceof Error ? err.message : 'Provider error';
+        return NextResponse.json({ error: message }, { status: 500 });
+      }
+    }
+
+    // 7. No caching — original path: resolve key, deduct, execute
     let apiKey: string;
     let usageId: string | undefined;
 
@@ -215,12 +277,11 @@ export function createGenerationHandler<TParams, TResult>(
       throw err;
     }
 
-    // 7. Execute provider call
     try {
       const result = await execute(params, apiKey, { userId, tier, usageId, tokenCost });
       return NextResponse.json(result, { status: successStatus });
     } catch (err) {
-      // 8. Refund tokens on provider failure
+      // Refund tokens on provider failure
       if (usageId) {
         try {
           await refundTokens(userId, usageId);

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -176,9 +176,13 @@ async function redisSet<T>(key: string, value: T, ttlSeconds: number): Promise<v
     // Enforce max entry size (10 MB)
     if (serialized.length > 10 * 1024 * 1024) return;
 
-    await fetch(`${url}/set/${encodeURIComponent(key)}/${encodeURIComponent(serialized)}/ex/${ttlSeconds}`, {
+    await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}` },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(['SET', key, serialized, 'EX', ttlSeconds]),
     });
   } catch (err) {
     captureException(err, { action: 'responseCache.redisSet', key });

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -55,7 +55,7 @@ const DEFAULT_TTL: Record<string, number> = {
   pixel_art_openai: 86400,
   skybox_generation: 604800,       // 7 days
   tileset_generation: 604800,      // 7 days
-  localize_cost_per_chunk: 86400,  // 24 hours
+  localize_scene: 86400,           // 24 hours
 };
 
 // Chat is never cached

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -71,6 +71,7 @@ function getTtlSeconds(operation: string, override?: number): number {
 // ---------------------------------------------------------------------------
 
 function sortedStringify(obj: unknown): string {
+  if (obj === undefined) return 'null';
   if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
   if (Array.isArray(obj)) return `[${obj.map(sortedStringify).join(',')}]`;
   const sorted = Object.keys(obj as Record<string, unknown>).sort();
@@ -79,9 +80,10 @@ function sortedStringify(obj: unknown): string {
 
 async function generateCacheKey(
   operation: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  userId?: string
 ): Promise<string> {
-  const payload = sortedStringify({ operation, params });
+  const payload = sortedStringify({ operation, params, userId: userId ?? null });
   const encoder = new TextEncoder();
   const data = encoder.encode(payload);
 
@@ -173,8 +175,8 @@ async function redisSet<T>(key: string, value: T, ttlSeconds: number): Promise<v
   try {
     const serialized = JSON.stringify(value);
 
-    // Enforce max entry size (10 MB)
-    if (serialized.length > 10 * 1024 * 1024) return;
+    // Enforce max entry size (10 MB, measured in bytes not code units)
+    if (Buffer.byteLength(serialized, 'utf-8') > 10 * 1024 * 1024) return;
 
     await fetch(url, {
       method: 'POST',
@@ -205,11 +207,12 @@ const inFlight = new Map<string, InFlightEntry<unknown>>();
  */
 export async function getCachedResult<T>(
   operation: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  userId?: string
 ): Promise<{ hit: true; result: T } | { hit: false }> {
   if (NEVER_CACHE_OPS.has(operation)) return { hit: false };
 
-  const key = await generateCacheKey(operation, params);
+  const key = await generateCacheKey(operation, params, userId);
 
   // Check Redis first, fall back to memory
   if (isUpstashConfigured()) {
@@ -236,14 +239,14 @@ export async function cachedGenerate<T>(
   operation: string,
   params: Record<string, unknown>,
   executeFn: () => Promise<T>,
-  config?: { ttlSeconds?: number; skipCache?: boolean }
+  config?: { ttlSeconds?: number; skipCache?: boolean; userId?: string }
 ): Promise<{ result: T; cached: boolean }> {
   if (config?.skipCache || NEVER_CACHE_OPS.has(operation)) {
     const result = await executeFn();
     return { result, cached: false };
   }
 
-  const key = await generateCacheKey(operation, params);
+  const key = await generateCacheKey(operation, params, config?.userId);
 
   // 1. Check cache
   if (isUpstashConfigured()) {

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -1,0 +1,319 @@
+/**
+ * AI generation response cache with prompt deduplication.
+ *
+ * Caches generation results (SFX, textures, 3D models, sprites) by hashing
+ * the operation + normalized params. Uses Upstash Redis when available,
+ * falls back to in-memory LRU.
+ *
+ * Cache hits skip token deduction entirely — users pay nothing for repeated
+ * identical requests.
+ */
+
+import { captureException } from '@/lib/monitoring/sentry-server';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CacheConfig {
+  /** Operation name (e.g. 'sfx_generation') — used for TTL lookup and key prefix */
+  operation: string;
+  /** Override the default TTL for this operation (in seconds) */
+  ttlSeconds?: number;
+  /** Skip caching entirely for this request */
+  skipCache?: boolean;
+}
+
+interface CacheEntry<T> {
+  result: T;
+  createdAt: number;
+  ttlMs: number;
+  operation: string;
+}
+
+interface InFlightEntry<T> {
+  promise: Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// TTL defaults per operation type (seconds)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TTL: Record<string, number> = {
+  sfx_generation: 86400,           // 24 hours
+  voice_generation: 86400,         // 24 hours
+  voice_batch_cost_per_item: 86400,
+  music_generation: 86400,         // 24 hours
+  '3d_generation_standard': 604800, // 7 days
+  '3d_generation_high': 604800,
+  image_to_3d: 604800,
+  texture_generation: 604800,      // 7 days
+  sprite_generation_dalle3: 86400, // 24 hours
+  sprite_generation_replicate: 86400,
+  sprite_sheet_cost_per_frame: 86400,
+  pixel_art_replicate: 86400,
+  pixel_art_openai: 86400,
+  skybox_generation: 604800,       // 7 days
+  tileset_generation: 604800,      // 7 days
+  localize_cost_per_chunk: 86400,  // 24 hours
+};
+
+// Chat is never cached
+const NEVER_CACHE_OPS = new Set(['chat']);
+
+function getTtlSeconds(operation: string, override?: number): number {
+  if (override !== undefined) return override;
+  return DEFAULT_TTL[operation] ?? 3600; // Default 1 hour
+}
+
+// ---------------------------------------------------------------------------
+// Cache key generation (SHA-256 of operation + params)
+// ---------------------------------------------------------------------------
+
+function sortedStringify(obj: unknown): string {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(sortedStringify).join(',')}]`;
+  const sorted = Object.keys(obj as Record<string, unknown>).sort();
+  return `{${sorted.map(k => `${JSON.stringify(k)}:${sortedStringify((obj as Record<string, unknown>)[k])}`).join(',')}}`;
+}
+
+async function generateCacheKey(
+  operation: string,
+  params: Record<string, unknown>
+): Promise<string> {
+  const payload = sortedStringify({ operation, params });
+  const encoder = new TextEncoder();
+  const data = encoder.encode(payload);
+
+  if (typeof globalThis.crypto?.subtle?.digest === 'function') {
+    const hash = await globalThis.crypto.subtle.digest('SHA-256', data);
+    const hex = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, '0')).join('');
+    return `gen-cache:${operation}:${hex}`;
+  }
+
+  // Fallback: djb2 hash
+  let h = 5381;
+  for (let i = 0; i < data.length; i++) {
+    h = ((h << 5) + h + data[i]) | 0;
+  }
+  return `gen-cache:${operation}:${(h >>> 0).toString(36)}`;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory LRU cache (dev-only fallback when Upstash not configured)
+//
+// WARNING: Not suitable for production. Serverless functions are stateless —
+// each instance has its own cache, cold starts reset it, and large generation
+// results (base64 audio/images, 1-10MB each) cause memory pressure. Keep the
+// cap low; this exists only for local development without Redis.
+// ---------------------------------------------------------------------------
+
+const MAX_MEMORY_ENTRIES = 30;
+const memoryCache = new Map<string, CacheEntry<unknown>>();
+
+function memoryGet<T>(key: string): T | undefined {
+  const entry = memoryCache.get(key) as CacheEntry<T> | undefined;
+  if (!entry) return undefined;
+
+  if (Date.now() - entry.createdAt > entry.ttlMs) {
+    memoryCache.delete(key);
+    return undefined;
+  }
+
+  // Move to end (most recent)
+  memoryCache.delete(key);
+  memoryCache.set(key, entry);
+  return entry.result;
+}
+
+function memorySet<T>(key: string, result: T, ttlMs: number, operation: string): void {
+  // Evict oldest if at capacity
+  if (memoryCache.size >= MAX_MEMORY_ENTRIES) {
+    const firstKey = memoryCache.keys().next().value;
+    if (firstKey !== undefined) memoryCache.delete(firstKey);
+  }
+
+  memoryCache.set(key, { result, createdAt: Date.now(), ttlMs, operation });
+}
+
+// ---------------------------------------------------------------------------
+// Upstash Redis cache layer
+// ---------------------------------------------------------------------------
+
+function isUpstashConfigured(): boolean {
+  return Boolean(
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN,
+  );
+}
+
+async function redisGet<T>(key: string): Promise<T | undefined> {
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+
+  try {
+    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!resp.ok) return undefined;
+    const body = await resp.json() as { result: string | null };
+    if (!body.result) return undefined;
+
+    return JSON.parse(body.result) as T;
+  } catch (err) {
+    captureException(err, { action: 'responseCache.redisGet', key });
+    return undefined;
+  }
+}
+
+async function redisSet<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+  const url = process.env.UPSTASH_REDIS_REST_URL!;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN!;
+
+  try {
+    const serialized = JSON.stringify(value);
+
+    // Enforce max entry size (10 MB)
+    if (serialized.length > 10 * 1024 * 1024) return;
+
+    await fetch(`${url}/set/${encodeURIComponent(key)}/${encodeURIComponent(serialized)}/ex/${ttlSeconds}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch (err) {
+    captureException(err, { action: 'responseCache.redisSet', key });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-flight deduplication
+// ---------------------------------------------------------------------------
+
+const inFlight = new Map<string, InFlightEntry<unknown>>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a cached result exists for the given operation + params.
+ * Returns the cached result if found, undefined otherwise.
+ */
+export async function getCachedResult<T>(
+  operation: string,
+  params: Record<string, unknown>
+): Promise<{ hit: true; result: T } | { hit: false }> {
+  if (NEVER_CACHE_OPS.has(operation)) return { hit: false };
+
+  const key = await generateCacheKey(operation, params);
+
+  // Check Redis first, fall back to memory
+  if (isUpstashConfigured()) {
+    const cached = await redisGet<T>(key);
+    if (cached !== undefined) return { hit: true, result: cached };
+  }
+
+  const memResult = memoryGet<T>(key);
+  if (memResult !== undefined) return { hit: true, result: memResult };
+
+  return { hit: false };
+}
+
+/**
+ * Execute a generation function with cache-aware deduplication.
+ *
+ * - If a cached result exists, returns it immediately.
+ * - If an identical request is already in-flight, piggybacks on it.
+ * - Otherwise, executes the function and caches the result.
+ *
+ * Returns { result, cached } so callers can add X-Cache headers.
+ */
+export async function cachedGenerate<T>(
+  operation: string,
+  params: Record<string, unknown>,
+  executeFn: () => Promise<T>,
+  config?: { ttlSeconds?: number; skipCache?: boolean }
+): Promise<{ result: T; cached: boolean }> {
+  if (config?.skipCache || NEVER_CACHE_OPS.has(operation)) {
+    const result = await executeFn();
+    return { result, cached: false };
+  }
+
+  const key = await generateCacheKey(operation, params);
+
+  // 1. Check cache
+  if (isUpstashConfigured()) {
+    const cached = await redisGet<T>(key);
+    if (cached !== undefined) return { result: cached, cached: true };
+  }
+  const memResult = memoryGet<T>(key);
+  if (memResult !== undefined) return { result: memResult, cached: true };
+
+  // 2. Check in-flight dedup
+  const existing = inFlight.get(key);
+  if (existing) {
+    const result = await existing.promise as T;
+    return { result, cached: true };
+  }
+
+  // 3. Execute and cache
+  const ttlSeconds = getTtlSeconds(operation, config?.ttlSeconds);
+  const ttlMs = ttlSeconds * 1000;
+
+  const promise = executeFn();
+  inFlight.set(key, { promise });
+
+  try {
+    const result = await promise;
+
+    // Store in both caches
+    memorySet(key, result, ttlMs, operation);
+    if (isUpstashConfigured()) {
+      // Fire-and-forget Redis write
+      redisSet(key, result, ttlSeconds).catch((err) =>
+        captureException(err, { action: 'responseCache.backgroundSet', key })
+      );
+    }
+
+    return { result, cached: false };
+  } finally {
+    inFlight.delete(key);
+  }
+}
+
+/**
+ * Invalidate cached results for an operation (or all operations).
+ */
+export async function invalidateCache(operation?: string): Promise<void> {
+  if (operation) {
+    // Remove matching entries from memory cache
+    for (const [key, entry] of memoryCache) {
+      if ((entry as CacheEntry<unknown>).operation === operation) {
+        memoryCache.delete(key);
+      }
+    }
+  } else {
+    memoryCache.clear();
+  }
+
+  // Redis invalidation requires SCAN which is not available via REST API.
+  // For Redis, we rely on TTL expiration. Manual invalidation clears memory only.
+}
+
+/**
+ * Get cache statistics for monitoring.
+ */
+export function getCacheStats(): {
+  memoryEntries: number;
+  memoryMaxEntries: number;
+  inFlightRequests: number;
+} {
+  return {
+    memoryEntries: memoryCache.size,
+    memoryMaxEntries: MAX_MEMORY_ENTRIES,
+    inFlightRequests: inFlight.size,
+  };
+}
+
+// Exported for testing
+export { generateCacheKey as _generateCacheKey, memoryCache as _memoryCache, inFlight as _inFlight };


### PR DESCRIPTION
## Summary
- Adds `responseCache.ts` — SHA-256 cache key generation, in-memory LRU (30 entries, dev-only), Upstash Redis via REST API, in-flight deduplication to coalesce concurrent identical requests
- Integrates cache into `createGenerationHandler` via `cacheKeyParams` / `cacheTtlSeconds` config options — cache check runs BEFORE token deduction so hits are free
- Enables caching on SFX, voice, and localize routes (routes that return actual results). Async job routes (texture, sprite, model, etc.) are NOT cached because their job IDs are ephemeral
- Operation-specific TTLs: SFX/voice 24h, 3D models 7d, textures 7d, chat never cached
- 18 new tests covering key generation, caching, dedup, LRU eviction, error handling

Closes #6991

## Test plan
- [x] 18 responseCache unit tests pass (key generation, cache/miss, dedup, eviction, errors)
- [x] 14 createGenerationHandler tests pass (no regressions)
- [x] 22 route integration tests pass (all generate routes work correctly)
- [x] ESLint zero warnings
- [x] TypeScript compiles cleanly