### PR TITLE
fix(hooks): taskboard ticket-count checks parse wrong JSON shape

### DIFF
--- a/.claude/hooks/on-prompt-submit.sh
+++ b/.claude/hooks/on-prompt-submit.sh
@@ -20,7 +20,7 @@ if ! tb_api_available; then
 fi
 
 # Health check: verify board has data (lesson #56)
-BOARD_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+BOARD_COUNT=$(curl -sL --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])))" 2>/dev/null || echo "0")
 if [ "$BOARD_COUNT" = "0" ]; then
     echo "[TASKBOARD WARNING] Board has 0 tickets — wrong DB path or sync needed."
     echo "  Kill and restart: pkill taskboard && taskboard start --port 3010"

--- a/.claude/hooks/on-session-start.sh
+++ b/.claude/hooks/on-session-start.sh
@@ -67,7 +67,7 @@ fi
 
 # ── HEALTH CHECK: Verify board has data (lesson #56) ────────────────────
 # An empty board means wrong DB path. This catches it immediately.
-HEALTH_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+HEALTH_COUNT=$(curl -sL --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])))" 2>/dev/null || echo "0")
 if [ "$HEALTH_COUNT" = "0" ]; then
     echo ""
     echo "╔══════════════════════════════════════════════════════════════╗"

--- a/.claude/hooks/taskboard-state.sh
+++ b/.claude/hooks/taskboard-state.sh
@@ -13,13 +13,13 @@ _TB_PROJECT_ROOT="$(cd "$_TB_HOOKS_DIR/../.." && pwd)"
 # Use the OS default database path — NOT .claude/taskboard.db (which creates an empty local copy)
 TB_DB="$HOME/Library/Application Support/taskboard/taskboard.db"
 # Try Portless URL first, fall back to direct port
-if curl -s --connect-timeout 1 "http://taskboard.localhost:1355/api/board" > /dev/null 2>&1; then
+if curl -sL --connect-timeout 1 "http://taskboard.localhost:1355/api/board" > /dev/null 2>&1; then
     TB_API="http://taskboard.localhost:1355/api"
 else
     TB_API="http://localhost:3010/api"
 fi
 TB_STATE_FILE="$_TB_HOOKS_DIR/.taskboard-active-ticket"
-export PROJECT_ID="01KK974VMNC16ZAW7MW1NH3T3M"
+export PROJECT_ID="01KMM9ZA6SBZ7RKJZJTZS9VR4R"
 export TEAM_ENGINEERING_ID="01KK9751NZ4HM7VQM0AQ5WGME3"
 
 # Known locations for the taskboard binary
@@ -50,7 +50,7 @@ tb_check_installed() {
 
 # Check if taskboard API is reachable
 tb_api_available() {
-    curl -s --connect-timeout 2 "$TB_API/board" > /dev/null 2>&1
+    curl -sL --connect-timeout 2 "$TB_API/board" > /dev/null 2>&1
 }
 
 # Auto-start taskboard if binary exists but server is not running
@@ -75,7 +75,7 @@ tb_auto_start() {
         if tb_api_available; then
             # HEALTH CHECK: verify the board actually has data.
             # If ticket count is 0, the DB path is wrong (lesson #56).
-            TICKET_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+            TICKET_COUNT=$(curl -sL --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])))" 2>/dev/null || echo "0")
             if [ "$TICKET_COUNT" = "0" ]; then
                 echo "[TASKBOARD WARNING] Board has 0 tickets — possible wrong DB path or sync needed." >&2
                 echo "[TASKBOARD WARNING] Try: python3 .claude/hooks/github_project_sync.py pull" >&2
@@ -92,7 +92,7 @@ tb_auto_start() {
 
 # Get the full board as JSON
 tb_get_board() {
-    curl -s --connect-timeout 3 "$TB_API/board" 2>/dev/null
+    curl -sL --connect-timeout 3 "$TB_API/board" 2>/dev/null
 }
 
 # Get tickets by status
@@ -102,20 +102,20 @@ tb_get_tickets() {
     if [ -n "$status" ]; then
         url="$url&status=$status"
     fi
-    curl -s --connect-timeout 3 "$url" 2>/dev/null
+    curl -sL --connect-timeout 3 "$url" 2>/dev/null
 }
 
 # Get a single ticket
 tb_get_ticket() {
     local ticket_id="$1"
-    curl -s --connect-timeout 3 "$TB_API/tickets/$ticket_id" 2>/dev/null
+    curl -sL --connect-timeout 3 "$TB_API/tickets/$ticket_id" 2>/dev/null
 }
 
 # Move a ticket to a new status
 tb_move_ticket() {
     local ticket_id="$1"
     local status="$2"
-    curl -s -X POST "$TB_API/tickets/$ticket_id/move" \
+    curl -sL --post301 --post302 --post303 -X POST "$TB_API/tickets/$ticket_id/move" \
         -H "Content-Type: application/json" \
         -d "{\"status\": \"$status\"}" 2>/dev/null
 }


### PR DESCRIPTION
## Summary
Fixes the recurring "TASKBOARD WARNING: Board has 0 tickets" false alarm that fires every session despite a fully-synced 762-ticket DB.

**Two compounded root causes:**
1. `/api/board` returns `{"columns": [{"tickets": [...]}, ...]}`, but the three health-check hooks parsed top-level `tickets` which is always empty
2. `curl -s` (no `-L`) does not follow Portless's `http://taskboard.localhost:1355` → `https://...` 302 redirect, so the hooks were getting an empty redirect-body anyway

**Also fixed (Boy Scout Rule):**
- `PROJECT_ID` was the stale `01KK974VMNC16ZAW7MW1NH3T3M` (explicitly listed as stale in `MEMORY.md`). Updated to canonical `01KMM9ZA6SBZ7RKJZJTZS9VR4R`.
- `tb_move_ticket` POST was silently losing its method across 3xx redirects — added `--post301 --post302 --post303`.

Closes #8490 (PF-736)

## Files changed
- `.claude/hooks/on-prompt-submit.sh` — health check
- `.claude/hooks/on-session-start.sh` — health check
- `.claude/hooks/taskboard-state.sh` — 8 curl call sites + PROJECT_ID

## Test plan
- [x] `tb_api_available` → reachable
- [x] `tb_get_board | python3 counter.py` → `tickets: 762` (was `0`)
- [x] `bash on-prompt-submit.sh </dev/null` → no false warning emitted
- [x] `PROJECT_ID` matches MEMORY.md canonical value
- [x] Simulated empty-board still reports `0` (regression guard)