### PR TITLE
feat: batch MCP tool registration for startup performance

### DIFF
--- a/.changeset/batch-mcp-tools.md
+++ b/.changeset/batch-mcp-tools.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-mcp": patch
+---
+
+Batch MCP tool registration in chunks of 50 to avoid blocking the event loop during startup. Migrates from deprecated `tool()` to `registerTool()` API.

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -17,8 +17,8 @@ async function main() {
   const editorUrl = process.env.FORGE_EDITOR_WS_URL ?? 'ws://localhost:3001/api/mcp/ws';
   const bridge = new EditorBridge(editorUrl);
 
-  // Register all tools from the command manifest
-  registerTools(server, bridge);
+  // Register all tools from the command manifest (batched for large manifests)
+  await registerTools(server, bridge);
 
   // Register MCP resources (scene graph, selection, etc.)
   registerResources(server, bridge);

--- a/mcp-server/src/tools/__tests__/generated.test.ts
+++ b/mcp-server/src/tools/__tests__/generated.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import manifest from '../../../manifest/commands.json';
+
+// Mock the MCP SDK
+const mockRegisterTool = vi.fn();
+const mockServer = {
+  registerTool: mockRegisterTool,
+} as unknown;
+
+// Mock EditorBridge
+const mockBridge = {
+  executeCommand: vi.fn(),
+} as unknown;
+
+// Mock setImmediate for batching tests
+vi.stubGlobal('setImmediate', (fn: () => void) => {
+  Promise.resolve().then(fn);
+});
+
+describe('registerTools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers all manifest commands as MCP tools', async () => {
+    const { registerTools } = await import('../generated.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { EditorBridge } = await import('../../transport/websocket.js');
+
+    await registerTools(
+      mockServer as InstanceType<typeof McpServer>,
+      mockBridge as InstanceType<typeof EditorBridge>,
+    );
+
+    expect(mockRegisterTool).toHaveBeenCalledTimes(manifest.commands.length);
+  });
+
+  it('registers each command with correct name and description', async () => {
+    const { registerTools } = await import('../generated.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { EditorBridge } = await import('../../transport/websocket.js');
+
+    await registerTools(
+      mockServer as InstanceType<typeof McpServer>,
+      mockBridge as InstanceType<typeof EditorBridge>,
+    );
+
+    const firstCmd = manifest.commands[0];
+    const firstCall = mockRegisterTool.mock.calls[0];
+    expect(firstCall[0]).toBe(firstCmd.name);
+    expect(firstCall[1].description).toBe(firstCmd.description);
+  });
+
+  it('tool handler calls bridge.executeCommand', async () => {
+    const { registerTools } = await import('../generated.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { EditorBridge } = await import('../../transport/websocket.js');
+
+    await registerTools(
+      mockServer as InstanceType<typeof McpServer>,
+      mockBridge as InstanceType<typeof EditorBridge>,
+    );
+
+    // Get the handler from the first registered tool
+    const firstCall = mockRegisterTool.mock.calls[0];
+    const handler = firstCall[2]; // callback is 3rd arg
+    const firstCmd = manifest.commands[0];
+
+    (mockBridge as { executeCommand: ReturnType<typeof vi.fn> }).executeCommand.mockResolvedValueOnce({ ok: true });
+
+    const result = await handler({ foo: 'bar' });
+    expect((mockBridge as { executeCommand: ReturnType<typeof vi.fn> }).executeCommand).toHaveBeenCalledWith(
+      firstCmd.name,
+      { foo: 'bar' },
+    );
+    expect(result.content[0].type).toBe('text');
+  });
+
+  it('tool handler returns error on bridge failure', async () => {
+    const { registerTools } = await import('../generated.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { EditorBridge } = await import('../../transport/websocket.js');
+
+    await registerTools(
+      mockServer as InstanceType<typeof McpServer>,
+      mockBridge as InstanceType<typeof EditorBridge>,
+    );
+
+    const firstCall = mockRegisterTool.mock.calls[0];
+    const handler = firstCall[2];
+
+    (mockBridge as { executeCommand: ReturnType<typeof vi.fn> }).executeCommand.mockRejectedValueOnce(
+      new Error('Connection lost'),
+    );
+
+    const result = await handler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Connection lost');
+  });
+
+  it('registers tools with inputSchema config', async () => {
+    const { registerTools } = await import('../generated.js');
+    const { McpServer } = await import('@modelcontextprotocol/sdk/server/mcp.js');
+    const { EditorBridge } = await import('../../transport/websocket.js');
+
+    await registerTools(
+      mockServer as InstanceType<typeof McpServer>,
+      mockBridge as InstanceType<typeof EditorBridge>,
+    );
+
+    const firstCall = mockRegisterTool.mock.calls[0];
+    const config = firstCall[1];
+    expect(config).toHaveProperty('inputSchema');
+    expect(config).toHaveProperty('description');
+  });
+});

--- a/mcp-server/src/tools/generated.ts
+++ b/mcp-server/src/tools/generated.ts
@@ -12,11 +12,10 @@ function jsonSchemaToZod(prop: Record<string, unknown>): z.ZodTypeAny {
 
   switch (type) {
     case 'string': {
-      let schema = z.string();
       if (prop.enum) {
         return z.enum(prop.enum as [string, ...string[]]);
       }
-      return schema;
+      return z.string();
     }
     case 'number':
       return z.number();
@@ -53,7 +52,6 @@ function buildZodSchema(
     if (!required.has(key)) {
       fieldSchema = fieldSchema.optional();
     }
-    // Add description if available
     if (prop.description) {
       fieldSchema = fieldSchema.describe(prop.description as string);
     }
@@ -63,39 +61,80 @@ function buildZodSchema(
   return shape;
 }
 
+// Size of each registration batch. Yields the event loop between batches
+// so that startup doesn't block for the full manifest.
+const BATCH_SIZE = 50;
+
+/**
+ * Register a single command as an MCP tool.
+ */
+function registerCommand(
+  server: McpServer,
+  bridge: EditorBridge,
+  cmd: (typeof manifest.commands)[number],
+): void {
+  const zodShape = buildZodSchema(cmd.parameters as unknown as {
+    properties?: Record<string, Record<string, unknown>>;
+    required?: string[];
+  });
+
+  server.registerTool(
+    cmd.name,
+    {
+      description: cmd.description,
+      inputSchema: zodShape,
+    },
+    async (args) => {
+      try {
+        const result = await bridge.executeCommand(cmd.name, args as Record<string, unknown>);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
 /**
  * Register all commands from the manifest as MCP tools.
+ *
+ * Registers in batches of {@link BATCH_SIZE}, yielding the event loop between
+ * batches so that large manifests (350+ commands) don't block startup.
+ *
+ * Returns a Promise that resolves when all tools are registered.
  */
-export function registerTools(server: McpServer, bridge: EditorBridge): void {
-  for (const cmd of manifest.commands) {
-    const zodShape = buildZodSchema(cmd.parameters as unknown as {
-      properties?: Record<string, Record<string, unknown>>;
-      required?: string[];
-    });
+export async function registerTools(server: McpServer, bridge: EditorBridge): Promise<void> {
+  const commands = manifest.commands;
 
-    server.tool(
-      cmd.name,
-      cmd.description,
-      zodShape,
-      async (args) => {
-        try {
-          const result = await bridge.executeCommand(cmd.name, args as Record<string, unknown>);
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
-              },
-            ],
-          };
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            content: [{ type: 'text' as const, text: `Error: ${message}` }],
-            isError: true,
-          };
-        }
-      }
-    );
+  // Small manifests: register synchronously (no overhead)
+  if (commands.length <= BATCH_SIZE) {
+    for (const cmd of commands) {
+      registerCommand(server, bridge, cmd);
+    }
+    return;
+  }
+
+  // Large manifests: register in batches, yielding between each
+  for (let i = 0; i < commands.length; i += BATCH_SIZE) {
+    const batch = commands.slice(i, i + BATCH_SIZE);
+    for (const cmd of batch) {
+      registerCommand(server, bridge, cmd);
+    }
+
+    // Yield to the event loop between batches
+    if (i + BATCH_SIZE < commands.length) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Refactors `registerTools` to process commands in batches of 50, yielding the event loop between batches so startup doesn't block for the full 350-command manifest
- Migrates from deprecated `server.tool()` to `server.registerTool()` API (config object pattern)
- Extracts `registerCommand` helper for single-tool registration
- Adds 5 tests covering registration count, config shape, handler dispatch, and error handling

Closes #8225

## Test plan
- [x] 5 new registerTools tests pass
- [x] 405 total MCP server tests pass (0 regressions)
- [x] TypeScript compiles cleanly