### PR TITLE
feat: blog infrastructure with index, per-post pages, RSS feed (SEO-010)

### DIFF
--- a/.changeset/seo-blog-infrastructure.md
+++ b/.changeset/seo-blog-infrastructure.md
@@ -1,0 +1,5 @@
+---
+"spawnforge-web": minor
+---
+
+Add blog infrastructure with index page, per-post pages with BlogPosting JSON-LD, RSS feed, and 2 initial posts

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -13,6 +13,8 @@ const contentComponents: Record<string, React.ComponentType> = {
   'spawnforge-vs-unity-vs-godot': SpawnForgeVsUnityVsGodot,
 };
 
+export const dynamicParams = false;
+
 export function generateStaticParams() {
   return getAllBlogSlugs().map((slug) => ({ slug }));
 }

--- a/web/src/app/blog/[slug]/page.tsx
+++ b/web/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from 'next';
+import { cacheLife, cacheTag } from 'next/cache';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getBlogPost, getAllBlogSlugs } from '@/lib/blog';
+import SpawnForgeBrowserAiGameEngine from '../content/spawnforge-browser-ai-game-engine';
+import SpawnForgeVsUnityVsGodot from '../content/spawnforge-vs-unity-vs-godot';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
+
+const contentComponents: Record<string, React.ComponentType> = {
+  'spawnforge-browser-ai-game-engine': SpawnForgeBrowserAiGameEngine,
+  'spawnforge-vs-unity-vs-godot': SpawnForgeVsUnityVsGodot,
+};
+
+export function generateStaticParams() {
+  return getAllBlogSlugs().map((slug) => ({ slug }));
+}
+
+interface BlogPostPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getBlogPost(slug);
+  if (!post) return { title: 'Not Found — SpawnForge' };
+
+  return {
+    title: post.title,
+    description: post.description,
+    alternates: { canonical: `/blog/${slug}` },
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      type: 'article',
+      publishedTime: post.date,
+      authors: [post.author],
+    },
+  };
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  'use cache';
+  cacheLife('days');
+  cacheTag('blog');
+
+  const { slug } = await params;
+  const post = getBlogPost(slug);
+  if (!post) notFound();
+
+  const Content = contentComponents[slug];
+  if (!Content) notFound();
+
+  // Static JSON-LD from static blog metadata — no user input, safe for injection
+  const jsonLd = JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.description,
+    datePublished: post.date,
+    author: {
+      '@type': 'Organization',
+      name: post.author,
+      url: SITE_URL,
+    },
+    publisher: {
+      '@type': 'Organization',
+      name: 'SpawnForge',
+      url: SITE_URL,
+    },
+    url: `${SITE_URL}/blog/${slug}`,
+    mainEntityOfPage: `${SITE_URL}/blog/${slug}`,
+  });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd }}
+      />
+      <article className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+        <Link
+          href="/blog"
+          className="mb-8 inline-flex items-center text-sm text-zinc-400 hover:text-orange-400"
+        >
+          &larr; All posts
+        </Link>
+
+        <header className="mb-10">
+          <h1 className="mb-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            {post.title}
+          </h1>
+          <div className="flex items-center gap-3 text-sm text-zinc-500">
+            <time dateTime={post.date}>
+              {new Date(post.date).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </time>
+            <span>&middot;</span>
+            <span>{post.readingTime}</span>
+            <span>&middot;</span>
+            <span>{post.author}</span>
+          </div>
+        </header>
+
+        <div className="prose prose-invert prose-zinc max-w-none prose-headings:font-semibold prose-headings:tracking-tight prose-a:text-orange-400 prose-a:no-underline hover:prose-a:underline prose-code:rounded prose-code:bg-zinc-800 prose-code:px-1 prose-code:py-0.5 prose-code:text-orange-300">
+          <Content />
+        </div>
+      </article>
+    </>
+  );
+}

--- a/web/src/app/blog/content/spawnforge-browser-ai-game-engine.tsx
+++ b/web/src/app/blog/content/spawnforge-browser-ai-game-engine.tsx
@@ -1,0 +1,94 @@
+export default function SpawnForgeBrowserAiGameEngine() {
+  return (
+    <>
+      <p>
+        Game development has traditionally required downloading large IDEs, learning complex
+        programming languages, and wrestling with build pipelines. SpawnForge takes a different
+        approach: everything happens in your browser.
+      </p>
+
+      <h2>What is SpawnForge?</h2>
+      <p>
+        SpawnForge is an AI-native 2D/3D game engine built for the browser. It combines a
+        Bevy-based Rust/WebAssembly rendering engine with a React visual editor and 350 MCP
+        (Model Context Protocol) commands. You can create games through natural language
+        descriptions, visual scripting, or traditional code.
+      </p>
+
+      <h2>Browser-Native Architecture</h2>
+      <p>
+        Under the hood, SpawnForge uses WebGPU for primary rendering with automatic WebGL2
+        fallback for older browsers. The engine is written in Rust and compiled to WebAssembly,
+        giving near-native performance without plugins or downloads. The editor shell is built
+        with Next.js and React, providing a modern, responsive interface.
+      </p>
+      <p>
+        This architecture means there is zero setup friction. Open a URL, start creating. Your
+        first entity can exist in under 30 seconds.
+      </p>
+
+      <h2>AI-First Design</h2>
+      <p>
+        SpawnForge was built with AI integration from day one, not bolted on afterward.
+        Every engine operation is a JSON command through a single <code>handle_command()</code> entry
+        point. This means the visual editor and AI agents use the exact same API — there is no
+        separate &ldquo;AI mode.&rdquo;
+      </p>
+      <p>
+        The built-in chat panel lets you describe what you want in plain language. The AI executes
+        compound actions — spawning entities, configuring materials, writing scripts — iterating
+        across multiple turns until the scene matches your description. 25+ AI modules handle
+        everything from scene generation to asset creation.
+      </p>
+
+      <h2>350 MCP Commands</h2>
+      <p>
+        The Model Context Protocol (MCP) server exposes 350 commands across 41 categories. Any
+        MCP-compatible agent or LLM can create scenes, configure physics, write game scripts, and
+        export finished games — all without touching the UI.
+      </p>
+      <p>
+        Categories span the full engine: transforms, materials, physics, audio, animation,
+        particles, tilemaps, scripting, game components, and more. The commands are documented at{' '}
+        <a href="https://docs.spawnforge.ai/mcp" className="text-orange-400 hover:underline">
+          docs.spawnforge.ai/mcp
+        </a>.
+      </p>
+
+      <h2>Visual Scripting</h2>
+      <p>
+        For creators who prefer a visual approach, SpawnForge includes a React Flow-based node
+        graph editor with 73 node types across 10 categories. Non-programmers create game logic
+        by connecting visual blocks, which compile to TypeScript. The visual scripting system
+        covers variables, conditions, loops, events, physics interactions, and more.
+      </p>
+
+      <h2>Full Engine Capabilities</h2>
+      <p>SpawnForge is not a toy or a prototyping tool. The engine includes:</p>
+      <ul>
+        <li>PBR materials with 56 presets across 9 categories</li>
+        <li>2D and 3D physics powered by Rapier</li>
+        <li>Spatial audio with bus mixing, reverb zones, and adaptive music</li>
+        <li>GPU particle effects with 9 presets</li>
+        <li>Skeletal animation, keyframe animation, and glTF import</li>
+        <li>CSG boolean operations and procedural terrain</li>
+        <li>Tilemap editor for 2D games</li>
+        <li>TypeScript scripting sandbox with 14+ API namespaces</li>
+      </ul>
+
+      <h2>Publish Instantly</h2>
+      <p>
+        One click publishes your game to a shareable URL on spawnforge.ai. Players load and play
+        directly in the browser. You can also export as a standalone ZIP with PWA support for
+        platforms like itch.io.
+      </p>
+
+      <h2>Getting Started</h2>
+      <p>
+        SpawnForge offers a free tier with no credit card required. Sign up, open the editor, and
+        start building. The Starter bundle system provides 11 pre-configured game skeletons
+        (Platformer, Shooter, Runner, Puzzle, and more) to get you building in seconds.
+      </p>
+    </>
+  );
+}

--- a/web/src/app/blog/content/spawnforge-vs-unity-vs-godot.tsx
+++ b/web/src/app/blog/content/spawnforge-vs-unity-vs-godot.tsx
@@ -1,0 +1,156 @@
+export default function SpawnForgeVsUnityVsGodot() {
+  return (
+    <>
+      <p>
+        Choosing a game engine is one of the most consequential decisions in game development.
+        This guide compares SpawnForge, Unity, and Godot across the dimensions that matter
+        most: setup, learning curve, AI capabilities, web support, and cost.
+      </p>
+
+      <h2>Setup and Getting Started</h2>
+      <p>
+        <strong>SpawnForge</strong> runs entirely in the browser. Open a URL, sign up, and start
+        building. No download, no IDE configuration, no build system setup. First entity in
+        under 30 seconds.
+      </p>
+      <p>
+        <strong>Unity</strong> requires downloading Unity Hub (~1GB), installing an editor
+        version (~3-5GB), creating a project, and configuring build settings. Expect 15-30 minutes
+        before your first build.
+      </p>
+      <p>
+        <strong>Godot</strong> is lighter — a single ~40MB executable download. Create a project,
+        learn the node system, and start building. Roughly 5-10 minutes to first scene.
+      </p>
+
+      <h2>Programming Languages</h2>
+      <p>
+        <strong>SpawnForge:</strong> Natural language (describe what you want), visual scripting
+        (73 node types), or TypeScript. All three approaches use the same engine API.
+      </p>
+      <p>
+        <strong>Unity:</strong> C# exclusively. Unity-specific APIs require learning the
+        component system, lifecycle methods, and editor workflow.
+      </p>
+      <p>
+        <strong>Godot:</strong> GDScript (Python-like, purpose-built), C#, or C++ via
+        GDExtension. GDScript is the primary and best-supported option.
+      </p>
+
+      <h2>AI Integration</h2>
+      <p>
+        <strong>SpawnForge:</strong> 25+ AI modules built into the editor from day one. 350 MCP
+        commands let any LLM drive the full engine. AI generates 3D models, textures, sound
+        effects, voice lines, and music. The chat panel executes multi-turn compound actions.
+      </p>
+      <p>
+        <strong>Unity:</strong> Unity Muse provides AI-assisted coding suggestions and texture
+        generation. Separate subscription required. Not integrated into the core workflow.
+      </p>
+      <p>
+        <strong>Godot:</strong> No built-in AI features. Community plugins exist for code
+        completion, but nothing approaching full scene generation or asset creation.
+      </p>
+
+      <h2>Web Export and Browser Support</h2>
+      <p>
+        <strong>SpawnForge:</strong> Games run in the browser by default — it is the native
+        platform. WebGPU primary rendering with WebGL2 fallback. One-click publish to a
+        shareable URL.
+      </p>
+      <p>
+        <strong>Unity:</strong> WebGL build target available but produces large bundles (often
+        50-100MB+), requires long compile times, and has limited API support. No WebGPU export.
+      </p>
+      <p>
+        <strong>Godot:</strong> HTML5 export exists but is experimental. Binary sizes are large,
+        and some features are unavailable. Web is not the primary target.
+      </p>
+
+      <h2>Rendering</h2>
+      <p>
+        <strong>SpawnForge:</strong> WebGPU (via wgpu 27) with automatic WebGL2 fallback. PBR
+        materials, GPU particles, skeletal animation, post-processing. Optimized for browser
+        delivery.
+      </p>
+      <p>
+        <strong>Unity:</strong> Industry-leading rendering with HDRP, URP, and built-in pipelines.
+        Ray tracing support on desktop. WebGL export uses older rendering path.
+      </p>
+      <p>
+        <strong>Godot:</strong> Vulkan renderer (forward+ and mobile), OpenGL 3.3 fallback,
+        and a software renderer. Strong for desktop, limited for web.
+      </p>
+
+      <h2>Pricing</h2>
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-zinc-700">
+            <th className="py-2 pr-4 font-medium text-zinc-400">Engine</th>
+            <th className="py-2 pr-4 font-medium text-zinc-400">Free Tier</th>
+            <th className="py-2 font-medium text-zinc-400">Paid Plans</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="border-b border-zinc-800">
+            <td className="py-2 pr-4 text-orange-400">SpawnForge</td>
+            <td className="py-2 pr-4 text-zinc-300">Yes, with AI credits</td>
+            <td className="py-2 text-zinc-300">$9/mo Starter, $29/mo Pro, $99/mo Studio</td>
+          </tr>
+          <tr className="border-b border-zinc-800">
+            <td className="py-2 pr-4 text-zinc-300">Unity</td>
+            <td className="py-2 pr-4 text-zinc-300">Yes (revenue cap: $200K)</td>
+            <td className="py-2 text-zinc-300">$399/yr Plus, $2,040/yr Pro</td>
+          </tr>
+          <tr>
+            <td className="py-2 pr-4 text-zinc-300">Godot</td>
+            <td className="py-2 pr-4 text-zinc-300">Completely free</td>
+            <td className="py-2 text-zinc-300">N/A (open source, MIT license)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Physics</h2>
+      <p>
+        All three engines offer capable physics. SpawnForge uses Rapier for both 2D and 3D
+        (6 collider shapes, joints, forces, raycasting). Unity uses PhysX (3D) and Box2D (2D).
+        Godot has its own physics engine with Jolt as an optional 3D backend.
+      </p>
+
+      <h2>Community and Ecosystem</h2>
+      <p>
+        <strong>Unity</strong> has the largest ecosystem — decades of tutorials, a massive Asset
+        Store, and a huge professional community. <strong>Godot</strong> has a passionate
+        open-source community, active forums, and a growing asset library. <strong>SpawnForge
+        </strong> is newer but offers a built-in community gallery for sharing and discovering
+        games, plus 350 MCP commands that make the engine accessible to AI agents and tools.
+      </p>
+
+      <h2>When to Choose Each Engine</h2>
+      <p>
+        <strong>Choose SpawnForge</strong> if you want browser-native development, AI-assisted
+        creation, or need to prototype and publish quickly without setup friction. Ideal for game
+        jams, education, web-first games, and creators who prefer natural language over code.
+      </p>
+      <p>
+        <strong>Choose Unity</strong> if you need AAA-quality rendering, cross-platform deployment
+        (console, mobile, desktop), or access to the largest plugin ecosystem. Best for teams
+        with C# expertise building commercial games.
+      </p>
+      <p>
+        <strong>Choose Godot</strong> if you value open source, want full control over the engine,
+        or prefer GDScript. Excellent for indie developers who want a lightweight, free engine
+        with no revenue strings attached.
+      </p>
+
+      <h2>Conclusion</h2>
+      <p>
+        There is no universally &ldquo;best&rdquo; engine — only the best engine for your
+        specific project. SpawnForge excels at browser-based, AI-assisted game creation with
+        minimal friction. Unity leads in cross-platform commercial development. Godot offers the
+        freedom of open source with a growing feature set. Try all three for your next project
+        and see which workflow fits you best.
+      </p>
+    </>
+  );
+}

--- a/web/src/app/blog/feed.xml/route.ts
+++ b/web/src/app/blog/feed.xml/route.ts
@@ -1,0 +1,45 @@
+import { blogPosts } from '@/lib/blog';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://spawnforge.ai';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+export async function GET() {
+  const items = blogPosts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/blog/${post.slug}</link>
+      <description>${escapeXml(post.description)}</description>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+      <guid>${SITE_URL}/blog/${post.slug}</guid>
+    </item>`
+    )
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>SpawnForge Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>News, tutorials, and insights about AI-powered game creation with SpawnForge.</description>
+    <language>en-us</language>
+    <atom:link href="${SITE_URL}/blog/feed.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  });
+}

--- a/web/src/app/blog/page.tsx
+++ b/web/src/app/blog/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from 'next';
+import { cacheLife, cacheTag } from 'next/cache';
+import Link from 'next/link';
+import { blogPosts } from '@/lib/blog';
+
+export const metadata: Metadata = {
+  title: 'Blog — SpawnForge',
+  description:
+    'News, tutorials, and insights about AI-powered game creation with SpawnForge.',
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: 'SpawnForge Blog',
+    description:
+      'News, tutorials, and comparisons for AI game development.',
+  },
+};
+
+export default async function BlogIndexPage() {
+  'use cache';
+  cacheLife('days');
+  cacheTag('blog');
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <h1 className="mb-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+        Blog
+      </h1>
+      <p className="mb-12 text-lg text-zinc-300">
+        News, tutorials, and insights about AI-powered game creation.
+      </p>
+
+      <div className="space-y-8">
+        {blogPosts.map((post) => (
+          <article key={post.slug} className="group">
+            <Link href={`/blog/${post.slug}`} className="block rounded-lg border border-zinc-800 bg-zinc-900/50 p-6 transition-colors hover:border-orange-500/50 hover:bg-zinc-900">
+              <div className="mb-2 flex items-center gap-3 text-sm text-zinc-500">
+                <time dateTime={post.date}>
+                  {new Date(post.date).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </time>
+                <span>&middot;</span>
+                <span>{post.readingTime}</span>
+              </div>
+              <h2 className="mb-2 text-xl font-semibold text-white group-hover:text-orange-400">
+                {post.title}
+              </h2>
+              <p className="text-zinc-400">{post.description}</p>
+            </Link>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import { SITE_URL } from "@/lib/constants";
 import { getDb, queryWithResilience } from "@/lib/db/client";
 import { publishedGames, users } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
+import { getAllBlogSlugs } from "@/lib/blog";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
@@ -104,10 +105,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.8,
     },
-    ...[
-      "spawnforge-browser-ai-game-engine",
-      "spawnforge-vs-unity-vs-godot",
-    ].map((slug) => ({
+    ...getAllBlogSlugs().map((slug) => ({
       url: `${SITE_URL}/blog/${slug}`,
       lastModified: now,
       changeFrequency: "monthly" as const,

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -98,6 +98,21 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.5,
     },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    ...[
+      "spawnforge-browser-ai-game-engine",
+      "spawnforge-vs-unity-vs-godot",
+    ].map((slug) => ({
+      url: `${SITE_URL}/blog/${slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    })),
   ];
 
   // Query published games for dynamic sitemap entries

--- a/web/src/lib/blog.ts
+++ b/web/src/lib/blog.ts
@@ -1,0 +1,37 @@
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  author: string;
+  readingTime: string;
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    slug: 'spawnforge-browser-ai-game-engine',
+    title: 'SpawnForge: The Browser-Based AI Game Engine',
+    description:
+      'An overview of SpawnForge — the AI-native 2D/3D game engine that runs entirely in your browser. Build games with natural language, visual scripting, or code.',
+    date: '2026-04-14',
+    author: 'SpawnForge Team',
+    readingTime: '6 min read',
+  },
+  {
+    slug: 'spawnforge-vs-unity-vs-godot',
+    title: 'SpawnForge vs Unity vs Godot: Complete Comparison',
+    description:
+      'A detailed comparison of SpawnForge, Unity, and Godot for browser-based game development — setup, languages, AI features, pricing, and publishing.',
+    date: '2026-04-14',
+    author: 'SpawnForge Team',
+    readingTime: '8 min read',
+  },
+];
+
+export function getBlogPost(slug: string): BlogPost | undefined {
+  return blogPosts.find((p) => p.slug === slug);
+}
+
+export function getAllBlogSlugs(): string[] {
+  return blogPosts.map((p) => p.slug);
+}

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -136,6 +136,7 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     '/compare(.*)',
     '/use-cases(.*)',
     '/changelog(.*)',
+    '/blog(.*)',
   ];
   if (process.env.NODE_ENV !== 'production') {
     publicRoutes.push('/dev(.*)');


### PR DESCRIPTION
## Summary
- Add blog index page (`/blog`) and per-post pages (`/blog/[slug]`) with `generateStaticParams`, `'use cache'` caching, and BlogPosting JSON-LD structured data
- Add RSS 2.0 feed at `/blog/feed.xml` with XML escaping and cache headers
- Add 2 initial blog posts as TSX content components (avoids MDX dependencies)
- Register `/blog(.*)` in proxy public routes and add blog entries to sitemap

Closes #8427

## Test plan
- [x] ESLint passes (`--max-warnings 0`)
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Vitest suite passes
- [ ] Verify `/blog` renders post listing with dates and reading times
- [ ] Verify `/blog/spawnforge-browser-ai-game-engine` renders full post with JSON-LD
- [ ] Verify `/blog/spawnforge-vs-unity-vs-godot` renders full post with JSON-LD
- [ ] Verify `/blog/feed.xml` returns valid RSS 2.0 XML
- [ ] Verify invalid slug returns 404