### PR TITLE
feat: breadcrumb navigation with BreadcrumbList schema (SEO-013)

### DIFF
--- a/.changeset/seo-breadcrumbs.md
+++ b/.changeset/seo-breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": minor
+---
+
+Add reusable Breadcrumbs component with BreadcrumbList JSON-LD schema and apply to pricing, community, and play pages

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { cacheLife, cacheTag } from 'next/cache';
 import { GalleryPage } from '@/components/community/GalleryPage';
+import { Breadcrumbs } from '@/components/marketing/Breadcrumbs';
 
 export const metadata: Metadata = {
   title: 'Community Gallery - SpawnForge',
@@ -16,5 +17,10 @@ export default async function CommunityPage() {
   'use cache';
   cacheLife('days');
   cacheTag('community');
-  return <GalleryPage />;
+  return (
+    <div className="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+      <Breadcrumbs items={[{ label: 'Community', href: '/community' }]} />
+      <GalleryPage />
+    </div>
+  );
 }

--- a/web/src/app/play/[userId]/[slug]/page.tsx
+++ b/web/src/app/play/[userId]/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { cache } from 'react';
 import { getDb, queryWithResilience } from '@/lib/db/client';
 import { publishedGames, users } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
@@ -12,17 +13,22 @@ interface PlayPageProps {
   params: Promise<{ userId: string; slug: string }>;
 }
 
-async function getGameTitle(clerkId: string, slug: string): Promise<string | null> {
+const getGameData = cache(async (clerkId: string, slug: string) => {
   try {
     const [user] = await queryWithResilience(() => getDb()
-      .select({ id: users.id })
+      .select({ id: users.id, displayName: users.displayName })
       .from(users)
       .where(eq(users.clerkId, clerkId))
       .limit(1));
     if (!user) return null;
 
     const [game] = await queryWithResilience(() => getDb()
-      .select({ title: publishedGames.title })
+      .select({
+        title: publishedGames.title,
+        description: publishedGames.description,
+        createdAt: publishedGames.createdAt,
+        status: publishedGames.status,
+      })
       .from(publishedGames)
       .where(
         and(
@@ -31,11 +37,19 @@ async function getGameTitle(clerkId: string, slug: string): Promise<string | nul
         )
       )
       .limit(1));
-    return game?.title ?? null;
+    if (!game) return null;
+
+    return {
+      title: game.title,
+      description: game.description,
+      createdAt: game.createdAt,
+      status: game.status,
+      authorName: user.displayName,
+    };
   } catch {
     return null;
   }
-}
+});
 
 /**
  * Generate dynamic metadata for the published game page.
@@ -45,84 +59,17 @@ export async function generateMetadata({
   params,
 }: PlayPageProps): Promise<Metadata> {
   const { userId: clerkId, slug } = await params;
+  const game = await getGameData(clerkId, slug);
 
-  try {
-    const [user] = await queryWithResilience(() => getDb()
-      .select({ id: users.id })
-      .from(users)
-      .where(eq(users.clerkId, clerkId))
-      .limit(1));
-
-    if (!user) {
-      return { title: 'Game Not Found - SpawnForge' };
-    }
-
-    const [game] = await queryWithResilience(() => getDb()
-      .select({ title: publishedGames.title, description: publishedGames.description })
-      .from(publishedGames)
-      .where(
-        and(
-          eq(publishedGames.userId, user.id),
-          eq(publishedGames.slug, slug)
-        )
-      )
-      .limit(1));
-
-    if (!game) {
-      return { title: 'Game Not Found - SpawnForge' };
-    }
-
-    return {
-      title: `${game.title} - SpawnForge`,
-      description: game.description || `Play ${game.title} on SpawnForge`,
-      alternates: { canonical: `/play/${clerkId}/${slug}` },
-    };
-  } catch {
-    return { title: 'SpawnForge' };
+  if (!game) {
+    return { title: 'Game Not Found - SpawnForge' };
   }
-}
 
-/**
- * Fetch game data for VideoGame JSON-LD.
- * Returns null if game not found or DB unavailable.
- */
-async function getGameData(clerkId: string, slug: string) {
-  try {
-    const [user] = await queryWithResilience(() => getDb()
-      .select({ id: users.id, displayName: users.displayName })
-      .from(users)
-      .where(eq(users.clerkId, clerkId))
-      .limit(1));
-
-    if (!user) return null;
-
-    const [game] = await queryWithResilience(() => getDb()
-      .select({
-        title: publishedGames.title,
-        description: publishedGames.description,
-        createdAt: publishedGames.createdAt,
-      })
-      .from(publishedGames)
-      .where(
-        and(
-          eq(publishedGames.userId, user.id),
-          eq(publishedGames.slug, slug),
-          eq(publishedGames.status, 'published')
-        )
-      )
-      .limit(1));
-
-    if (!game) return null;
-
-    return {
-      title: game.title,
-      description: game.description,
-      authorName: user.displayName,
-      createdAt: game.createdAt,
-    };
-  } catch {
-    return null;
-  }
+  return {
+    title: `${game.title} - SpawnForge`,
+    description: game.description || `Play ${game.title} on SpawnForge`,
+    alternates: { canonical: `/play/${clerkId}/${slug}` },
+  };
 }
 
 /**
@@ -133,32 +80,31 @@ async function getGameData(clerkId: string, slug: string) {
 export default async function PlayPage({ params }: PlayPageProps) {
   const { userId, slug } = await params;
   const { userId: viewerClerkId } = await safeAuth();
-  const gameTitle = await getGameTitle(userId, slug);
-
-  const gameData = await getGameData(userId, slug);
+  const game = await getGameData(userId, slug);
 
   // VideoGame JSON-LD — user-controlled values from DB (title, description).
   // JSON.stringify does NOT escape '<', so we replace it with < to
   // prevent script tag breakout (XSS via </script> in user content).
-  const videoGameJsonLd = gameData
+  // Only emitted for published games; drafts have no public schema.
+  const videoGameJsonLd = game && game.status === 'published'
     ? JSON.stringify({
         '@context': 'https://schema.org',
         '@type': 'VideoGame',
-        name: gameData.title,
-        description: gameData.description || `Play ${gameData.title} on SpawnForge`,
+        name: game.title,
+        description: game.description || `Play ${game.title} on SpawnForge`,
         url: `${SITE_URL}/play/${userId}/${slug}`,
         gamePlatform: 'Web Browser',
         playMode: 'SinglePlayer',
         applicationCategory: 'Game',
-        author: gameData.authorName
-          ? { '@type': 'Person', name: gameData.authorName }
+        author: game.authorName
+          ? { '@type': 'Person', name: game.authorName }
           : undefined,
         publisher: {
           '@type': 'Organization',
           name: 'SpawnForge',
           url: SITE_URL,
         },
-        datePublished: gameData.createdAt?.toISOString(),
+        datePublished: game.createdAt?.toISOString(),
       }).replace(/</g, '\\u003c')
     : null;
 
@@ -173,9 +119,9 @@ export default async function PlayPage({ params }: PlayPageProps) {
       <div className="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">
         <Breadcrumbs
           items={[
-            { label: 'Play', href: '/community' },
-            ...(gameTitle
-              ? [{ label: gameTitle, href: `/play/${userId}/${slug}` }]
+            { label: 'Community', href: '/community' },
+            ...(game?.title
+              ? [{ label: game.title, href: `/play/${userId}/${slug}` }]
               : []),
           ]}
         />

--- a/web/src/app/play/[userId]/[slug]/page.tsx
+++ b/web/src/app/play/[userId]/[slug]/page.tsx
@@ -4,11 +4,37 @@ import { publishedGames, users } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { safeAuth } from '@/lib/auth/safe-auth';
 import { GamePlayer } from '@/components/play/GamePlayer';
+import { Breadcrumbs } from '@/components/marketing/Breadcrumbs';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
 
 interface PlayPageProps {
   params: Promise<{ userId: string; slug: string }>;
+}
+
+async function getGameTitle(clerkId: string, slug: string): Promise<string | null> {
+  try {
+    const [user] = await queryWithResilience(() => getDb()
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.clerkId, clerkId))
+      .limit(1));
+    if (!user) return null;
+
+    const [game] = await queryWithResilience(() => getDb()
+      .select({ title: publishedGames.title })
+      .from(publishedGames)
+      .where(
+        and(
+          eq(publishedGames.userId, user.id),
+          eq(publishedGames.slug, slug)
+        )
+      )
+      .limit(1));
+    return game?.title ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -107,6 +133,7 @@ async function getGameData(clerkId: string, slug: string) {
 export default async function PlayPage({ params }: PlayPageProps) {
   const { userId, slug } = await params;
   const { userId: viewerClerkId } = await safeAuth();
+  const gameTitle = await getGameTitle(userId, slug);
 
   const gameData = await getGameData(userId, slug);
 
@@ -143,6 +170,16 @@ export default async function PlayPage({ params }: PlayPageProps) {
           dangerouslySetInnerHTML={{ __html: videoGameJsonLd }}
         />
       )}
+      <div className="mx-auto max-w-7xl px-4 pt-4 sm:px-6 lg:px-8">
+        <Breadcrumbs
+          items={[
+            { label: 'Play', href: '/community' },
+            ...(gameTitle
+              ? [{ label: gameTitle, href: `/play/${userId}/${slug}` }]
+              : []),
+          ]}
+        />
+      </div>
       <GamePlayer
         userId={userId}
         slug={slug}

--- a/web/src/app/play/[userId]/[slug]/page.tsx
+++ b/web/src/app/play/[userId]/[slug]/page.tsx
@@ -27,13 +27,13 @@ const getGameData = cache(async (clerkId: string, slug: string) => {
         title: publishedGames.title,
         description: publishedGames.description,
         createdAt: publishedGames.createdAt,
-        status: publishedGames.status,
       })
       .from(publishedGames)
       .where(
         and(
           eq(publishedGames.userId, user.id),
-          eq(publishedGames.slug, slug)
+          eq(publishedGames.slug, slug),
+          eq(publishedGames.status, 'published')
         )
       )
       .limit(1));
@@ -43,7 +43,6 @@ const getGameData = cache(async (clerkId: string, slug: string) => {
       title: game.title,
       description: game.description,
       createdAt: game.createdAt,
-      status: game.status,
       authorName: user.displayName,
     };
   } catch {
@@ -85,8 +84,8 @@ export default async function PlayPage({ params }: PlayPageProps) {
   // VideoGame JSON-LD — user-controlled values from DB (title, description).
   // JSON.stringify does NOT escape '<', so we replace it with < to
   // prevent script tag breakout (XSS via </script> in user content).
-  // Only emitted for published games; drafts have no public schema.
-  const videoGameJsonLd = game && game.status === 'published'
+  // getGameData filters for status='published', so drafts return null.
+  const videoGameJsonLd = game
     ? JSON.stringify({
         '@context': 'https://schema.org',
         '@type': 'VideoGame',

--- a/web/src/app/pricing/page.tsx
+++ b/web/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { cacheLife, cacheTag } from 'next/cache';
 import { PricingPage } from '@/components/pricing/PricingPage';
+import { Breadcrumbs } from '@/components/marketing/Breadcrumbs';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
 
@@ -76,7 +77,10 @@ export default async function Pricing() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: pricingJsonLd }}
       />
-      <PricingPage />
+      <div className="mx-auto max-w-7xl px-4 pt-8 sm:px-6 lg:px-8">
+        <Breadcrumbs items={[{ label: 'Pricing', href: '/pricing' }]} />
+        <PricingPage />
+      </div>
     </>
   );
 }

--- a/web/src/components/marketing/Breadcrumbs.tsx
+++ b/web/src/components/marketing/Breadcrumbs.tsx
@@ -14,6 +14,8 @@ interface BreadcrumbsProps {
 export function Breadcrumbs({ items }: BreadcrumbsProps) {
   const allItems: BreadcrumbItem[] = [{ label: 'Home', href: '/' }, ...items];
 
+  // Escape '<' as '\u003c' to prevent script tag breakout XSS when
+  // breadcrumb labels contain user-controlled data (e.g. game titles).
   const jsonLd = JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
@@ -23,7 +25,7 @@ export function Breadcrumbs({ items }: BreadcrumbsProps) {
       name: item.label,
       item: `${SITE_URL}${item.href}`,
     })),
-  });
+  }).replace(/</g, '\\u003c');
 
   return (
     <>

--- a/web/src/components/marketing/Breadcrumbs.tsx
+++ b/web/src/components/marketing/Breadcrumbs.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
+
+export interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+interface BreadcrumbsProps {
+  items: BreadcrumbItem[];
+}
+
+export function Breadcrumbs({ items }: BreadcrumbsProps) {
+  const allItems: BreadcrumbItem[] = [{ label: 'Home', href: '/' }, ...items];
+
+  const jsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: allItems.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.label,
+      item: `${SITE_URL}${item.href}`,
+    })),
+  });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
+      <nav aria-label="Breadcrumb" className="mb-6">
+        <ol className="flex flex-wrap items-center gap-1 text-sm text-zinc-400">
+          {allItems.map((item, index) => {
+            const isLast = index === allItems.length - 1;
+            return (
+              <li key={item.href} className="flex items-center gap-1">
+                {index > 0 && (
+                  <span aria-hidden="true" className="text-zinc-600">/</span>
+                )}
+                {isLast ? (
+                  <span aria-current="page" className="text-zinc-200">
+                    {item.label}
+                  </span>
+                ) : (
+                  <Link
+                    href={item.href}
+                    className="hover:text-orange-400 transition-colors"
+                  >
+                    {item.label}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+    </>
+  );
+}

--- a/web/src/components/marketing/__tests__/Breadcrumbs.test.tsx
+++ b/web/src/components/marketing/__tests__/Breadcrumbs.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { Breadcrumbs } from '../Breadcrumbs';
+
+// Stub next/link to plain <a> for test rendering
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+describe('Breadcrumbs', () => {
+  it('renders Home plus provided items', () => {
+    const { getByText } = render(
+      <Breadcrumbs items={[{ label: 'Pricing', href: '/pricing' }]} />
+    );
+
+    expect(getByText('Home')).toBeDefined();
+    expect(getByText('Pricing')).toBeDefined();
+  });
+
+  it('marks the last item as current page', () => {
+    const { getByText } = render(
+      <Breadcrumbs items={[{ label: 'Blog', href: '/blog' }]} />
+    );
+
+    const lastItem = getByText('Blog');
+    expect(lastItem.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('escapes < in JSON-LD to prevent script injection', () => {
+    const { container } = render(
+      <Breadcrumbs items={[{ label: '<script>alert(1)</script>', href: '/xss' }]} />
+    );
+
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script).toBeDefined();
+    const content = script!.innerHTML;
+
+    // Raw '<' must not appear — replaced with \u003c
+    expect(content).not.toContain('<script>');
+    expect(content).toContain('\\u003c');
+  });
+
+  it('generates valid BreadcrumbList JSON-LD', () => {
+    const { container } = render(
+      <Breadcrumbs items={[{ label: 'Docs', href: '/docs' }]} />
+    );
+
+    const script = container.querySelector('script[type="application/ld+json"]');
+    // The content has \u003c escaping which is valid JSON
+    const raw = script!.innerHTML.replace(/\\u003c/g, '<');
+    const jsonLd = JSON.parse(raw);
+
+    expect(jsonLd['@type']).toBe('BreadcrumbList');
+    expect(jsonLd.itemListElement).toHaveLength(2); // Home + Docs
+    expect(jsonLd.itemListElement[0].name).toBe('Home');
+    expect(jsonLd.itemListElement[1].name).toBe('Docs');
+  });
+});


### PR DESCRIPTION
## Summary
- Create reusable `Breadcrumbs` component at `web/src/components/marketing/Breadcrumbs.tsx`
- Includes BreadcrumbList JSON-LD structured data for rich search results
- Semantic HTML: `<nav aria-label="Breadcrumb">`, `<ol>`, `aria-current="page"`
- Applied to pricing, community, and play pages
- Play page breadcrumbs include dynamic game title from DB
- Other pages (compare, faq, about, blog) can adopt as their PRs land

Closes #8430

## Test plan
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly
- [ ] Visual verification: breadcrumbs render on /pricing, /community
- [ ] Play page shows "Home / Play / Game Title" breadcrumb trail
- [ ] BreadcrumbList JSON-LD validates in Google Rich Results Test