### PR TITLE
fix: nightly quality gate — replace nested vi.mock with vi.doMock

### DIFF
--- a/.changeset/nightly-vi-domock.md
+++ b/.changeset/nightly-vi-domock.md
@@ -1,0 +1,13 @@
+---
+"spawnforge": patch
+---
+
+Stabilize the nightly quality gate by replacing nested `vi.mock()` calls with `vi.doMock()` in 4 test files. `vi.mock` is statically hoisted to module scope by Vitest, so re-registering inside a function body after `vi.resetModules()` becomes a hard error in newer Vitest versions. The non-hoisted `vi.doMock()` is the correct primitive when re-registering after a module reset.
+
+Affected test files:
+- `src/app/api/bridges/aseprite/execute/route.test.ts`
+- `src/lib/auth/__tests__/edge-cases.test.ts`
+- `src/lib/bridges/__tests__/bridgeManager.test.ts`
+- `src/lib/rateLimit/__tests__/distributed.test.ts`
+
+No production behavior changes; tests pass with identical assertions.

--- a/web/src/app/api/bridges/aseprite/execute/route.test.ts
+++ b/web/src/app/api/bridges/aseprite/execute/route.test.ts
@@ -11,9 +11,9 @@ vi.mock('@/lib/bridges/luaTemplates', () => ({
 // Each test gets a fresh route module to avoid the module-level cache
 async function importRoute() {
   vi.resetModules();
-  // Re-apply mocks after reset
-  vi.mock('server-only', () => ({}));
-  vi.mock('@/lib/bridges/luaTemplates', () => ({
+  // Re-apply mocks after reset (vi.doMock is not hoisted, unlike vi.mock)
+  vi.doMock('server-only', () => ({}));
+  vi.doMock('@/lib/bridges/luaTemplates', () => ({
     ALLOWED_TEMPLATES: new Set(['createSprite', 'createAnimation', 'editSprite', 'applyPalette', 'exportSheet']),
   }));
   const { POST } = await import('./route');

--- a/web/src/lib/auth/__tests__/edge-cases.test.ts
+++ b/web/src/lib/auth/__tests__/edge-cases.test.ts
@@ -292,11 +292,12 @@ describe('Clerk keys — missing key graceful degradation', () => {
 
     // Re-import authenticateRequest to pick up env change
     vi.resetModules();
-    vi.mock('@clerk/nextjs/server', () => ({
+    // vi.doMock is not hoisted, so it runs after vi.resetModules() as intended
+    vi.doMock('@clerk/nextjs/server', () => ({
       auth: vi.fn(),
       clerkClient: vi.fn(),
     }));
-    vi.mock('@/lib/auth/user-service', () => ({
+    vi.doMock('@/lib/auth/user-service', () => ({
       getUserByClerkId: vi.fn(),
       syncUserFromClerk: vi.fn(),
     }));
@@ -323,11 +324,12 @@ describe('Clerk keys — missing key graceful degradation', () => {
     delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
     vi.resetModules();
-    vi.mock('@clerk/nextjs/server', () => ({
+    // vi.doMock is not hoisted, so it runs after vi.resetModules() as intended
+    vi.doMock('@clerk/nextjs/server', () => ({
       auth: vi.fn(),
       clerkClient: vi.fn(),
     }));
-    vi.mock('@/lib/auth/user-service', () => ({
+    vi.doMock('@/lib/auth/user-service', () => ({
       getUserByClerkId: vi.fn(),
       syncUserFromClerk: vi.fn(),
     }));

--- a/web/src/lib/bridges/__tests__/bridgeManager.test.ts
+++ b/web/src/lib/bridges/__tests__/bridgeManager.test.ts
@@ -27,19 +27,20 @@ import * as childProcess from 'child_process';
 async function importBridgeManager() {
   vi.resetModules();
   // Re-apply mocks after module reset
-  vi.mock('server-only', () => ({}));
-  vi.mock('child_process', () => ({
+  // vi.doMock is not hoisted, so it runs after vi.resetModules() as intended
+  vi.doMock('server-only', () => ({}));
+  vi.doMock('child_process', () => ({
     execFile: vi.fn(),
     default: { execFile: vi.fn() },
   }));
-  vi.mock('fs', () => ({
+  vi.doMock('fs', () => ({
     existsSync: vi.fn(),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
     mkdirSync: vi.fn(),
     default: { existsSync: vi.fn(), readFileSync: vi.fn(), writeFileSync: vi.fn(), mkdirSync: vi.fn() },
   }));
-  vi.mock('os', () => ({
+  vi.doMock('os', () => ({
     homedir: vi.fn(() => '/mock-home'),
     platform: vi.fn(() => 'darwin'),
     default: { homedir: vi.fn(() => '/mock-home'), platform: vi.fn(() => 'darwin') },

--- a/web/src/lib/rateLimit/__tests__/distributed.test.ts
+++ b/web/src/lib/rateLimit/__tests__/distributed.test.ts
@@ -27,7 +27,8 @@ beforeEach(async () => {
   vi.resetAllMocks();
   mockFetch.mockReset();
   // Re-import after reset so the module gets a fresh state
-  vi.mock('@/lib/rateLimit', () => ({
+  // vi.doMock is not hoisted, so it runs after vi.resetModules() as intended
+  vi.doMock('@/lib/rateLimit', () => ({
     rateLimit: vi.fn(),
   }));
   globalThis.fetch = mockFetch;


### PR DESCRIPTION
## Summary
- Fixed 4 test files using `vi.mock` inside functions after `vi.resetModules()` — these would become errors in a future Vitest version
- Root cause: `vi.mock` is always hoisted to module scope regardless of where it appears; after `vi.resetModules()`, re-registration must use `vi.doMock` (not hoisted, runs at call site)
- No test assertions weakened — all 4 files pass with identical behavior

**Files fixed:**
- `src/app/api/bridges/aseprite/execute/route.test.ts` — `importRoute()` helper
- `src/lib/auth/__tests__/edge-cases.test.ts` — Clerk keys degradation tests
- `src/lib/bridges/__tests__/bridgeManager.test.ts` — `importBridgeManager()` helper
- `src/lib/rateLimit/__tests__/distributed.test.ts` — `beforeEach` re-registration

Closes #8495 (PF-742)

## Test plan
- [x] All 4 fixed files run 59 tests with zero failures
- [x] No `vi.mock not at the top level` warnings in output
- [x] ESLint zero warnings on changed files
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Full suite: 15,298 tests passed, 4 skipped (exit code 0)
- [x] Coverage: statements 79.97%, branches 69.71%, functions 74.8%, lines 81.37% — all above thresholds