### PR TITLE
feat: public changelog page (SEO-014)

### DIFF
--- a/.changeset/seo-changelog-page.md
+++ b/.changeset/seo-changelog-page.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": minor
+---
+
+Add public changelog page at /changelog rendering CHANGELOG.md content with styled release cards

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -71,6 +71,11 @@ const nextConfig: NextConfig = {
     // cache-eligible components to declare cacheTag() and cacheLife() hints
     // so Next.js can skip re-rendering on subsequent requests.
     useCache: true,
+    // Include CHANGELOG.md in the serverless function bundle so the
+    // changelog page can read it at runtime (cache revalidation).
+    outputFileTracingIncludes: {
+      '/changelog': ['../CHANGELOG.md'],
+    },
   },
   images: {
     remotePatterns: [

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -71,11 +71,12 @@ const nextConfig: NextConfig = {
     // cache-eligible components to declare cacheTag() and cacheLife() hints
     // so Next.js can skip re-rendering on subsequent requests.
     useCache: true,
-    // Include CHANGELOG.md in the serverless function bundle so the
-    // changelog page can read it at runtime (cache revalidation).
-    outputFileTracingIncludes: {
-      '/changelog': ['../CHANGELOG.md'],
-    },
+  },
+  // Include CHANGELOG.md in the serverless function bundle so the
+  // changelog page can read it at runtime (cache revalidation).
+  // Top-level in Next.js 15+ (moved out of experimental).
+  outputFileTracingIncludes: {
+    '/changelog': ['../CHANGELOG.md'],
   },
   images: {
     remotePatterns: [

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -16,7 +16,6 @@ export const metadata: Metadata = {
 function renderContent(lines: string[]) {
   const elements: React.ReactNode[] = [];
   let listItems: string[] = [];
-  let subheading: string | null = null;
 
   const flushList = () => {
     if (listItems.length > 0) {
@@ -34,10 +33,10 @@ function renderContent(lines: string[]) {
   for (const line of lines) {
     if (line.startsWith('### ')) {
       flushList();
-      subheading = line.replace('### ', '');
+      const heading = line.replace('### ', '');
       elements.push(
         <h3 key={`h3-${elements.length}`} className="mb-2 mt-4 text-sm font-semibold uppercase tracking-wider text-orange-400">
-          {subheading}
+          {heading}
         </h3>
       );
     } else if (line.startsWith('- ')) {
@@ -45,6 +44,13 @@ function renderContent(lines: string[]) {
       listItems.push(text);
     } else if (line.trim() === '') {
       flushList();
+    } else {
+      flushList();
+      elements.push(
+        <p key={`p-${elements.length}`} className="mb-3 text-zinc-300">
+          {line}
+        </p>
+      );
     }
   }
   flushList();

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import { cacheLife, cacheTag } from 'next/cache';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { readChangelog } from '@/lib/changelog';
 
 export const metadata: Metadata = {
   title: 'Changelog — SpawnForge',
@@ -13,23 +12,6 @@ export const metadata: Metadata = {
     description: 'Track every SpawnForge release — features, fixes, and improvements.',
   },
 };
-
-function parseChangelog(markdown: string) {
-  const lines = markdown.split('\n');
-  const sections: { heading: string; content: string[] }[] = [];
-  let current: { heading: string; content: string[] } | null = null;
-
-  for (const line of lines) {
-    if (line.startsWith('## ')) {
-      if (current) sections.push(current);
-      current = { heading: line.replace('## ', ''), content: [] };
-    } else if (current) {
-      current.content.push(line);
-    }
-  }
-  if (current) sections.push(current);
-  return sections;
-}
 
 function renderContent(lines: string[]) {
   const elements: React.ReactNode[] = [];
@@ -74,16 +56,7 @@ export default async function ChangelogPage() {
   cacheLife('days');
   cacheTag('changelog');
 
-  let sections: { heading: string; content: string[] }[] = [];
-  try {
-    const changelogPath = join(process.cwd(), '..', 'CHANGELOG.md');
-    const raw = readFileSync(changelogPath, 'utf-8');
-    sections = parseChangelog(raw).filter(
-      (s) => s.content.some((line) => line.trim() !== '')
-    );
-  } catch {
-    // Fallback: file not found in CI/build
-  }
+  const sections = readChangelog();
 
   return (
     <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -1,0 +1,111 @@
+import type { Metadata } from 'next';
+import { cacheLife, cacheTag } from 'next/cache';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const metadata: Metadata = {
+  title: 'Changelog — SpawnForge',
+  description:
+    'See what has changed in SpawnForge — new features, fixes, and improvements.',
+  alternates: { canonical: '/changelog' },
+  openGraph: {
+    title: 'SpawnForge Changelog',
+    description: 'Track every SpawnForge release — features, fixes, and improvements.',
+  },
+};
+
+function parseChangelog(markdown: string) {
+  const lines = markdown.split('\n');
+  const sections: { heading: string; content: string[] }[] = [];
+  let current: { heading: string; content: string[] } | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      if (current) sections.push(current);
+      current = { heading: line.replace('## ', ''), content: [] };
+    } else if (current) {
+      current.content.push(line);
+    }
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+function renderContent(lines: string[]) {
+  const elements: React.ReactNode[] = [];
+  let listItems: string[] = [];
+  let subheading: string | null = null;
+
+  const flushList = () => {
+    if (listItems.length > 0) {
+      elements.push(
+        <ul key={`list-${elements.length}`} className="mb-4 list-disc space-y-1 pl-6 text-zinc-300">
+          {listItems.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      );
+      listItems = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      flushList();
+      subheading = line.replace('### ', '');
+      elements.push(
+        <h3 key={`h3-${elements.length}`} className="mb-2 mt-4 text-sm font-semibold uppercase tracking-wider text-orange-400">
+          {subheading}
+        </h3>
+      );
+    } else if (line.startsWith('- ')) {
+      const text = line.replace(/^- \*\*(.*?)\*\*:?\s*/, '$1: ').replace(/^- /, '');
+      listItems.push(text);
+    } else if (line.trim() === '') {
+      flushList();
+    }
+  }
+  flushList();
+  return elements;
+}
+
+export default async function ChangelogPage() {
+  'use cache';
+  cacheLife('days');
+  cacheTag('changelog');
+
+  let sections: { heading: string; content: string[] }[] = [];
+  try {
+    const changelogPath = join(process.cwd(), '..', 'CHANGELOG.md');
+    const raw = readFileSync(changelogPath, 'utf-8');
+    sections = parseChangelog(raw);
+  } catch {
+    // Fallback: file not found in CI/build
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="mb-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        Changelog
+      </h1>
+      <p className="mb-12 text-lg text-zinc-300">
+        Track every SpawnForge release — features, fixes, and improvements.
+      </p>
+
+      {sections.length === 0 ? (
+        <p className="text-zinc-400">No changelog entries yet.</p>
+      ) : (
+        <div className="space-y-10">
+          {sections.map((section) => (
+            <div key={section.heading} className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-6">
+              <h2 className="mb-4 text-xl font-semibold text-white">
+                {section.heading}
+              </h2>
+              {renderContent(section.content)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -78,7 +78,9 @@ export default async function ChangelogPage() {
   try {
     const changelogPath = join(process.cwd(), '..', 'CHANGELOG.md');
     const raw = readFileSync(changelogPath, 'utf-8');
-    sections = parseChangelog(raw);
+    sections = parseChangelog(raw).filter(
+      (s) => s.content.some((line) => line.trim() !== '')
+    );
   } catch {
     // Fallback: file not found in CI/build
   }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -92,6 +92,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly" as const,
       priority: 0.6,
     })),
+    {
+      url: `${SITE_URL}/changelog`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.5,
+    },
   ];
 
   // Query published games for dynamic sitemap entries

--- a/web/src/lib/__tests__/changelog.test.ts
+++ b/web/src/lib/__tests__/changelog.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment node
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseChangelog } from '../changelog';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => ''),
+  };
+});
+
+import { existsSync, readFileSync } from 'node:fs';
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+describe('parseChangelog', () => {
+  it('splits markdown into sections by ## headings', () => {
+    const md = '## 1.0.0\n- Feature A\n\n## 0.9.0\n- Feature B\n';
+    const sections = parseChangelog(md);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('1.0.0');
+    expect(sections[1].heading).toBe('0.9.0');
+  });
+
+  it('captures content lines under each section', () => {
+    const md = '## 1.0.0\n### Added\n- Feature A\n- Feature B\n';
+    const sections = parseChangelog(md);
+
+    expect(sections[0].content).toContain('### Added');
+    expect(sections[0].content).toContain('- Feature A');
+    expect(sections[0].content).toContain('- Feature B');
+  });
+
+  it('skips lines before the first ## heading', () => {
+    const md = '# Changelog\n\nSome intro text.\n\n## 1.0.0\n- Fix\n';
+    const sections = parseChangelog(md);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('1.0.0');
+  });
+
+  it('returns empty array for markdown with no ## headings', () => {
+    const md = '# Title\nJust text.';
+    const sections = parseChangelog(md);
+
+    expect(sections).toHaveLength(0);
+  });
+
+  it('handles empty content sections', () => {
+    const md = '## [Unreleased]\n\n## 1.0.0\n- Fix\n';
+    const sections = parseChangelog(md);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].heading).toBe('[Unreleased]');
+    expect(sections[0].content).toEqual(['']);
+  });
+});
+
+describe('readChangelog', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockExistsSync.mockReset().mockReturnValue(false);
+    mockReadFileSync.mockReset().mockReturnValue('');
+  });
+
+  it('returns parsed sections when file exists', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('## 1.0.0\n### Added\n- Cool feature\n');
+
+    const { readChangelog } = await import('../changelog');
+    const sections = readChangelog();
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('1.0.0');
+  });
+
+  it('returns empty array when no changelog file found', async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const { readChangelog } = await import('../changelog');
+    const sections = readChangelog();
+    expect(sections).toHaveLength(0);
+  });
+
+  it('filters out sections with only whitespace content', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      '## [Unreleased]\n\n## 1.0.0\n- Real content\n'
+    );
+
+    const { readChangelog } = await import('../changelog');
+    const sections = readChangelog();
+    expect(sections).toHaveLength(1);
+    expect(sections[0].heading).toBe('1.0.0');
+  });
+});

--- a/web/src/lib/changelog.ts
+++ b/web/src/lib/changelog.ts
@@ -1,0 +1,49 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ChangelogSection {
+  heading: string;
+  content: string[];
+}
+
+export function parseChangelog(markdown: string): ChangelogSection[] {
+  const lines = markdown.split('\n');
+  const sections: ChangelogSection[] = [];
+  let current: ChangelogSection | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      if (current) sections.push(current);
+      current = { heading: line.replace('## ', ''), content: [] };
+    } else if (current) {
+      current.content.push(line);
+    }
+  }
+  if (current) sections.push(current);
+  return sections;
+}
+
+export function readChangelog(): ChangelogSection[] {
+  // Try multiple paths: Vercel rootDirectory=web puts cwd at web/,
+  // so ../CHANGELOG.md reaches the repo root. Also try cwd itself
+  // for monorepo setups where cwd is the repo root.
+  const candidates = [
+    join(process.cwd(), '..', 'CHANGELOG.md'),
+    join(process.cwd(), 'CHANGELOG.md'),
+  ];
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      try {
+        const raw = readFileSync(candidate, 'utf-8');
+        return parseChangelog(raw).filter(
+          (s) => s.content.some((line) => line.trim() !== '')
+        );
+      } catch {
+        // File exists but can't be read — try next candidate
+      }
+    }
+  }
+
+  return [];
+}

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -135,6 +135,7 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     '/about(.*)',
     '/compare(.*)',
     '/use-cases(.*)',
+    '/changelog(.*)',
   ];
   if (process.env.NODE_ENV !== 'production') {
     publicRoutes.push('/dev(.*)');


### PR DESCRIPTION
## Summary
- Add `/changelog` page that reads and renders `CHANGELOG.md` at build time
- Server component with markdown parser — renders release sections as styled cards
- Graceful fallback when file isn't available (CI/build environments)
- Added `/changelog(.*)` to proxy public routes
- Added to sitemap with weekly change frequency

Closes #8431

## Test plan
- [x] ESLint passes with zero warnings
- [x] TypeScript compiles cleanly
- [ ] Visual verification: `/changelog` displays release entries
- [ ] Verify graceful fallback when CHANGELOG.md is missing