### PR TITLE
fix(hooks): count taskboard tickets across columns[].tickets

### DIFF
--- a/.changeset/taskboard-hooks-ticket-count.md
+++ b/.changeset/taskboard-hooks-ticket-count.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Fix taskboard ticket-count hooks parsing wrong JSON shape. The `/api/board` endpoint returns `{"columns": [{"status": "...", "tickets": [...]}]}`, but three hooks were looking for a top-level `tickets` array, causing every session/prompt to fire a false "Board has 0 tickets — wrong DB path" warning even with 700+ tickets in the DB. Affects `.claude/hooks/on-session-start.sh`, `.claude/hooks/on-prompt-submit.sh`, and `.claude/hooks/taskboard-state.sh`. The fix sums `columns[].tickets` and falls back to the legacy top-level `tickets` shape so the warning fires only on a genuinely empty board.

--- a/.claude/hooks/on-prompt-submit.sh
+++ b/.claude/hooks/on-prompt-submit.sh
@@ -20,7 +20,7 @@ if ! tb_api_available; then
 fi
 
 # Health check: verify board has data (lesson #56)
-BOARD_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+BOARD_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])) or len(d.get('tickets',[])))" 2>/dev/null || echo "0")
 if [ "$BOARD_COUNT" = "0" ]; then
     echo "[TASKBOARD WARNING] Board has 0 tickets — wrong DB path or sync needed."
     echo "  Kill and restart: pkill taskboard && taskboard start --port 3010"

--- a/.claude/hooks/on-session-start.sh
+++ b/.claude/hooks/on-session-start.sh
@@ -67,7 +67,7 @@ fi
 
 # ── HEALTH CHECK: Verify board has data (lesson #56) ────────────────────
 # An empty board means wrong DB path. This catches it immediately.
-HEALTH_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+HEALTH_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])) or len(d.get('tickets',[])))" 2>/dev/null || echo "0")
 if [ "$HEALTH_COUNT" = "0" ]; then
     echo ""
     echo "╔══════════════════════════════════════════════════════════════╗"

--- a/.claude/hooks/taskboard-state.sh
+++ b/.claude/hooks/taskboard-state.sh
@@ -75,7 +75,7 @@ tb_auto_start() {
         if tb_api_available; then
             # HEALTH CHECK: verify the board actually has data.
             # If ticket count is 0, the DB path is wrong (lesson #56).
-            TICKET_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('tickets',[])))" 2>/dev/null || echo "0")
+            TICKET_COUNT=$(curl -s --connect-timeout 2 "$TB_API/board" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(len(c.get('tickets',[])) for c in d.get('columns',[])) or len(d.get('tickets',[])))" 2>/dev/null || echo "0")
             if [ "$TICKET_COUNT" = "0" ]; then
                 echo "[TASKBOARD WARNING] Board has 0 tickets — possible wrong DB path or sync needed." >&2
                 echo "[TASKBOARD WARNING] Try: python3 .claude/hooks/github_project_sync.py pull" >&2


### PR DESCRIPTION
## Summary

Three hooks were parsing the wrong JSON shape from `/api/board`, causing a false "Board has 0 tickets — wrong DB path" warning to fire on every session/prompt — even with 769 tickets in the local DB.

The `/api/board` endpoint returns:
```json
{ "columns": [{ "status": "todo", "tickets": [...] }, ...] }
```

But these hooks were checking `len(json.load(...).get("tickets", []))` (a top-level `tickets` array that doesn't exist).

## Fix

Changed the parser in three hooks to sum `columns[].tickets`, with a fallback to top-level `tickets` for any future shape change:

```python
sum(len(c.get('tickets',[])) for c in d.get('columns',[])) or len(d.get('tickets',[]))
```

Files:
- `.claude/hooks/on-session-start.sh:70`
- `.claude/hooks/on-prompt-submit.sh:23`
- `.claude/hooks/taskboard-state.sh:78`

## Why this matters

The hooks ran a "GitHub sync to populate the board" branch every time, which (a) was unnecessary work, (b) trained us to ignore the warning, so a genuine drift would now be missed.

## Test plan

- [x] Live count: `0` → `769` against `http://localhost:3010/api/board`
- [x] Empty `{"columns":[]}` returns `0`
- [x] Empty `{"columns":[{"tickets":[]}]}` returns `0`
- [x] Legacy `{"tickets":[]}` returns `0`
- [ ] CI quality gates green
- [ ] No more `[TASKBOARD WARNING] Board has 0 tickets` on next session start

Closes #8490