### PR TITLE
fix: suppress transient network errors from Sentry in hydrateFromServer

### DIFF
--- a/web/src/stores/generationStore.ts
+++ b/web/src/stores/generationStore.ts
@@ -229,7 +229,12 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
         hydrated: true,
       }));
     } catch (err) {
-      captureException(err, { context: 'generationStore.hydrateFromServer' });
+      // Don't report transient network errors — these fire when the server is
+      // temporarily unreachable (e.g. dev server not ready) and create noise.
+      const isNetworkError = err instanceof TypeError && err.message === 'Failed to fetch';
+      if (!isNetworkError) {
+        captureException(err, { context: 'generationStore.hydrateFromServer' });
+      }
       set({ hydrated: true });
     }
   },


### PR DESCRIPTION
## Summary

- `generationStore.hydrateFromServer` was calling `captureException` unconditionally in its catch block, including for `TypeError: Failed to fetch` — a transient network-level failure
- This generated 14 Sentry events from a single developer's local machine (React Strict Mode double-invoking the effect while the dev server was unavailable)
- Fix: guard `captureException` behind an `isNetworkError` check so only unexpected, non-network errors are reported

## Test plan

- [ ] Verify `generationStore` unit tests pass: `npx vitest run src/stores/__tests__/generationStore.test.ts`
- [ ] Confirm no new Sentry events for `generationStore.hydrateFromServer` after deploy

Closes #8454 (SPAWNFORGE-AI-4)

https://claude.ai/code/session_01FSUjzJkMFXMErfg2Ao5Jqz