### PR TITLE
fix: prevent SSR hydration mismatch in ShareButtons and GamePlayer

### DIFF
--- a/.changeset/fix-share-buttons-lint.md
+++ b/.changeset/fix-share-buttons-lint.md
@@ -1,0 +1,5 @@
+---
+'spawnforge': patch
+---
+
+fix: replace useState+useEffect with useSyncExternalStore for navigator.share detection in ShareButtons

--- a/web/src/components/play/GamePlayer.tsx
+++ b/web/src/components/play/GamePlayer.tsx
@@ -37,9 +37,18 @@ export function GamePlayer({ userId, slug, isAuthenticated = false }: GamePlayer
   const [engineState, setEngineState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [clickToStart, setClickToStart] = useState(false);
+  // shareUrl must be captured after mount — window.location.href is undefined
+  // during SSR, so reading it at render time causes a hydration mismatch
+  // (server: '', client: actual URL). An empty string also throws in addUtm's
+  // new URL() call, so ShareButtons is only rendered once the URL is known.
+  const [shareUrl, setShareUrl] = useState('');
 
   const containerRef = useRef<HTMLDivElement>(null);
   const initStartedRef = useRef(false);
+
+  useEffect(() => {
+    setShareUrl(window.location.href);
+  }, []);
 
   // Fetch game data from the API
   useEffect(() => {
@@ -225,10 +234,10 @@ export function GamePlayer({ userId, slug, isAuthenticated = false }: GamePlayer
             slug={slug}
             isAuthenticated={isAuthenticated}
           />
-          {gameData && (
+          {gameData && shareUrl && (
             <ShareButtons
               gameTitle={gameData.title}
-              gameUrl={typeof window !== 'undefined' ? window.location.href : ''}
+              gameUrl={shareUrl}
             />
           )}
           <button

--- a/web/src/components/play/ShareButtons.tsx
+++ b/web/src/components/play/ShareButtons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { Share2, X as XIcon } from 'lucide-react';
 
 interface ShareButtonsProps {
@@ -18,6 +18,13 @@ function addUtm(url: string, source: string): string {
 
 export function ShareButtons({ gameTitle, gameUrl }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
+  // hasNativeShare must be determined after mount — navigator.share is
+  // undefined during SSR, so computing it at render time causes a hydration
+  // mismatch (server: false, client: potentially true).
+  const [hasNativeShare, setHasNativeShare] = useState(false);
+  useEffect(() => {
+    setHasNativeShare(!!navigator.share);
+  }, []);
 
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
     `Check out "${gameTitle}" on SpawnForge!`
@@ -48,8 +55,6 @@ export function ShareButtons({ gameTitle, gameUrl }: ShareButtonsProps) {
       // User cancelled or API not available
     }
   }, [gameTitle, gameUrl]);
-
-  const hasNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
 
   const btnClass =
     'rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-zinc-300';

--- a/web/src/components/play/ShareButtons.tsx
+++ b/web/src/components/play/ShareButtons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useSyncExternalStore } from 'react';
 import { Share2, X as XIcon } from 'lucide-react';
 
 interface ShareButtonsProps {
@@ -18,13 +18,14 @@ function addUtm(url: string, source: string): string {
 
 export function ShareButtons({ gameTitle, gameUrl }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
-  // hasNativeShare must be determined after mount — navigator.share is
-  // undefined during SSR, so computing it at render time causes a hydration
-  // mismatch (server: false, client: potentially true).
-  const [hasNativeShare, setHasNativeShare] = useState(false);
-  useEffect(() => {
-    setHasNativeShare(!!navigator.share);
-  }, []);
+  // navigator.share is undefined during SSR. useSyncExternalStore provides
+  // the server snapshot (false) and the client snapshot (actual capability)
+  // without triggering the set-state-in-effect lint rule.
+  const hasNativeShare = useSyncExternalStore(
+    () => () => {},
+    () => !!navigator.share,
+    () => false,
+  );
 
   const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
     `Check out "${gameTitle}" on SpawnForge!`

--- a/web/src/components/play/ShareButtons.tsx
+++ b/web/src/components/play/ShareButtons.tsx
@@ -16,13 +16,17 @@ function addUtm(url: string, source: string): string {
   return u.toString();
 }
 
+// Stable subscribe reference — useSyncExternalStore requires a stable function
+// identity to avoid unsubscribing/resubscribing on every render.
+const noopSubscribe = () => () => {};
+
 export function ShareButtons({ gameTitle, gameUrl }: ShareButtonsProps) {
   const [copied, setCopied] = useState(false);
   // navigator.share is undefined during SSR. useSyncExternalStore provides
   // the server snapshot (false) and the client snapshot (actual capability)
   // without triggering the set-state-in-effect lint rule.
   const hasNativeShare = useSyncExternalStore(
-    () => () => {},
+    noopSubscribe,
     () => !!navigator.share,
     () => false,
   );


### PR DESCRIPTION
## Summary

- **`ShareButtons.tsx`**: `hasNativeShare` was computed at render time via `typeof navigator !== 'undefined' && !!navigator.share`. During SSR `navigator` is undefined → `false`. On the client it may be `true`. The mismatch caused React to produce different markup between server and client, triggering a hydration error on the play page.  Moved to `useState(false)` + `useEffect` so SSR and initial client render both produce `false`, then the effect updates it post-mount.

- **`GamePlayer.tsx`**: `window.location.href` was passed directly as the `gameUrl` prop to `ShareButtons` with an SSR guard (`typeof window !== 'undefined' ? window.location.href : ''`). SSR produces `''`; the client produces the full URL. `addUtm()` calls `new URL(url)` which throws on an empty string. Fixed by capturing `window.location.href` in `useState('') + useEffect`, and gating `<ShareButtons>` on `shareUrl` being populated.

Both bugs were introduced in `8c3ee07` (feat: E2 Community & Viral Growth, 2026-04-12) and detected during Sentry triage (SPAWNFORGE-AI-7 / #8450).

Closes #8450

## Test plan
- [ ] Visit a published game play page — share buttons render correctly, no console hydration warnings
- [ ] Verify `hasNativeShare` button appears only on devices with `navigator.share` (mobile Chrome/Safari), not in desktop Chrome/Firefox
- [ ] Verify X and Reddit share links include correct UTM params
- [ ] Verify copy-link button works
- [ ] `cd web && npx eslint --max-warnings 0 src/components/play/ShareButtons.tsx src/components/play/GamePlayer.tsx`
- [ ] `cd web && npx tsc --noEmit`
- [ ] `cd web && npx vitest run src/components/play/__tests__/ShareButtons.test.tsx src/components/play/__tests__/GamePlayer.test.tsx`