### PR TITLE
feat: add FAQ and About pages with structured data

### DIFF
--- a/.changeset/seo-faq-about-pages.md
+++ b/.changeset/seo-faq-about-pages.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": minor
+---
+
+Add FAQ page with FAQPage JSON-LD schema and About page with product statistics, architecture overview, and entity establishment data

--- a/web/src/app/about/page.tsx
+++ b/web/src/app/about/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next';
+import { cacheLife, cacheTag } from 'next/cache';
+
+export const metadata: Metadata = {
+  title: 'About — SpawnForge',
+  description: 'SpawnForge is an AI-native browser-based 2D/3D game creation platform. Rust/WASM engine, WebGPU rendering, 350 MCP commands, visual scripting.',
+  alternates: { canonical: '/about' },
+  openGraph: {
+    title: 'About SpawnForge',
+    description: 'AI-native browser-based game engine — Rust/WASM, WebGPU, 350 MCP commands.',
+  },
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
+
+const stats = [
+  { label: 'MCP Commands', value: '350', detail: 'across 41 categories' },
+  { label: 'Visual Script Nodes', value: '73', detail: 'drag-and-drop logic' },
+  { label: 'Material Presets', value: '56', detail: 'PBR materials' },
+  { label: 'AI Modules', value: '25+', detail: 'specialized agents' },
+] as const;
+
+// Static JSON-LD (safe constant — no user input, no XSS risk)
+const aboutJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'AboutPage',
+  mainEntity: {
+    '@type': ['WebApplication', 'SoftwareApplication'],
+    name: 'SpawnForge',
+    url: SITE_URL,
+    applicationCategory: ['GameApplication', 'DeveloperApplication'],
+    operatingSystem: 'Web Browser',
+    description:
+      'AI-native browser-based 2D and 3D game creation platform. Rust engine compiled to WASM with WebGPU rendering, 350 MCP commands, and visual scripting.',
+  },
+});
+
+export default async function AboutPage() {
+  'use cache';
+  cacheLife('days');
+  cacheTag('about');
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+      {/* JSON-LD structured data — static constant, no user input */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: aboutJsonLd }}
+      />
+
+      <h1 className="mb-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        About SpawnForge
+      </h1>
+      <p className="mb-12 max-w-2xl text-lg text-zinc-300 leading-relaxed">
+        SpawnForge is an AI-native, browser-based game creation platform. Describe your game
+        in natural language and watch it come to life — or use the visual editor for
+        fine-grained control. No downloads, no installs.
+      </p>
+
+      {/* Stats grid */}
+      <div className="mb-16 grid grid-cols-2 gap-6 sm:grid-cols-4">
+        {stats.map((stat) => (
+          <div key={stat.label} className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-6 text-center">
+            <div className="text-3xl font-bold text-white">{stat.value}</div>
+            <div className="mt-1 text-sm font-medium text-zinc-300">{stat.label}</div>
+            <div className="mt-0.5 text-xs text-zinc-500">{stat.detail}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Architecture */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-semibold text-white">Architecture</h2>
+        <div className="space-y-3 text-zinc-300 leading-relaxed">
+          <p>
+            <strong className="text-white">Engine:</strong> Built in Rust using the Bevy 0.18 ECS
+            framework, compiled to WebAssembly via wasm-bindgen. The engine handles scene
+            management, physics (Rapier 3D and 2D), rendering, animation, particles, and audio
+            metadata — all at native speed in the browser.
+          </p>
+          <p>
+            <strong className="text-white">Rendering:</strong> WebGPU primary (wgpu 27) with
+            automatic WebGL2 fallback. Four binaries — two editor and two runtime variants —
+            ensure compatibility across Chrome, Firefox, Safari, and Edge.
+          </p>
+          <p>
+            <strong className="text-white">Editor:</strong> React shell (Next.js 16) with Zustand
+            state management and Tailwind CSS. JSON commands flow from the editor to the engine
+            via the wasm-bindgen bridge; events flow back through callbacks.
+          </p>
+          <p>
+            <strong className="text-white">AI:</strong> Multi-agent orchestration with 350 MCP
+            commands across 41 categories. AI generates 3D models, textures, sound effects,
+            music, and voice — then uses MCP commands to place and configure them in the scene.
+          </p>
+        </div>
+      </section>
+
+      {/* Key Capabilities */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-2xl font-semibold text-white">Key Capabilities</h2>
+        <ul className="grid gap-3 text-zinc-300 sm:grid-cols-2">
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            AI game creation from natural language
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Full 2D and 3D engine in the browser
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Visual scripting (73 node types)
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            TypeScript scripting with forge.* API
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            One-click browser game publishing
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            PBR materials (56 presets)
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Skeletal animation and GPU particles
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Rapier 3D and 2D physics simulation
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Tilemap editor and dialogue system
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" />
+            Economy designer and leaderboards
+          </li>
+        </ul>
+      </section>
+
+      {/* Positioning */}
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold text-white">How SpawnForge is Different</h2>
+        <div className="space-y-3 text-zinc-300 leading-relaxed">
+          <p>
+            Traditional game engines like Unity and Godot require desktop installation,
+            proprietary scripting languages, and complex build pipelines. SpawnForge runs
+            entirely in the browser — you can go from idea to published game without leaving
+            your browser tab.
+          </p>
+          <p>
+            Where other tools add AI as an afterthought, SpawnForge was built AI-first. The
+            entire engine is controllable through 350 MCP commands, making it the most
+            AI-accessible game engine available. AI is not a feature — it is the primary
+            creation interface.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/faq/page.tsx
+++ b/web/src/app/faq/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next';
+import { cacheLife, cacheTag } from 'next/cache';
+
+export const metadata: Metadata = {
+  title: 'FAQ — SpawnForge',
+  description: 'Frequently asked questions about SpawnForge — the AI-powered browser-based game creation platform.',
+  alternates: { canonical: '/faq' },
+  openGraph: {
+    title: 'FAQ — SpawnForge',
+    description: 'Frequently asked questions about SpawnForge.',
+  },
+};
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
+
+const faqs = [
+  {
+    question: 'What is SpawnForge?',
+    answer:
+      'SpawnForge is an AI-powered, browser-based 2D and 3D game creation platform. It lets you build games using natural language prompts or a visual editor — no downloads or installs required. The engine is built in Rust, compiled to WebAssembly, and renders via WebGPU with a WebGL2 fallback.',
+  },
+  {
+    question: 'Is SpawnForge free?',
+    answer:
+      'Yes. SpawnForge offers a free Starter tier with AI chat (limited), 1 published game, community templates, and basic export. Paid plans start at $9/month (Hobbyist) with unlimited AI chat and asset generation, up to $99/month (Pro) with team collaboration and API access.',
+  },
+  {
+    question: 'What browsers does SpawnForge support?',
+    answer:
+      'SpawnForge works in any modern browser. It uses WebGPU for primary rendering (Chrome 113+, Edge 113+, Firefox Nightly) and automatically falls back to WebGL2 for broader compatibility (Chrome 56+, Firefox 51+, Safari 15+, Edge 79+).',
+  },
+  {
+    question: 'Can I export games from SpawnForge?',
+    answer:
+      "Yes. You can publish games to a shareable URL with one click, or export them as standalone HTML/JS bundles that run anywhere. Published games are hosted on SpawnForge's CDN and playable at spawnforge.ai/play/[your-id]/[game-slug].",
+  },
+  {
+    question: 'Does SpawnForge support 3D games?',
+    answer:
+      'Yes. SpawnForge supports both 2D and 3D game development. 3D features include PBR materials (56 presets), skeletal animation, GPU particles, CSG boolean operations, procedural terrain, GLTF model import, and real-time Rapier 3D physics simulation.',
+  },
+  {
+    question: 'How does AI game creation work?',
+    answer:
+      'You describe what you want in natural language — for example, "create a platformer with a jumping character and moving platforms." Multi-agent AI interprets your prompt and executes commands to build the scene, add physics, configure scripting, generate assets, and set up game logic. You can then refine everything manually in the visual editor.',
+  },
+  {
+    question: 'What is MCP for game development?',
+    answer:
+      'MCP (Model Context Protocol) is the command interface between the AI and the game engine. SpawnForge exposes 350 MCP commands across 41 categories — from spawning entities and applying materials to configuring physics, audio, animation, scripting, and game components. This gives the AI precise, fine-grained control over every aspect of game creation.',
+  },
+  {
+    question: 'How does SpawnForge compare to Unity or Godot?',
+    answer:
+      'SpawnForge is browser-native (no download/install), AI-first (natural language game creation), and uses WebGPU rendering. Unlike Unity (C#) or Godot (GDScript), SpawnForge uses TypeScript scripting and visual scripting with 73 node types. It publishes games to the web with one click. The tradeoff: SpawnForge targets web games specifically, while Unity/Godot support native desktop and mobile builds.',
+  },
+] as const;
+
+// Static FAQPage JSON-LD (safe constant — no user input, no XSS risk)
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: faq.answer,
+    },
+  })),
+  url: `${SITE_URL}/faq`,
+});
+
+export default async function FaqPage() {
+  'use cache';
+  cacheLife('days');
+  cacheTag('faq');
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      {/* JSON-LD structured data — static constant, no user input */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: faqJsonLd }}
+      />
+      <h1 className="mb-2 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        Frequently Asked Questions
+      </h1>
+      <p className="mb-12 text-zinc-400">
+        Common questions about SpawnForge, the AI-powered game creation platform.
+      </p>
+      <dl className="space-y-8">
+        {faqs.map((faq) => (
+          <div key={faq.question} className="border-b border-zinc-800 pb-8 last:border-0">
+            <dt className="mb-3 text-lg font-semibold text-white">{faq.question}</dt>
+            <dd className="text-zinc-300 leading-relaxed">{faq.answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -53,5 +53,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "yearly",
       priority: 0.2,
     },
+    {
+      url: `${SITE_URL}/faq`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/about`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -131,6 +131,8 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     '/monitoring(.*)',
     '/llms.txt',
     '/llms-full.txt',
+    '/faq(.*)',
+    '/about(.*)',
   ];
   if (process.env.NODE_ENV !== 'production') {
     publicRoutes.push('/dev(.*)');


### PR DESCRIPTION
## Summary
- **SEO-005**: Create `/faq` page with 8 Q&A pairs covering common questions (what is SpawnForge, pricing, browser support, 3D support, AI creation, MCP, comparison). Includes `FAQPage` JSON-LD for Google rich results
- **SEO-008**: Create `/about` page with concrete statistics (350 MCP commands, 73 nodes, 56 materials, 25+ AI modules), architecture overview, capabilities list, and positioning statement. Includes `AboutPage` + `SoftwareApplication` JSON-LD
- Add `/faq` and `/about` to proxy public routes and sitemap
- Both pages use `'use cache'` + `cacheLife('days')` + `cacheTag()` pattern

Closes #8422 (SEO-005)
Closes #8425 (SEO-008)

## Test plan
- [ ] `/faq` accessible without auth
- [ ] `/about` accessible without auth
- [ ] FAQPage JSON-LD validates in Google Rich Results Test
- [ ] AboutPage JSON-LD validates in Google Rich Results Test
- [ ] Both pages have proper metadata (title, description, OG, canonical)
- [ ] `npx eslint --max-warnings 0 . && npx tsc --noEmit` passes