### PR TITLE
perf: remove force-dynamic from landing page, move auth to proxy

### DIFF
--- a/.changeset/seo-004-landing-cache.md
+++ b/.changeset/seo-004-landing-cache.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Move authenticated-user redirect from root page to proxy middleware, removing force-dynamic and enabling static caching of the landing page for improved LCP

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,14 +1,11 @@
-import { redirect } from 'next/navigation';
-import { safeAuth } from '@/lib/auth/safe-auth';
 import type { Metadata } from 'next';
-
-export const dynamic = 'force-dynamic';
 import LandingPage from './(marketing)/page';
 
 export const metadata: Metadata = {
   title: 'SpawnForge - AI-Powered Game Creation Platform',
   description:
     'Create 2D and 3D games in your browser with AI. No downloads, no installs. Describe your game and watch it come to life.',
+  alternates: { canonical: '/' },
   openGraph: {
     title: 'SpawnForge - Create Games with AI',
     description:
@@ -17,10 +14,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Home() {
-  const { userId } = await safeAuth();
-  if (userId) {
-    redirect('/dashboard');
-  }
+// Auth redirect moved to proxy.ts — landing page can be statically cached.
+export default function Home() {
   return <LandingPage />;
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -140,6 +140,15 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     const corsResponse = handleCors(req);
     if (corsResponse) return corsResponse;
 
+    // Redirect authenticated users from landing page to dashboard.
+    // This runs in the proxy so the landing page itself can be statically cached.
+    if (req.nextUrl.pathname === '/') {
+      const { userId } = await auth();
+      if (userId) {
+        return NextResponse.redirect(new URL('/dashboard', req.url));
+      }
+    }
+
     if (!isPublicRoute(req)) {
       await auth.protect();
     }


### PR DESCRIPTION
## Summary
- Move authenticated-user dashboard redirect from root `page.tsx` to `proxy.ts` (middleware)
- Remove `force-dynamic` export and `safeAuth()` call from the landing page
- Landing page can now be statically cached / edge-cached, improving LCP for unauthenticated visitors
- Authenticated users are still redirected to `/dashboard` via the proxy layer

Closes #8418 (SEO-004)

## Test plan
- [ ] Unauthenticated user sees landing page (should be fast/cached)
- [ ] Authenticated user visiting `/` is redirected to `/dashboard`
- [ ] Verify via `x-vercel-cache` header that landing page is cache-eligible
- [ ] Lighthouse LCP improvement on landing page
- [ ] `npx eslint --max-warnings 0 . && npx tsc --noEmit && npx vitest run` — all 15272 tests pass