### PR TITLE
feat: SEO foundation — metadataBase, JSON-LD, canonicals, AI robots.txt

### DIFF
--- a/.changeset/seo-foundation.md
+++ b/.changeset/seo-foundation.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": minor
+---
+
+Add SEO foundation: metadataBase for canonical URL resolution, SoftwareApplication + Organization JSON-LD schema with pricing tiers, canonical URLs on all public pages, and AI crawler directives in robots.txt

--- a/web/src/app/__tests__/robots.test.ts
+++ b/web/src/app/__tests__/robots.test.ts
@@ -40,4 +40,43 @@ describe('robots', () => {
     const result = robots();
     expect(result.sitemap).toContain('/sitemap.xml');
   });
+
+  describe('AI crawler rules', () => {
+    const AI_BOTS = ['GPTBot', 'ChatGPT-User', 'Google-Extended', 'ClaudeBot', 'CCBot', 'PerplexityBot', 'Anthropic'];
+
+    it('includes a rule for every expected AI crawler', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const userAgents = rules.map((r) => r.userAgent);
+
+      for (const bot of AI_BOTS) {
+        expect(userAgents).toContain(bot);
+      }
+    });
+
+    it('allows public content paths for AI crawlers', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const gptRule = rules.find((r) => r.userAgent === 'GPTBot');
+
+      expect(gptRule).toBeDefined();
+      const allowed = gptRule!.allow as string[];
+      expect(allowed).toContain('/');
+      expect(allowed).toContain('/pricing');
+      expect(allowed).toContain('/llms.txt');
+      expect(allowed).toContain('/llms-full.txt');
+    });
+
+    it('disallows private paths for AI crawlers', () => {
+      const result = robots();
+      const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+      const gptRule = rules.find((r) => r.userAgent === 'GPTBot');
+
+      expect(gptRule).toBeDefined();
+      const disallow = gptRule!.disallow as string[];
+      expect(disallow).toContain('/api/');
+      expect(disallow).toContain('/admin/');
+      expect(disallow).toContain('/dev/');
+    });
+  });
 });

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -1,9 +1,15 @@
+import type { Metadata } from 'next';
 import { cacheLife, cacheTag } from 'next/cache';
 import { GalleryPage } from '@/components/community/GalleryPage';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Community Gallery - SpawnForge',
-  description: 'Discover and play games created by the community',
+  description: 'Discover and play games created by the SpawnForge community. Browse, play, and get inspired by AI-powered 2D and 3D browser games.',
+  alternates: { canonical: '/community' },
+  openGraph: {
+    title: 'Community Gallery - SpawnForge',
+    description: 'Discover and play games created by the SpawnForge community.',
+  },
 };
 
 export default async function CommunityPage() {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { defaultLocale } from "@/i18n/config";
 import messages from "@/i18n/messages/en.json";
 import { Toaster } from "sonner";
 import { ServiceWorkerRegistration } from "@/components/ServiceWorkerRegistration";
+import { SITE_URL } from "@/lib/constants";
 import "./globals.css";
 
 // Lazy-load analytics and consent providers — they rely on browser APIs
@@ -35,8 +36,6 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -39,6 +39,7 @@ const geistMono = Geist_Mono({
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "SpawnForge",
   description: "AI-Powered Game Creation Platform — build 2D and 3D games in your browser with natural language and a visual editor.",
   manifest: "/manifest.json",
@@ -58,16 +59,49 @@ export const metadata: Metadata = {
   },
 };
 
-// Static JSON-LD Organization schema (safe constant — no user input)
-const jsonLdString = JSON.stringify({
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  name: "SpawnForge",
-  url: SITE_URL,
-  logo: `${SITE_URL}/favicon.ico`,
-  description: "AI-Powered Game Creation Platform — build 2D and 3D games in your browser with natural language and a visual editor.",
-  sameAs: [],
-});
+// Static JSON-LD: combined SoftwareApplication + Organization schema (safe constant — no user input)
+const jsonLdString = JSON.stringify([
+  {
+    "@context": "https://schema.org",
+    "@type": ["WebApplication", "SoftwareApplication"],
+    name: "SpawnForge",
+    url: SITE_URL,
+    description: "AI-Powered Game Creation Platform — build 2D and 3D games in your browser with natural language and a visual editor.",
+    applicationCategory: ["GameApplication", "DeveloperApplication"],
+    operatingSystem: "Web Browser",
+    browserRequirements: "WebGPU or WebGL2 capable browser",
+    offers: {
+      "@type": "AggregateOffer",
+      lowPrice: "0",
+      highPrice: "99",
+      priceCurrency: "USD",
+      offerCount: 4,
+      offers: [
+        { "@type": "Offer", name: "Free", price: "0", priceCurrency: "USD" },
+        { "@type": "Offer", name: "Starter", price: "9", priceCurrency: "USD" },
+        { "@type": "Offer", name: "Pro", price: "29", priceCurrency: "USD" },
+        { "@type": "Offer", name: "Studio", price: "99", priceCurrency: "USD" },
+      ],
+    },
+    featureList: [
+      "AI-powered game creation from natural language prompts",
+      "2D and 3D game engine (Rust/WASM, WebGPU + WebGL2)",
+      "Visual scripting with 73 node types",
+      "350 MCP commands for AI-assisted editing",
+      "One-click browser game publishing",
+      "Real-time physics simulation (Rapier)",
+      "AI asset generation (3D models, textures, audio, music)",
+    ],
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "SpawnForge",
+    url: SITE_URL,
+    logo: `${SITE_URL}/favicon.ico`,
+    description: "AI-Powered Game Creation Platform — build 2D and 3D games in your browser with natural language and a visual editor.",
+  },
+]);
 
 export default function RootLayout({
   children,

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,6 +9,7 @@ export const metadata: Metadata = {
   title: 'SpawnForge - AI-Powered Game Creation Platform',
   description:
     'Create 2D and 3D games in your browser with AI. No downloads, no installs. Describe your game and watch it come to life.',
+  alternates: { canonical: '/' },
   openGraph: {
     title: 'SpawnForge - Create Games with AI',
     description:

--- a/web/src/app/play/[userId]/[slug]/page.tsx
+++ b/web/src/app/play/[userId]/[slug]/page.tsx
@@ -47,6 +47,7 @@ export async function generateMetadata({
     return {
       title: `${game.title} - SpawnForge`,
       description: game.description || `Play ${game.title} on SpawnForge`,
+      alternates: { canonical: `/play/${clerkId}/${slug}` },
     };
   } catch {
     return { title: 'SpawnForge' };

--- a/web/src/app/pricing/page.tsx
+++ b/web/src/app/pricing/page.tsx
@@ -4,6 +4,12 @@ import { PricingPage } from '@/components/pricing/PricingPage';
 
 export const metadata: Metadata = {
   title: 'Pricing — SpawnForge',
+  description: 'SpawnForge pricing plans — Free, Starter ($9/mo), Pro ($29/mo), and Studio ($99/mo). AI-powered game creation for every budget.',
+  alternates: { canonical: '/pricing' },
+  openGraph: {
+    title: 'Pricing — SpawnForge',
+    description: 'SpawnForge pricing plans — Free, Starter ($9/mo), Pro ($29/mo), and Studio ($99/mo). AI-powered game creation for every budget.',
+  },
 };
 
 export default async function Pricing() {

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -6,6 +6,7 @@ import { LegalLayout } from '@/components/legal/LegalLayout';
 export const metadata: Metadata = {
   title: 'Privacy Policy - SpawnForge',
   description: 'SpawnForge Privacy Policy - AI-Powered Game Creation Platform',
+  alternates: { canonical: '/privacy' },
 };
 
 const tableOfContents = [

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -2,14 +2,24 @@ import type { MetadataRoute } from "next";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";
 
+const DISALLOW_PRIVATE = ["/api/", "/admin/", "/dev/", "/settings/", "/health/", "/api-docs/"];
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
         userAgent: "*",
         allow: "/",
-        disallow: ["/api/", "/admin/", "/dev/", "/settings/", "/health/", "/api-docs/"],
+        disallow: DISALLOW_PRIVATE,
       },
+      // AI crawlers — explicitly allow public content for LLM discoverability
+      ...["GPTBot", "ChatGPT-User", "Google-Extended", "ClaudeBot", "CCBot", "PerplexityBot", "Anthropic"].map(
+        (bot) => ({
+          userAgent: bot,
+          allow: ["/", "/pricing", "/community", "/play/", "/terms", "/privacy", "/llms.txt", "/llms-full.txt"],
+          disallow: DISALLOW_PRIVATE,
+        }),
+      ),
     ],
     sitemap: `${SITE_URL}/sitemap.xml`,
   };

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";
+import { SITE_URL } from "@/lib/constants";
 
 const DISALLOW_PRIVATE = ["/api/", "/admin/", "/dev/", "/settings/", "/health/", "/api-docs/"];
 

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,5 @@
 import type { MetadataRoute } from "next";
-
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";
+import { SITE_URL } from "@/lib/constants";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -6,6 +6,7 @@ import { LegalLayout } from '@/components/legal/LegalLayout';
 export const metadata: Metadata = {
   title: 'Terms of Service - SpawnForge',
   description: 'SpawnForge Terms of Service - AI-Powered Game Creation Platform',
+  alternates: { canonical: '/terms' },
 };
 
 const tableOfContents = [

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -107,3 +107,10 @@ export const AI_QUEUE_DEFAULT_MAX_DEPTH = 20;
 
 /** Maximum number of retries for the WASM engine initialisation sequence. */
 export const ENGINE_INIT_MAX_RETRIES = 3;
+
+// ---------------------------------------------------------------------------
+// Site URL
+// ---------------------------------------------------------------------------
+
+/** Canonical site URL, driven by NEXT_PUBLIC_SITE_URL env var (build-time). */
+export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://spawnforge.ai";


### PR DESCRIPTION
## Summary
- **SEO-001**: Add `metadataBase` to root layout for proper canonical/OG URL resolution. Add `alternates.canonical` to all public pages (pricing, community, terms, privacy, play/[userId]/[slug], root)
- **SEO-002**: Upgrade root JSON-LD from bare Organization to combined `[WebApplication, SoftwareApplication]` + Organization schema with `AggregateOffer` (4 pricing tiers) and `featureList`
- **SEO-003**: Add per-user-agent `robots.txt` rules for 7 AI crawlers (GPTBot, ChatGPT-User, Google-Extended, ClaudeBot, CCBot, PerplexityBot, Anthropic) explicitly allowing public content
- Enhanced pricing and community page metadata with full descriptions and OG data

Closes #8415 (SEO-001)
Closes #8416 (SEO-002)
Closes #8417 (SEO-003)

## Test plan
- [ ] `curl https://spawnforge.ai/robots.txt` shows AI crawler rules
- [ ] View source on `/pricing` confirms `<link rel="canonical" href="https://spawnforge.ai/pricing">`
- [ ] Google Rich Results Test validates SoftwareApplication + Organization JSON-LD
- [ ] Lighthouse SEO audit passes on all public pages
- [ ] `npx eslint --max-warnings 0 . && npx tsc --noEmit && npx vitest run` — all 15272 tests pass