### PR TITLE
feat: dynamic sitemap with published games

### DIFF
--- a/.changeset/geo-003-dynamic-sitemap.md
+++ b/.changeset/geo-003-dynamic-sitemap.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": minor
+---
+
+Dynamic sitemap now includes all published games from the database alongside static pages, enabling search engines to discover `/play/[userId]/[slug]` URLs

--- a/.changeset/geo-003-dynamic-sitemap.md
+++ b/.changeset/geo-003-dynamic-sitemap.md
@@ -1,5 +1,5 @@
 ---
-"spawnforge": minor
+"web": minor
 ---
 
 Dynamic sitemap now includes all published games from the database alongside static pages, enabling search engines to discover `/play/[userId]/[slug]` URLs

--- a/web/src/app/__tests__/sitemap.test.ts
+++ b/web/src/app/__tests__/sitemap.test.ts
@@ -4,49 +4,63 @@
  * @vitest-environment node
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock DB to avoid real database calls in tests
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    })),
+  })),
+  queryWithResilience: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+
 import sitemap from '../sitemap';
 
 describe('sitemap', () => {
-  it('returns an array of sitemap entries', () => {
-    const result = sitemap();
+  it('returns an array of sitemap entries', async () => {
+    const result = await sitemap();
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
   });
 
-  it('includes the homepage with priority 1.0', () => {
-    const result = sitemap();
-    // The first entry should be the root with highest priority
+  it('includes the homepage with priority 1.0', async () => {
+    const result = await sitemap();
     expect(result[0].priority).toBe(1.0);
   });
 
-  it('includes public pages', () => {
-    const result = sitemap();
+  it('includes public pages', async () => {
+    const result = await sitemap();
     const urls = result.map((entry) => entry.url);
 
-    expect(urls.some((u) => u.includes('/pricing'))).toBe(true);
-    expect(urls.some((u) => u.includes('/community'))).toBe(true);
-    expect(urls.some((u) => u.includes('/docs'))).toBe(true);
-    expect(urls.some((u) => u.includes('/privacy'))).toBe(true);
-    expect(urls.some((u) => u.includes('/terms'))).toBe(true);
+    expect(urls.some((u: string) => u.includes('/pricing'))).toBe(true);
+    expect(urls.some((u: string) => u.includes('/community'))).toBe(true);
+    expect(urls.some((u: string) => u.includes('/docs'))).toBe(true);
+    expect(urls.some((u: string) => u.includes('/privacy'))).toBe(true);
+    expect(urls.some((u: string) => u.includes('/terms'))).toBe(true);
   });
 
-  it('all entries have lastModified and changeFrequency', () => {
-    const result = sitemap();
+  it('all entries have lastModified and changeFrequency', async () => {
+    const result = await sitemap();
     for (const entry of result) {
       expect(entry.lastModified).toBeDefined();
       expect(entry.changeFrequency).toBeDefined();
     }
   });
 
-  it('does not include private routes', () => {
-    const result = sitemap();
+  it('does not include private routes', async () => {
+    const result = await sitemap();
     const urls = result.map((entry) => entry.url);
 
-    expect(urls.some((u) => u.includes('/api/'))).toBe(false);
-    expect(urls.some((u) => u.includes('/admin'))).toBe(false);
-    expect(urls.some((u) => u.includes('/dev'))).toBe(false);
-    expect(urls.some((u) => u.includes('/editor'))).toBe(false);
-    expect(urls.some((u) => u.includes('/settings'))).toBe(false);
+    expect(urls.some((u: string) => u.includes('/api/'))).toBe(false);
+    expect(urls.some((u: string) => u.includes('/admin'))).toBe(false);
+    expect(urls.some((u: string) => u.includes('/dev'))).toBe(false);
+    expect(urls.some((u: string) => u.includes('/editor'))).toBe(false);
+    expect(urls.some((u: string) => u.includes('/settings'))).toBe(false);
   });
 });

--- a/web/src/app/__tests__/sitemap.test.ts
+++ b/web/src/app/__tests__/sitemap.test.ts
@@ -6,7 +6,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const mockWhere = vi.fn(() => Promise.resolve([]));
+type GameRow = { slug: string; clerkId: string; updatedAt: Date };
+const mockWhere = vi.fn<() => Promise<GameRow[]>>(() => Promise.resolve([]));
 
 vi.mock('@/lib/db/client', () => ({
   getDb: vi.fn(() => ({

--- a/web/src/app/__tests__/sitemap.test.ts
+++ b/web/src/app/__tests__/sitemap.test.ts
@@ -4,15 +4,16 @@
  * @vitest-environment node
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock DB to avoid real database calls in tests
+const mockWhere = vi.fn(() => Promise.resolve([]));
+
 vi.mock('@/lib/db/client', () => ({
   getDb: vi.fn(() => ({
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         innerJoin: vi.fn(() => ({
-          where: vi.fn(() => Promise.resolve([])),
+          where: mockWhere,
         })),
       })),
     })),
@@ -62,5 +63,60 @@ describe('sitemap', () => {
     expect(urls.some((u: string) => u.includes('/dev'))).toBe(false);
     expect(urls.some((u: string) => u.includes('/editor'))).toBe(false);
     expect(urls.some((u: string) => u.includes('/settings'))).toBe(false);
+  });
+
+  describe('dynamic game entries', () => {
+    beforeEach(() => {
+      mockWhere.mockReset();
+    });
+
+    it('includes published games from the database', async () => {
+      const updatedAt = new Date('2026-04-01');
+      mockWhere.mockResolvedValueOnce([
+        { slug: 'cool-game', clerkId: 'user_abc', updatedAt },
+        { slug: 'another-game', clerkId: 'user_xyz', updatedAt },
+      ]);
+
+      const result = await sitemap();
+      const urls = result.map((e) => e.url);
+
+      expect(urls).toContain('https://spawnforge.ai/play/user_abc/cool-game');
+      expect(urls).toContain('https://spawnforge.ai/play/user_xyz/another-game');
+    });
+
+    it('sets weekly changeFrequency and 0.6 priority for game entries', async () => {
+      mockWhere.mockResolvedValueOnce([
+        { slug: 'my-game', clerkId: 'user_1', updatedAt: new Date() },
+      ]);
+
+      const result = await sitemap();
+      const gameEntry = result.find((e) => e.url.includes('/play/'));
+
+      expect(gameEntry).toBeDefined();
+      expect(gameEntry!.changeFrequency).toBe('weekly');
+      expect(gameEntry!.priority).toBe(0.6);
+    });
+
+    it('uses game updatedAt as lastModified', async () => {
+      const updatedAt = new Date('2026-03-15T10:00:00Z');
+      mockWhere.mockResolvedValueOnce([
+        { slug: 'dated-game', clerkId: 'user_2', updatedAt },
+      ]);
+
+      const result = await sitemap();
+      const gameEntry = result.find((e) => e.url.includes('/play/'));
+
+      expect(gameEntry!.lastModified).toBe(updatedAt);
+    });
+
+    it('returns only static pages when DB query fails', async () => {
+      mockWhere.mockRejectedValueOnce(new Error('DB unavailable'));
+
+      const result = await sitemap();
+      const gameEntries = result.filter((e) => e.url.includes('/play/'));
+
+      expect(gameEntries).toHaveLength(0);
+      expect(result.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,10 +1,13 @@
 import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/constants";
+import { getDb, queryWithResilience } from "@/lib/db/client";
+import { publishedGames, users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
 
-  return [
+  const staticPages: MetadataRoute.Sitemap = [
     {
       url: SITE_URL,
       lastModified: now,
@@ -54,4 +57,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.2,
     },
   ];
+
+  // Query published games for dynamic sitemap entries
+  let gamePages: MetadataRoute.Sitemap = [];
+  try {
+    const games = await queryWithResilience(() =>
+      getDb()
+        .select({
+          slug: publishedGames.slug,
+          clerkId: users.clerkId,
+          updatedAt: publishedGames.updatedAt,
+        })
+        .from(publishedGames)
+        .innerJoin(users, eq(publishedGames.userId, users.id))
+        .where(eq(publishedGames.status, "published"))
+    );
+
+    gamePages = games.map((game) => ({
+      url: `${SITE_URL}/play/${game.clerkId}/${game.slug}`,
+      lastModified: game.updatedAt,
+      changeFrequency: "weekly" as const,
+      priority: 0.6,
+    }));
+  } catch {
+    // If DB is unavailable (CI, build), return static pages only
+  }
+
+  return [...staticPages, ...gamePages];
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { SITE_URL } from "@/lib/constants";
 import { getDb, queryWithResilience } from "@/lib/db/client";
 import { publishedGames, users } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
@@ -70,7 +70,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         })
         .from(publishedGames)
         .innerJoin(users, eq(publishedGames.userId, users.id))
-        .where(eq(publishedGames.status, "published"))
+        .where(and(eq(publishedGames.status, "published"), eq(users.banned, 0)))
     );
 
     gamePages = games.map((game) => ({


### PR DESCRIPTION
## Summary
- Convert `sitemap.ts` from sync to async
- Query `publishedGames` table (joined with `users` for clerkId) for all games with `status='published'`
- Include all `/play/[userId]/[slug]` URLs in the sitemap with `priority: 0.6` and `changeFrequency: 'weekly'`
- Graceful fallback to static pages only when DB is unavailable (CI/build environments)
- Updated sitemap tests to handle async function + DB mocking

Closes #8421 (GEO-003)

## Test plan
- [ ] `curl https://spawnforge.ai/sitemap.xml` includes published game URLs
- [ ] Sitemap still works correctly in CI without database access
- [ ] `npx vitest run src/app/__tests__/sitemap.test.ts` — 5 tests pass
- [ ] `npx tsc --noEmit` passes