### PR TITLE
fix: suppress dev network errors from Sentry in generationStore

### DIFF
--- a/.changeset/fix-generation-store-sentry-noise.md
+++ b/.changeset/fix-generation-store-sentry-noise.md
@@ -1,0 +1,5 @@
+---
+'spawnforge': patch
+---
+
+fix: suppress network TypeError from Sentry in generationStore.hydrateFromServer

--- a/web/src/stores/generationStore.ts
+++ b/web/src/stores/generationStore.ts
@@ -229,7 +229,14 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
         hydrated: true,
       }));
     } catch (err) {
-      captureException(err, { context: 'generationStore.hydrateFromServer' });
+      // Network-level TypeError ("Failed to fetch") is expected in dev when
+      // the API isn't reachable (missing DATABASE_URL, no Clerk keys, etc.).
+      // Only report genuine server-side errors to Sentry.
+      const isNetworkError =
+        err instanceof TypeError && /failed to fetch/i.test(err.message);
+      if (!isNetworkError) {
+        captureException(err, { context: 'generationStore.hydrateFromServer' });
+      }
       set({ hydrated: true });
     }
   },


### PR DESCRIPTION
## Summary

- `generationStore.hydrateFromServer` calls `fetch('/api/jobs?status=active')` on mount. In dev without `DATABASE_URL` or Clerk keys, this throws `TypeError: Failed to fetch` at the network level (not an HTTP error).
- The catch block unconditionally called `captureException`, sending 14 noise events to Sentry (SPAWNFORGE-AI-4).
- Fix: skip `captureException` for `TypeError` with "Failed to fetch" message. Non-network errors still reported.

Closes #8414

## Test plan
- [ ] `cd web && npx vitest run src/stores/__tests__/generationStore.test.ts` — 44/44 pass
- [ ] Start dev server without `DATABASE_URL` — no Sentry events from hydration
- [ ] Start dev server with full env — hydration works normally