### PR TITLE
chore(security): bump grid 1.0.1 + rand 0.8.6/0.9.4 (PF-744)

### DIFF
--- a/.changeset/cargo-grid-rand-bump.md
+++ b/.changeset/cargo-grid-rand-bump.md
@@ -1,0 +1,11 @@
+---
+"spawnforge": patch
+---
+
+Bump engine Rust transitives to clear Dependabot alerts:
+
+- `grid` 1.0.0 → 1.0.1 (medium): integer overflow in `Grid::expand_rows()` could trigger UB via the safe `get()` API
+- `rand` 0.8.5 → 0.8.6 (low): soundness issue with custom logger + `rand::rng()`
+- `rand` 0.9.2 → 0.9.4 (low): same soundness backport on the 0.9 line
+
+`cargo check --target wasm32-unknown-unknown --features webgl2` passes after the bump.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -747,7 +747,7 @@ dependencies = [
  "getrandom 0.3.4",
  "naga",
  "naga_oil",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_pcg",
  "ron 0.8.1",
  "serde",
@@ -931,7 +931,7 @@ dependencies = [
  "glam 0.30.10",
  "itertools 0.14.0",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "serde",
  "thiserror 2.0.18",
@@ -2738,7 +2738,7 @@ dependencies = [
  "encase",
  "libm",
  "mint",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_core",
 ]
 
@@ -2852,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "guillotiere"
@@ -3497,7 +3497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_xorshift",
 ]
 
@@ -4181,18 +4181,18 @@ checksum = "019b4b213425016d7d84a153c4c73afb0946fbb4840e4eece7ba8848b9d6da22"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -4230,7 +4230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps three Rust transitives in `engine/Cargo.lock` to clear 3 open Dependabot alerts:

| Package | From | To | Severity | Alert |
|---|---|---|---|---|
| grid | 1.0.0 | 1.0.1 | medium | #75 |
| rand | 0.8.5 | 0.8.6 | low | #70 |
| rand | 0.9.2 | 0.9.4 | low | #69 |

- **grid 1.0.1** — fixes integer overflow in `Grid::expand_rows()` that could cause UB via the safe `get()` API.
- **rand 0.8.6 / 0.9.4** — fixes a soundness issue when a custom logger uses `rand::rng()`.

Bundles all three cargo bumps into one PR (replaces dependabot PR #8488 which only covers rand 0.8.x).

Closes #8503 (PF-744)

## Test plan

- [x] `cargo update -p grid -p rand@0.9.2 -p rand@0.8.5` → clean diff (only the three packages and their checksum lines)
- [x] `cargo check --target wasm32-unknown-unknown --features webgl2` passes (40s, no errors)
- [ ] CI green
- [ ] Dependabot auto-dismisses alerts #69, #70, #75 after merge