### PR TITLE
feat: ungate public docs pages for SEO/GEO discoverability

### DIFF
--- a/.changeset/geo-002-ungate-docs.md
+++ b/.changeset/geo-002-ungate-docs.md
@@ -1,0 +1,5 @@
+---
+"@spawnforge/docs": minor
+---
+
+Make MCP reference, API docs, getting started guides, and homepage publicly accessible without authentication for SEO/GEO discoverability

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,12 +1,25 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import type { Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = {
-  title: 'SpawnForge Documentation',
-  description: 'API reference and MCP command documentation for SpawnForge',
+const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL ?? 'https://docs.spawnforge.ai';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(DOCS_URL),
+  title: {
+    default: 'SpawnForge Documentation',
+    template: '%s | SpawnForge Docs',
+  },
+  description: 'API reference, MCP command documentation, and getting started guides for SpawnForge — the AI-powered game creation platform.',
+  openGraph: {
+    title: 'SpawnForge Documentation',
+    description: 'API reference, MCP command documentation, and guides for SpawnForge.',
+    siteName: 'SpawnForge Docs',
+    type: 'website',
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -7,7 +7,8 @@ const isPublicRoute = createRouteMatcher([
   '/sign-in(.*)',
   '/sign-up(.*)',
   '/api/webhooks(.*)',
-  '/mcp(.*)',
+  '/mcp',
+  '/mcp/(.*)',
 ]);
 
 function passThrough() {

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -8,9 +8,6 @@ const isPublicRoute = createRouteMatcher([
   '/sign-up(.*)',
   '/api/webhooks(.*)',
   '/mcp(.*)',
-  '/api-reference(.*)',
-  '/getting-started(.*)',
-  '/guides(.*)',
 ]);
 
 function passThrough() {

--- a/apps/docs/proxy.ts
+++ b/apps/docs/proxy.ts
@@ -3,9 +3,14 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 const isPublicRoute = createRouteMatcher([
+  '/',
   '/sign-in(.*)',
   '/sign-up(.*)',
   '/api/webhooks(.*)',
+  '/mcp(.*)',
+  '/api-reference(.*)',
+  '/getting-started(.*)',
+  '/guides(.*)',
 ]);
 
 function passThrough() {


### PR DESCRIPTION
## Summary
- Make docs homepage, MCP reference (`/mcp`), API reference (`/api-reference`), getting started guides (`/getting-started`), and general guides (`/guides`) publicly accessible without Clerk auth
- Internal docs remain auth-gated (any route not in the public matcher list)
- Add `metadataBase`, title template (`%s | SpawnForge Docs`), and OpenGraph metadata to docs layout
- 283 MCP command reference pages now indexable by search engines and AI crawlers

Closes #8420 (GEO-002)

## Test plan
- [ ] Visit `docs.spawnforge.ai/mcp/transform/spawn_entity` without auth — page loads
- [ ] Visit `docs.spawnforge.ai/getting-started` without auth — page loads
- [ ] Visit an internal docs route without auth — redirected to sign-in
- [ ] OG metadata present in page source
- [ ] Google can crawl docs.spawnforge.ai MCP reference