### PR TITLE
fix: nightly quality gate — stabilize WelcomeModal broken test

### DIFF
--- a/.changeset/fix-welcomemodal-test-nightly.md
+++ b/.changeset/fix-welcomemodal-test-nightly.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix WelcomeModal test broken by missing @testing-library/user-event dependency — replace dynamic userEvent.click with fireEvent.click

--- a/web/src/components/editor/__tests__/WelcomeModal.test.tsx
+++ b/web/src/components/editor/__tests__/WelcomeModal.test.tsx
@@ -109,20 +109,17 @@ describe('WelcomeModal', () => {
     // Spy restored by afterEach via vi.restoreAllMocks()
   });
 
-  it('does not throw when dismissing with "Don\'t show again" and setItem throws', async () => {
-    const { userEvent } = await import('@testing-library/user-event');
-    const user = userEvent.setup();
-
+  it('does not throw when dismissing with "Don\'t show again" and setItem throws', () => {
     vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
       throw new DOMException('Quota exceeded', 'QuotaExceededError');
     });
 
     render(<WelcomeModal />);
     const checkbox = screen.getByRole('checkbox', { name: /Don't show again/i });
-    await user.click(checkbox);
+    fireEvent.click(checkbox);
     const skipBtn = screen.getByRole('button', { name: /Skip/i });
     // Should not throw — dismissal succeeds even if write fails
-    await user.click(skipBtn);
+    fireEvent.click(skipBtn);
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

- Fixed 1 broken test suite (`WelcomeModal.test.tsx`) detected in the nightly quality gate
- Root cause: dynamic import of `@testing-library/user-event` which is not listed as a dependency and not installed
- Fix: replaced `userEvent.click()` calls with `fireEvent.click()` (already imported via `componentTestUtils`) — equivalent for this test's purpose (verifying localStorage errors don't prevent modal dismissal)
- Secondary fix: also resolved TypeScript type error `TS2307: Cannot find module '@testing-library/user-event'` in the same location

Closes #8460

## Nightly gate results

| Check | Result |
|-------|--------|
| ESLint (`--max-warnings 0`) | PASS — 0 warnings |
| TypeScript (`tsc --noEmit`) | PASS — 0 errors (after `@spawnforge/ui` package built) |
| Vitest (15,262 tests) | PASS — 1 broken suite fixed, 748 files passed |
| Coverage thresholds | PASS — stmt 80%, branch 69.7%, fn 74.8%, lines 81.4% |

## Test plan

- [x] Fixed test run 5/5 times with zero failures
- [x] ESLint zero warnings confirmed
- [x] TypeScript clean confirmed
- [x] Full vitest suite: 748 passed, 1 skipped, 0 failed

https://claude.ai/code/session_018haRUr1YHvi7Big6QEdmsJ