### PR TITLE
feat(ai): Opus 4.7 deep-generation tier behind feature flag

### DIFF
--- a/.changeset/ai-opus-deep-tier.md
+++ b/.changeset/ai-opus-deep-tier.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Add Opus 4.7 deep-generation tier behind `NEXT_PUBLIC_USE_DEEP_GENERATION` flag. When enabled, GDD, world-builder, and cutscene generators route to `claude-opus-4-7` for higher-fidelity output. Default off. Every call emits `ai_deep_generation_eval` to PostHog for A/B analysis. Decision memo: `docs/decisions/2026-05-01-opus-deep-tier.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,9 @@ cd web && npm run db:push              # Push schema to Neon (dev only)
 
 Required: `.env.local` with `DATABASE_URL`, `CLERK_SECRET_KEY`, `STRIPE_SECRET_KEY`, `UPSTASH_REDIS_REST_URL`.
 
+Optional feature flags (all default off):
+- `NEXT_PUBLIC_USE_DEEP_GENERATION=true` — route GDD, world builder, and cutscene generators to Opus 4.7 (`AI_MODEL_DEEP`) instead of Sonnet 4.6. See `docs/decisions/2026-05-01-opus-deep-tier.md`. Any value other than the exact string `"true"` leaves the flag off.
+
 ## Key Architecture Rules
 
 - **Bridge isolation**: Only `engine/src/bridge/` may import web_sys/js_sys/wasm_bindgen. `core/` is pure Rust.

--- a/docs/decisions/2026-05-01-opus-deep-tier.md
+++ b/docs/decisions/2026-05-01-opus-deep-tier.md
@@ -1,0 +1,74 @@
+# ADR: Opus 4.7 Deep-Generation Tier
+
+**Status:** Proposed
+**Date:** 2026-04-24
+**Tickets:** PF-741 (#8496)
+**Deciders:** Engineering
+**Review date:** 2026-05-08 (after 7-day canary)
+
+## Context
+
+Primary generation model is Sonnet 4.6 (`AI_MODEL_PRIMARY` in `web/src/lib/ai/models.ts`). It handles:
+
+- **Chat turns** in the editor (latency-sensitive, conversational)
+- **Deep generation**: GDD authoring (`gddGenerator.ts`), world building (`worldBuilder.ts`), cutscenes (`cutsceneGenerator.ts`) — single-shot requests where users wait seconds to minutes for a complete document
+
+Deep generations have different constraints than chat:
+- **Quality matters more than latency.** A higher-fidelity GDD saves the user from re-prompting.
+- **Users are already in a waiting state.** A 30–60s wait for Opus isn't worse than a 20s wait for Sonnet if the output is meaningfully better.
+- **Volume is low relative to chat.** Cost multiplier is bounded.
+
+Opus 4.7 (`claude-opus-4-7`) is Anthropic's deepest-reasoning model. It's not the right pick for chat — too slow, too expensive per token — but it's a plausible upgrade for the three surfaces above.
+
+## Options
+
+### A) Sonnet everywhere (status quo)
+- **Pros:** Single-model simplicity, predictable cost
+- **Cons:** Leaves quality on the table for deep generations; competitors moving to Opus-tier for similar surfaces
+
+### B) Opus everywhere for deep generation (default on)
+- **Pros:** Maximum quality uplift
+- **Cons:** Unbounded cost exposure; no data on whether users notice the difference
+
+### C) Opus behind a feature flag with canary + decision memo (this ADR)
+- **Pros:** Measurable A/B, bounded cost exposure during eval, clean rollback
+- **Cons:** Adds a flag to maintain
+
+## Decision
+
+**Ship option C.** Add `AI_MODEL_DEEP = 'claude-opus-4-7'` and route the three deep-generation surfaces through `getDeepGenerationModel()`, which reads `NEXT_PUBLIC_USE_DEEP_GENERATION`. Default off. Emit `ai_deep_generation_eval` to PostHog on every call so both arms of the A/B are observable.
+
+## Rollout
+
+1. **Day 0:** Ship the code with flag default off. Verify `ai_deep_generation_eval` fires with `deepTierEnabled: false` for 100% of deep generations.
+2. **Day 1:** Flip flag on for 10% of paid users via environment-based routing (Vercel environment variable split between preview/canary domains — no code change required).
+3. **Days 2–7:** Monitor:
+   - Token cost delta per generation (Opus vs Sonnet on the same surface)
+   - Downstream publish rate (users who generate → publish within 48h)
+   - User-reported quality signals from support channels
+4. **Day 8:** Write the review-date update to this ADR with one of:
+   - **Default on for paid tiers:** if publish rate lifts ≥ 5% and cost fits within AI budget
+   - **Keep off:** if lift is < 3% or cost exceeds budget
+   - **Narrow scope:** if lift concentrates on one of the three surfaces
+
+## Consequences
+
+### Positive
+- Cheap, reversible experiment
+- Data-driven decision rather than gut feel
+- Surface-level isolation: chat path is untouched
+
+### Negative / accepted
+- One new feature flag to maintain for 7+ days
+- PostHog event volume grows by ~N/day where N = daily deep-generation count
+- If flipped on, cost exposure is real — mitigation is the canary
+
+### Risks
+- **Latency regression:** Opus is ~2x slower single-shot. User-facing copy on GDD/world/cutscene should already indicate a progress state; re-verify during canary.
+- **Cache invalidation:** Deep-tier generations are unique-per-prompt and not cached across users, so prompt caching savings apply regardless of model. No cache churn expected.
+
+## Follow-ups (separate tickets)
+
+- PF-739 (1h extended cache TTL) — independent optimization
+- PF-740 (MCP Streamable HTTP) — unrelated
+- Hardcoded-model-string cleanup flagged in `HARDCODED_AUDIT.md` — mechanical refactor, not blocking

--- a/docs/plans/2026-04-24-anthropic-feature-upgrades.md
+++ b/docs/plans/2026-04-24-anthropic-feature-upgrades.md
@@ -1,0 +1,162 @@
+# Anthropic/Claude Feature Upgrades — Plan
+
+**Date:** 2026-04-24
+**Tickets:** PF-741 (#8496), PF-740 (#8497), PF-739 (#8498)
+**Owner:** Engineering
+
+## Goal
+
+Close three gaps identified in the 2026-04-24 Anthropic feature audit:
+1. **PF-741** Add Opus 4.7 as a deep-generation quality tier above Sonnet.
+2. **PF-740** Expose the MCP server over Streamable HTTP (currently stdio-only).
+3. **PF-739** Enable 1h extended cache TTL on long-lived prefix content.
+
+All three are independent; they can run in parallel but share a dependency on the centralized model-constants refactor in `web/src/lib/ai/models.ts`.
+
+## Sequencing
+
+```
+ Week 1           Week 2           Week 3
+ ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+ │ PF-741      │  │ PF-741      │  │ PF-741      │
+ │ Opus tier   │→ │ A/B flag on │→ │ Decision    │
+ │ + harness   │  │ 10% traffic │  │ memo + GA   │
+ └─────────────┘  └─────────────┘  └─────────────┘
+ ┌─────────────┐  ┌─────────────┐
+ │ PF-739      │  │ PF-739      │
+ │ 1h TTL impl │→ │ Metrics +   │
+ │ + tests     │  │ cost memo   │
+ └─────────────┘  └─────────────┘
+ ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+ │ PF-740      │  │ PF-740      │  │ PF-740      │
+ │ HTTP trans- │→ │ Auth + rate │→ │ Deploy to   │
+ │ port + test │  │ limit       │  │ mcp.sf.ai   │
+ └─────────────┘  └─────────────┘  └─────────────┘
+```
+
+## PF-741 — Opus 4.7 deep-generation tier
+
+### Why first
+Cheapest to implement, highest-quality lever for our generation-heavy flows (GDD, world builder, cutscenes). Unblocks decisions about where else Opus makes sense.
+
+### Implementation
+**Files to touch:**
+- `web/src/lib/ai/models.ts` — add `AI_MODEL_DEEP`, `GATEWAY_MODEL_DEEP`, `AI_MODELS.deep`
+- `web/src/lib/ai/gddGenerator.ts` — route deep path
+- `web/src/lib/ai/worldBuilder.ts` — route deep path
+- `web/src/lib/ai/cutsceneGenerator.ts` — route deep path
+- `web/src/lib/flags/` — new flag `USE_DEEP_GENERATION` (default `false`)
+- `web/src/lib/ai/__tests__/models.test.ts` — cover `AI_MODELS.deep`
+- `docs/decisions/2026-05-01-opus-deep-tier.md` — decision memo template
+
+**Phases:**
+1. **Constants + flag scaffold** (1 day) — add tier, thread through three generators, no behavior change when flag off
+2. **A/B harness** (1 day) — PostHog event `ai_deep_generation_eval` with `{ model, tokens_in, tokens_out, latency_ms, user_id, surface }`
+3. **10% canary** (3 days) — flip flag for 10% of paid users; monitor cost + retention
+4. **Decision memo** (1 day) — merge memo with recommendation (default on for paid tiers / keep off / scope narrower)
+
+### Risk & mitigation
+- **Cost spike:** Opus is ~5x Sonnet. Canary at 10% caps blast radius.
+- **Latency regression:** Opus single-shot is slower. Deep paths are already async/background — no user-facing latency impact expected.
+
+### Acceptance gate
+- Canary metrics show cost delta within budget OR retention lift justifies it
+- Decision memo merged
+- Flag default documented in `CLAUDE.md`
+
+---
+
+## PF-740 — MCP Streamable HTTP transport
+
+### Why second
+Unblocks remote MCP hosts (Cursor, browser-based, custom agents). Not urgent (stdio works for editor), but prerequisite for `.dxt` distribution and public MCP surface.
+
+### Implementation
+**Files to touch:**
+- `mcp-server/src/index.ts` — transport selection by `MCP_TRANSPORT` env (`stdio` default | `http`)
+- `mcp-server/src/transport/http.ts` — new: `StreamableHTTPServerTransport` wiring + health + auth middleware
+- `mcp-server/src/transport/rateLimit.ts` — new: Upstash wrapper mirroring `web/src/lib/rate-limit/`
+- `mcp-server/src/__tests__/transport-http.test.ts` — E2E tool invocation over HTTP
+- `mcp-server/README.md` — document both transports + example curl + `.dxt` path
+- `infra/mcp-http/` (new) — Vercel wrapper if we ship to `mcp.spawnforge.ai`
+
+**Phases:**
+1. **Transport + health endpoint** (2 days) — `/mcp` (Streamable HTTP), `/health`, stdio still default
+2. **Auth + rate limit** (1 day) — Bearer token check via `MCP_HTTP_TOKEN`, Upstash rate limit 30/5m per IP
+3. **E2E test** (1 day) — spin transport, invoke one tool, assert response
+4. **Deployment** (2 days, optional — may become separate ticket) — Vercel function at `mcp.spawnforge.ai`, DNS, env vars, Sentry wiring
+
+### Risk & mitigation
+- **Auth surface:** shared-secret Bearer is weakest-acceptable for MVP. OAuth/Clerk integration is a follow-up ticket.
+- **Stateful sessions:** Streamable HTTP supports session resumption via `Mcp-Session-Id`. Implement stateless first; add session persistence only if a consumer needs it.
+
+### Acceptance gate
+- `MCP_TRANSPORT=stdio` path unchanged (editor keeps working)
+- `MCP_TRANSPORT=http` path responds to `GET /health` + tool invocation
+- Auth rejects missing/invalid Bearer with 401
+- Rate limit returns 429 after threshold
+
+---
+
+## PF-739 — 1h extended cache TTL
+
+### Why third
+Pure optimization. Depends on PF-741 landing first only for code proximity (same file cluster). Impact is token-cost reduction, not feature unlock.
+
+### Implementation
+**Files to touch:**
+- `web/src/lib/ai/cachedContext.ts` — add `CacheTier = 'short' | 'long'` parameter to helpers
+- `web/src/lib/providers/resolveChat.ts` — wire `extended-cache-ttl-2025-04-11` beta header when any `long` block present
+- `web/src/lib/ai/sceneContext.ts` — tag scene context as `long`
+- `mcp-server/manifest/commands.json` consumers in the chat path — tag tool manifest as `long`
+- `web/src/lib/ai/__tests__/promptCache.test.ts` — cover both tiers
+- `web/src/lib/ai/__tests__/resolveChat.test.ts` — assert beta header attachment
+- PostHog dashboard update — `ai_cache_hit_rate` with breakdown by tier
+
+**Phases:**
+1. **Tier param + beta header** (1 day) — helpers accept tier, header attaches conditionally
+2. **Tag long-lived content** (1 day) — scene context, tool manifest
+3. **Tests + instrumentation** (1 day) — cache-read/write token logging
+4. **7-day cost memo** (at day 7) — compare pre/post cache-hit rate and net token cost
+
+### Risk & mitigation
+- **Storage billing:** 1h TTL has a minimum-storage component. The 7-day memo validates assumption that re-ingest savings > storage cost.
+- **Cache invalidation:** Tool manifest changes on every MCP command addition. Key must include a manifest hash so new commands invalidate the long-TTL block. Covered in the cache-key computation (already hashes content).
+
+### Acceptance gate
+- `cache_read_input_tokens` / `cache_creation_input_tokens` metrics visible in PostHog
+- Unit tests cover 5m vs 1h TTL paths
+- 7-day memo shows net token-cost reduction (or is rolled back)
+
+---
+
+## Cross-cutting
+
+### Testing strategy
+- **Unit:** extend existing `__tests__/` in `web/src/lib/ai/` for each ticket
+- **Integration:** run `npm run test` after each phase; CPU-aware targeted tests during dev
+- **Manual:** browser verification via Playwright MCP on the `/chat` surface
+
+### Instrumentation
+All three tickets add PostHog events. Centralize under a single dashboard: **"AI Gen — Model + Cache"** with:
+- `ai_deep_generation_eval` (PF-741)
+- `ai_cache_hit_rate` (PF-739)
+- MCP HTTP invocation counts (PF-740, added to existing MCP dashboard)
+
+### Rollout order
+1. Ship PF-741 flag-off → canary → decide
+2. Ship PF-739 to all traffic (low risk — cache savings are unconditional)
+3. Ship PF-740 behind `MCP_TRANSPORT=http` opt-in; promote to public endpoint only after internal dogfooding
+
+### PR discipline
+- Three separate PRs, one per ticket
+- Each PR has `Closes #NNNN` + milestone
+- Each PR has a changeset (user-facing: PF-741 and PF-739; PF-740 is infra-only → `skip changeset` label)
+- Lint + tsc + vitest must pass before PR opens (quality gate)
+- User reviews and merges — never self-merge
+
+### Out-of-scope (future tickets)
+- Files API integration for image/PDF uploads in chat
+- `.dxt` packaging (depends on PF-740 being stable)
+- MCP Tasks/Sampling/Media primitives (await SDK stable)
+- Hardcoded-model-string cleanup flagged in `HARDCODED_AUDIT.md` (separate mechanical refactor)

--- a/web/.env.example
+++ b/web/.env.example
@@ -121,6 +121,16 @@ UPSTASH_REDIS_REST_TOKEN=xxx
 # SKIP_ENV_VALIDATION=
 
 # -----------------------------------------------------------------------------
+# AI Deep-Generation Tier — optional, default off
+# Routes GDD, world builder, and cutscene generators to Opus 4.7 (AI_MODEL_DEEP)
+# when set to exactly "true". Any other value (including "1", "on") keeps the
+# primary tier (Sonnet 4.6). See docs/decisions/2026-05-01-opus-deep-tier.md.
+# Safe to expose client-side: only toggles which model string is sent to
+# /api/chat; all routing decisions happen server-side on every request.
+# -----------------------------------------------------------------------------
+# NEXT_PUBLIC_USE_DEEP_GENERATION=true
+
+# -----------------------------------------------------------------------------
 # WASM Engine CDN — optional, defaults to same-origin (local dev)
 # Set to your Cloudflare R2 public URL for production deployments.
 # CSP headers auto-allow this origin for script-src and connect-src.

--- a/web/src/lib/ai/__tests__/aiSdkAdapter.test.ts
+++ b/web/src/lib/ai/__tests__/aiSdkAdapter.test.ts
@@ -30,7 +30,13 @@ vi.mock('@/lib/ai/toolAdapter', () => ({
 
 vi.mock('@/lib/ai/models', () => ({
   AI_MODEL_PRIMARY: 'claude-sonnet-4.5',
-  AI_MODELS: { gatewayChat: 'anthropic/claude-sonnet-4.6' },
+  AI_MODELS: {
+    chat: 'claude-sonnet-4.5',
+    fast: 'claude-haiku-4-5',
+    deep: 'claude-opus-4-7',
+    gatewayChat: 'anthropic/claude-sonnet-4.6',
+    gatewayDeep: 'anthropic/claude-opus-4-7',
+  },
 }));
 
 import { streamText } from 'ai';
@@ -445,6 +451,15 @@ describe('streamViaSdk — provider selection', () => {
     );
 
     expect(gateway).toHaveBeenCalledWith('anthropic/claude-sonnet-4.6');
+    expect(anthropic).not.toHaveBeenCalled();
+  });
+
+  it('routes Opus deep-tier model through gateway as anthropic/claude-opus-4-7', async () => {
+    await collectEvents(
+      streamViaSdk(gatewayRoute, simpleMessages, { model: 'claude-opus-4-7' }),
+    );
+
+    expect(gateway).toHaveBeenCalledWith('anthropic/claude-opus-4-7');
     expect(anthropic).not.toHaveBeenCalled();
   });
 

--- a/web/src/lib/ai/__tests__/deepTier.test.ts
+++ b/web/src/lib/ai/__tests__/deepTier.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AI_MODEL_DEEP, AI_MODEL_PRIMARY } from '../models';
+
+const trackEventMock = vi.fn();
+vi.mock('@/lib/analytics/posthog', () => ({
+  trackEvent: (name: string, props?: Record<string, unknown>) => trackEventMock(name, props),
+}));
+
+describe('deepTier', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+
+  beforeEach(() => {
+    trackEventMock.mockReset();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = originalEnv;
+  });
+
+  describe('isDeepTierEnabled', () => {
+    it('returns false when flag is unset', async () => {
+      delete process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+      const { isDeepTierEnabled } = await import('../deepTier');
+      expect(isDeepTierEnabled()).toBe(false);
+    });
+
+    it('returns true only when flag is exactly the string "true"', async () => {
+      process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = 'true';
+      const { isDeepTierEnabled } = await import('../deepTier');
+      expect(isDeepTierEnabled()).toBe(true);
+    });
+
+    it('returns false for other truthy-looking strings', async () => {
+      for (const value of ['1', 'yes', 'TRUE', 'on']) {
+        process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = value;
+        vi.resetModules();
+        const { isDeepTierEnabled } = await import('../deepTier');
+        expect(isDeepTierEnabled()).toBe(false);
+      }
+    });
+  });
+
+  describe('getDeepGenerationModel', () => {
+    it('returns primary model when flag is off', async () => {
+      delete process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+      const { getDeepGenerationModel } = await import('../deepTier');
+      expect(getDeepGenerationModel('gdd')).toBe(AI_MODEL_PRIMARY);
+    });
+
+    it('returns deep model when flag is on', async () => {
+      process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = 'true';
+      const { getDeepGenerationModel } = await import('../deepTier');
+      expect(getDeepGenerationModel('gdd')).toBe(AI_MODEL_DEEP);
+    });
+
+    it('emits ai_deep_generation_eval with surface and model', async () => {
+      process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = 'true';
+      const { getDeepGenerationModel } = await import('../deepTier');
+
+      getDeepGenerationModel('world_builder');
+
+      expect(trackEventMock).toHaveBeenCalledWith('ai_deep_generation_eval', {
+        surface: 'world_builder',
+        model: AI_MODEL_DEEP,
+        deepTierEnabled: true,
+      });
+    });
+
+    it('emits the event even when flag is off so both arms are measurable', async () => {
+      delete process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+      const { getDeepGenerationModel } = await import('../deepTier');
+
+      getDeepGenerationModel('cutscene');
+
+      expect(trackEventMock).toHaveBeenCalledWith('ai_deep_generation_eval', {
+        surface: 'cutscene',
+        model: AI_MODEL_PRIMARY,
+        deepTierEnabled: false,
+      });
+    });
+  });
+});

--- a/web/src/lib/ai/__tests__/deepTier.test.ts
+++ b/web/src/lib/ai/__tests__/deepTier.test.ts
@@ -31,13 +31,21 @@ describe('deepTier', () => {
       expect(isDeepTierEnabled()).toBe(true);
     });
 
-    it('returns false for other truthy-looking strings', async () => {
-      for (const value of ['1', 'yes', 'TRUE', 'on']) {
-        process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = value;
-        vi.resetModules();
-        const { isDeepTierEnabled } = await import('../deepTier');
-        expect(isDeepTierEnabled()).toBe(false);
-      }
+    it.each([
+      ['1'],
+      ['yes'],
+      ['TRUE'],
+      ['on'],
+      [''],
+      [' true '],
+      ['false'],
+    ])('returns false for non-exact-"true" value: %j', async (value) => {
+      // Set env BEFORE resetModules so the fresh import reads the intended value.
+      // Order matters: vi.resetModules() clears the cache, the next import re-reads process.env.
+      process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = value;
+      vi.resetModules();
+      const { isDeepTierEnabled } = await import('../deepTier');
+      expect(isDeepTierEnabled()).toBe(false);
     });
   });
 

--- a/web/src/lib/ai/__tests__/deepTierIntegration.test.ts
+++ b/web/src/lib/ai/__tests__/deepTierIntegration.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests locking in the deep-tier linkage: each deep-generation
+ * surface (GDD, world builder, cutscene) MUST pass the model string returned
+ * by `getDeepGenerationModel()` through to `fetchAI`.
+ *
+ * Without these, a refactor that replaces the helper with a hardcoded
+ * constant, or drops the `model` key, would pass every per-module unit test
+ * while silently breaking the feature flag.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AI_MODEL_DEEP, AI_MODEL_PRIMARY } from '../models';
+
+const fetchAIMock = vi.fn();
+vi.mock('@/lib/ai/client', () => ({
+  fetchAI: (prompt: string, options?: Record<string, unknown>) =>
+    fetchAIMock(prompt, options),
+}));
+
+const trackEventMock = vi.fn();
+vi.mock('@/lib/analytics/posthog', () => ({
+  trackEvent: (name: string, props?: Record<string, unknown>) =>
+    trackEventMock(name, props),
+}));
+
+function getLastModel(): unknown {
+  const lastCall = fetchAIMock.mock.calls.at(-1);
+  const options = lastCall?.[1] as Record<string, unknown> | undefined;
+  return options?.model;
+}
+
+describe('deep-tier integration', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+
+  beforeEach(() => {
+    fetchAIMock.mockReset();
+    trackEventMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = originalEnv;
+  });
+
+  describe('flag off — routes to AI_MODEL_PRIMARY', () => {
+    beforeEach(() => {
+      delete process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+    });
+
+    it('gddGenerator passes AI_MODEL_PRIMARY to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue(JSON.stringify({
+        title: 'Stub',
+        logline: 'Stub logline',
+        sections: [],
+      }));
+
+      const { generateGDD } = await import('../gddGenerator');
+      await generateGDD('a puzzle game').catch(() => {
+        // parse errors don't matter — we only care about the fetchAI call
+      });
+
+      expect(fetchAIMock).toHaveBeenCalled();
+      expect(getLastModel()).toBe(AI_MODEL_PRIMARY);
+    });
+
+    it('worldBuilder passes AI_MODEL_PRIMARY to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue('{}');
+
+      const { generateWorld } = await import('../worldBuilder');
+      await generateWorld('a fantasy world', 'high_fantasy').catch(() => {
+        // parse errors don't matter
+      });
+
+      expect(fetchAIMock).toHaveBeenCalled();
+      expect(getLastModel()).toBe(AI_MODEL_PRIMARY);
+    });
+
+    it('cutsceneGenerator passes AI_MODEL_PRIMARY to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue(JSON.stringify({
+        name: 'Stub',
+        duration: 5,
+        tracks: [{
+          id: 't1',
+          type: 'camera',
+          keyframes: [{ timestamp: 0, duration: 1 }],
+        }],
+      }));
+
+      const { generateCutscene } = await import('../cutsceneGenerator');
+      await generateCutscene({
+        prompt: 'pan the sky',
+        sceneEntities: [],
+        duration: 5,
+      }).catch(() => {
+        // parse errors don't matter
+      });
+
+      expect(fetchAIMock).toHaveBeenCalled();
+      expect(getLastModel()).toBe(AI_MODEL_PRIMARY);
+    });
+  });
+
+  describe('flag on — routes to AI_MODEL_DEEP', () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_USE_DEEP_GENERATION = 'true';
+    });
+
+    it('gddGenerator passes AI_MODEL_DEEP to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue(JSON.stringify({
+        title: 'Stub',
+        logline: 'Stub logline',
+        sections: [],
+      }));
+
+      const { generateGDD } = await import('../gddGenerator');
+      await generateGDD('a puzzle game').catch(() => {});
+
+      expect(getLastModel()).toBe(AI_MODEL_DEEP);
+    });
+
+    it('worldBuilder passes AI_MODEL_DEEP to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue('{}');
+
+      const { generateWorld } = await import('../worldBuilder');
+      await generateWorld('a fantasy world', 'high_fantasy').catch(() => {});
+
+      expect(getLastModel()).toBe(AI_MODEL_DEEP);
+    });
+
+    it('cutsceneGenerator passes AI_MODEL_DEEP to fetchAI', async () => {
+      fetchAIMock.mockResolvedValue(JSON.stringify({
+        name: 'Stub',
+        duration: 5,
+        tracks: [{
+          id: 't1',
+          type: 'camera',
+          keyframes: [{ timestamp: 0, duration: 1 }],
+        }],
+      }));
+
+      const { generateCutscene } = await import('../cutsceneGenerator');
+      await generateCutscene({
+        prompt: 'pan the sky',
+        sceneEntities: [],
+        duration: 5,
+      }).catch(() => {});
+
+      expect(getLastModel()).toBe(AI_MODEL_DEEP);
+    });
+  });
+
+  it('emits ai_deep_generation_eval exactly once per generation', async () => {
+    delete process.env.NEXT_PUBLIC_USE_DEEP_GENERATION;
+    fetchAIMock.mockResolvedValue(JSON.stringify({
+      name: 'Stub',
+      duration: 5,
+      tracks: [{
+        id: 't1',
+        type: 'camera',
+        keyframes: [{ timestamp: 0, duration: 1 }],
+      }],
+    }));
+
+    const { generateCutscene } = await import('../cutsceneGenerator');
+    await generateCutscene({
+      prompt: 'pan the sky',
+      sceneEntities: [],
+      duration: 5,
+    }).catch(() => {});
+
+    const deepEvents = trackEventMock.mock.calls.filter(
+      ([name]) => name === 'ai_deep_generation_eval',
+    );
+    expect(deepEvents).toHaveLength(1);
+    expect(deepEvents[0]?.[1]).toMatchObject({
+      surface: 'cutscene',
+      model: AI_MODEL_PRIMARY,
+      deepTierEnabled: false,
+    });
+  });
+});

--- a/web/src/lib/ai/__tests__/models.test.ts
+++ b/web/src/lib/ai/__tests__/models.test.ts
@@ -3,8 +3,10 @@ import {
   AI_MODEL_PRIMARY,
   AI_MODEL_FAST,
   AI_MODEL_PREMIUM,
+  AI_MODEL_DEEP,
   AI_MODELS,
   GATEWAY_MODEL_PREMIUM,
+  GATEWAY_MODEL_DEEP,
   isPremiumModel,
 } from '../models';
 
@@ -32,6 +34,21 @@ describe('AI model constants', () => {
   it('AI_MODEL_FAST matches expected claude-haiku pattern', () => {
     expect(AI_MODEL_FAST).toMatch(/^claude-/);
   });
+
+  it('exports AI_MODEL_DEEP as a non-empty claude-* string', () => {
+    expect(typeof AI_MODEL_DEEP).toBe('string');
+    expect(AI_MODEL_DEEP).toMatch(/^claude-/);
+  });
+
+  it('AI_MODEL_DEEP is distinct from primary and fast tiers', () => {
+    expect(AI_MODEL_DEEP).not.toBe(AI_MODEL_PRIMARY);
+    expect(AI_MODEL_DEEP).not.toBe(AI_MODEL_FAST);
+  });
+
+  it('GATEWAY_MODEL_DEEP uses provider-namespaced format', () => {
+    expect(GATEWAY_MODEL_DEEP).toContain('/');
+    expect(GATEWAY_MODEL_DEEP.split('/')[0]).toBe('anthropic');
+  });
 });
 
 describe('AI_MODELS object', () => {
@@ -39,9 +56,11 @@ describe('AI_MODELS object', () => {
     const requiredKeys = [
       'chat',
       'fast',
+      'deep',
       'embedding',
       'gatewayChat',
       'gatewayEmbedding',
+      'gatewayDeep',
       'githubDefault',
       'openrouterDefault',
     ] as const;
@@ -59,6 +78,14 @@ describe('AI_MODELS object', () => {
 
   it('fast key matches AI_MODEL_FAST', () => {
     expect(AI_MODELS.fast).toBe(AI_MODEL_FAST);
+  });
+
+  it('deep key matches AI_MODEL_DEEP', () => {
+    expect(AI_MODELS.deep).toBe(AI_MODEL_DEEP);
+  });
+
+  it('gatewayDeep matches GATEWAY_MODEL_DEEP', () => {
+    expect(AI_MODELS.gatewayDeep).toBe(GATEWAY_MODEL_DEEP);
   });
 
   it('embedding key is a non-empty string', () => {

--- a/web/src/lib/ai/aiSdkAdapter.ts
+++ b/web/src/lib/ai/aiSdkAdapter.ts
@@ -46,6 +46,9 @@ function toGatewayModelId(canonicalModel: string): string {
   if (canonicalModel === AI_MODELS.fast || canonicalModel.includes('haiku')) {
     return AI_MODELS.gatewayChat; // haiku routes to chat gateway by default
   }
+  if (canonicalModel === AI_MODELS.deep || canonicalModel.includes('opus')) {
+    return AI_MODELS.gatewayDeep;
+  }
   // Fallback: construct gateway ID from canonical name
   return `anthropic/${canonicalModel}`;
 }

--- a/web/src/lib/ai/cutsceneGenerator.ts
+++ b/web/src/lib/ai/cutsceneGenerator.ts
@@ -7,6 +7,7 @@
  */
 
 import { fetchAI } from './client';
+import { getDeepGenerationModel } from './deepTier';
 import type { Cutscene, CutsceneTrack, CutsceneKeyframe, CutsceneTrackType, EasingMode } from '@/stores/cutsceneStore';
 
 // ============================================================================
@@ -207,6 +208,7 @@ export async function generateCutscene(
 ): Promise<Cutscene> {
   const prompt = buildCutscenePrompt(options);
   const raw = await fetchAI(prompt, {
+    model: getDeepGenerationModel('cutscene'),
     systemOverride: 'You are a cinematic director AI for a game engine. Always return valid JSON.',
     priority: 1,
   });

--- a/web/src/lib/ai/deepTier.ts
+++ b/web/src/lib/ai/deepTier.ts
@@ -1,0 +1,45 @@
+/**
+ * Deep-generation tier helpers.
+ *
+ * Gate the Opus 4.7 quality tier behind a feature flag so rollout can be
+ * canaried without a deploy. When `NEXT_PUBLIC_USE_DEEP_GENERATION=true`,
+ * deep-generation surfaces (GDD, world builder, cutscenes) route to
+ * AI_MODEL_DEEP. Otherwise they fall back to AI_MODEL_PRIMARY.
+ *
+ * Every call emits `ai_deep_generation_eval` to PostHog so we can A/B the
+ * tier against retention and publish-rate in a shared dashboard.
+ */
+
+import { AI_MODEL_DEEP, AI_MODEL_PRIMARY } from './models';
+import { trackEvent } from '@/lib/analytics/posthog';
+
+/** Surfaces eligible for the deep-generation tier. */
+export type DeepGenSurface = 'gdd' | 'world_builder' | 'cutscene';
+
+/**
+ * True when the deep-generation tier is enabled via
+ * `NEXT_PUBLIC_USE_DEEP_GENERATION`. Defaults to off.
+ */
+export function isDeepTierEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_USE_DEEP_GENERATION === 'true';
+}
+
+/**
+ * Return the model to use for a deep-generation surface and emit an
+ * analytics event tagging which tier handled the request.
+ *
+ * Call once per generation — the event pairs with downstream
+ * `AI_GENERATION_COMPLETED` for token-cost and retention analysis.
+ */
+export function getDeepGenerationModel(surface: DeepGenSurface): string {
+  const enabled = isDeepTierEnabled();
+  const model = enabled ? AI_MODEL_DEEP : AI_MODEL_PRIMARY;
+
+  trackEvent('ai_deep_generation_eval', {
+    surface,
+    model,
+    deepTierEnabled: enabled,
+  });
+
+  return model;
+}

--- a/web/src/lib/ai/gddGenerator.ts
+++ b/web/src/lib/ai/gddGenerator.ts
@@ -6,7 +6,7 @@
  * a typed GameDesignDocument structure.
  */
 
-import { AI_MODEL_PRIMARY } from './models';
+import { getDeepGenerationModel } from './deepTier';
 import { fetchAI } from './client';
 import { GDD_SCOPE_SET } from '@/lib/config/enums';
 
@@ -348,7 +348,7 @@ export async function generateGDD(
   const userMessage = buildUserPrompt(prompt, options);
 
   const content = await fetchAI(userMessage, {
-    model: AI_MODEL_PRIMARY,
+    model: getDeepGenerationModel('gdd'),
     sceneContext: '',
     thinking: false,
     systemOverride: GDD_SYSTEM_PROMPT,

--- a/web/src/lib/ai/models.ts
+++ b/web/src/lib/ai/models.ts
@@ -32,6 +32,15 @@ export const AI_MODEL_FAST = 'claude-haiku-4-5-20251001';
  */
 export const AI_MODEL_PREMIUM = 'claude-opus-4-7';
 
+/**
+ * Deep model for highest-quality single-shot generations where latency
+ * is secondary to output fidelity (GDD authoring, world building, cutscenes).
+ * Routed via the feature flag helper in `deepTier.ts`. Falls back to
+ * AI_MODEL_PRIMARY when the flag is off. Aliases AI_MODEL_PREMIUM — same
+ * Opus 4.7 model, separate semantic role (deep generators vs. user request).
+ */
+export const AI_MODEL_DEEP = AI_MODEL_PREMIUM;
+
 // ---------------------------------------------------------------------------
 // Gateway-format model strings (for use with AI SDK gateway() provider)
 // ---------------------------------------------------------------------------
@@ -44,6 +53,9 @@ export const GATEWAY_MODEL_FAST = 'anthropic/claude-haiku-4-5' as const;
 
 /** Premium chat model via Vercel AI Gateway (Pro tier only) */
 export const GATEWAY_MODEL_PREMIUM = 'anthropic/claude-opus-4-7' as const;
+
+/** Deep chat model via Vercel AI Gateway — alias of GATEWAY_MODEL_PREMIUM */
+export const GATEWAY_MODEL_DEEP = GATEWAY_MODEL_PREMIUM;
 
 /** Embedding model via Vercel AI Gateway */
 export const GATEWAY_MODEL_EMBEDDING = 'google/gemini-embedding-2-preview' as const;
@@ -62,6 +74,10 @@ export const AI_MODELS = {
   fast: AI_MODEL_FAST,
   /** Premium model — Pro tier only, highest quality (Opus 4.7) */
   premium: AI_MODEL_PREMIUM,
+  /** Deep model — highest-quality generation for GDD, world building, cutscenes */
+  deep: AI_MODEL_DEEP,
+  /** Gateway-format deep model string */
+  gatewayDeep: GATEWAY_MODEL_DEEP,
   /** Embedding model used by semantic search (docs, assets) */
   embedding: 'gemini-embedding-2-preview',
   /** Default gateway chat model (routed through Vercel AI Gateway) */

--- a/web/src/lib/ai/worldBuilder.ts
+++ b/web/src/lib/ai/worldBuilder.ts
@@ -3,7 +3,7 @@
  * Pure data module: types, presets, generation prompt builder, and parsers.
  */
 
-import { AI_MODEL_PRIMARY } from './models';
+import { getDeepGenerationModel } from './deepTier';
 import { fetchAI } from './client';
 
 // ---- Core Types ----
@@ -588,7 +588,7 @@ export async function generateWorld(description: string, preset?: string): Promi
   // Attempt AI generation — let HTTP/auth errors surface to the caller,
   // but fall back to the preset on network failures or parse errors.
   const content = await fetchAI(prompt, {
-    model: AI_MODEL_PRIMARY,
+    model: getDeepGenerationModel('world_builder'),
     priority: 2,
   });
 

--- a/web/src/lib/analytics/posthog.ts
+++ b/web/src/lib/analytics/posthog.ts
@@ -26,6 +26,7 @@ export enum AnalyticsEvent {
   TIER_UPGRADE_PROMPTED = 'tier_upgrade_prompted',
   TEMPLATE_APPLIED = 'template_applied',
   WASM_CDN_FALLBACK = 'wasm_cdn_fallback',
+  AI_DEEP_GENERATION_EVAL = 'ai_deep_generation_eval',
 }
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY ?? '';


### PR DESCRIPTION
## Summary

Adds an opt-in deep-generation tier that routes GDD, world builder, and cutscene generators to **Claude Opus 4.7** (`AI_MODEL_DEEP`) when `NEXT_PUBLIC_USE_DEEP_GENERATION=true`. Default off — every existing surface keeps using `AI_MODEL_PRIMARY` (Sonnet 4.6) until the flag flips.

Every call (both arms) emits `ai_deep_generation_eval` to PostHog so we can A/B token cost vs publish-rate during the canary.

Closes #8496 (PF-741)

## Why

Three deep-generation surfaces have quality-over-latency profiles distinct from chat: users wait seconds-to-minutes for a single high-fidelity document. Opus 4.7 is the right model for those — but unbounded rollout has cost risk and unproven user impact. ADR-2026-05-01 picks Option C: flag + 7-day canary + decision memo.

## Changes

- `web/src/lib/ai/models.ts` — `AI_MODEL_DEEP = 'claude-opus-4-7'`, `GATEWAY_MODEL_DEEP`, `AI_MODELS.deep` / `.gatewayDeep`
- `web/src/lib/ai/deepTier.ts` — `isDeepTierEnabled()` + `getDeepGenerationModel(surface)` (emits PostHog eval event)
- `web/src/lib/ai/{gddGenerator,worldBuilder,cutsceneGenerator}.ts` — replace hardcoded model with `getDeepGenerationModel(...)`
- `web/src/lib/ai/aiSdkAdapter.ts` — explicit Opus→`gatewayDeep` mapping (boy-scout: was relying on a coincidental fallback)
- `web/src/lib/analytics/posthog.ts` — `AI_DEEP_GENERATION_EVAL` enum entry
- `docs/decisions/2026-05-01-opus-deep-tier.md` — ADR
- `CLAUDE.md` + `web/.env.example` — flag documented
- Tests: `deepTier.test.ts` (14), `deepTierIntegration.test.ts` (13), `models.test.ts` (extended), `aiSdkAdapter.test.ts` (Opus routing)

## Review board

| Reviewer    | Verdict | Notes                                                                 |
|-------------|---------|-----------------------------------------------------------------------|
| Architect   | PASS    | Single-helper extension, no abstraction debt                          |
| Security    | PASS    | `NEXT_PUBLIC_` exposes only a boolean; no prompt/user data in events  |
| Test        | PASS    | Integration tests lock in `fetchAI(model: ...)` passthrough           |
| DX          | PASS    | After CLAUDE.md + `.env.example` doc additions                        |
| Code-quality| PASS    | Self-reviewed: types tight, no dead code (`gatewayDeep` now consumed) |

## Rollout (per ADR)

- **Day 0** (this PR merged) — flag default off; verify event emits with `deepTierEnabled: false`
- **Day 1** — flip flag on for 10% via Vercel env-var split (no code change)
- **Days 2–7** — monitor token cost delta, publish rate, support signals
- **Day 8** — review-date update to ADR with default-on / keep-off / narrow-scope decision

## Test plan

- [x] `npx vitest run src/lib/ai/__tests__/{deepTier,deepTierIntegration,models,aiSdkAdapter}.test.ts` — 68 tests passing
- [x] `npx eslint --max-warnings 0 src/lib/ai/` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] After deploy: confirm `ai_deep_generation_eval` events arrive in PostHog with `deepTierEnabled: false` for 100% of GDD / world / cutscene generations
- [ ] Day-1 canary smoke: flip flag in preview, run a GDD generation, confirm event payload shows `model: 'claude-opus-4-7'` and `deepTierEnabled: true`