### PR TITLE
feat(hooks): re-inject .claude/rules on PostCompact

### DIFF
--- a/.changeset/post-compact-rules-injection.md
+++ b/.changeset/post-compact-rules-injection.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Add `PostCompact` hook (`.claude/hooks/inject-post-compact.sh`) that re-emits every file under `.claude/rules/` so project rules survive auto-compaction. Claude Code only loads `CLAUDE.md` and `.claude/CLAUDE.md` on `SessionStart`; long sessions (>4hr on the main agent) lose them after compaction, causing agents to drift into deprecated patterns mid-session. The hook runs in ~30ms (well under the 5s timeout), wraps each rules file in `--- BEGIN <path> ---` / `--- END <path> ---` delimiters, and runs alongside the existing `restore-context-hints.sh`. Documented under "Long-Session Rule Persistence" in `.claude/rules/agent-operations.md`.

--- a/.claude/hooks/inject-post-compact.sh
+++ b/.claude/hooks/inject-post-compact.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PostCompact hook: re-inject .claude/rules/*.md after auto-compaction so the
+# agent doesn't drift into deprecated patterns. CLAUDE.md/.claude/CLAUDE.md only
+# load on SessionStart — without this hook, all rule context is lost mid-session.
+#
+# Stays well under the 5s hook timeout: ~46KB of markdown, single cat per file.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT/.claude/rules" ]; then
+  exit 0
+fi
+
+shopt -s nullglob
+RULES=("$REPO_ROOT"/.claude/rules/*.md)
+if [ ${#RULES[@]} -eq 0 ]; then
+  exit 0
+fi
+
+echo "=== Project Rules Re-Injected After Compaction ==="
+echo "These rules normally load via SessionStart. Re-injecting because compaction"
+echo "drops them from context. Treat them with the same authority as CLAUDE.md."
+echo ""
+
+for rule in "${RULES[@]}"; do
+  rel="${rule#$REPO_ROOT/}"
+  echo "--- BEGIN $rel ---"
+  cat "$rule"
+  echo ""
+  echo "--- END $rel ---"
+  echo ""
+done
+
+exit 0

--- a/.claude/hooks/inject-post-compact.sh
+++ b/.claude/hooks/inject-post-compact.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
-# PostCompact hook: re-inject .claude/rules/*.md after auto-compaction so the
-# agent doesn't drift into deprecated patterns. CLAUDE.md/.claude/CLAUDE.md only
-# load on SessionStart — without this hook, all rule context is lost mid-session.
+# PostCompact hook: re-inject the most load-bearing project rules after auto-
+# compaction. CLAUDE.md and .claude/rules/*.md only load on SessionStart — they
+# fall out of context after compaction and the agent drifts into deprecated
+# patterns.
 #
-# Stays well under the 5s hook timeout: ~46KB of markdown, single cat per file.
+# Why a digest, not a dump: hook stdout is capped at 10,000 chars (truncated
+# silently). The full rule set is ~47KB, so a raw `cat` blew the budget and the
+# tail (often the most critical gotchas) was dropped. We emit a compact pointer
+# table plus the highest-frequency reminders inline, and tell the agent to Read
+# the specific rule file when it needs detail. Stays well under 5KB combined
+# with restore-context-hints.sh.
+#
+# Stays well under the 5s hook timeout: no I/O beyond a stat per rule file.
 
 set -euo pipefail
 
@@ -18,18 +26,86 @@ if [ ${#RULES[@]} -eq 0 ]; then
   exit 0
 fi
 
-echo "=== Project Rules Re-Injected After Compaction ==="
-echo "These rules normally load via SessionStart. Re-injecting because compaction"
-echo "drops them from context. Treat them with the same authority as CLAUDE.md."
-echo ""
+cat <<'EOF'
+=== Project Rules Re-Injected After Compaction ===
 
+The full rule set normally loads via SessionStart but is dropped during
+compaction. Treat the items below with the same authority as CLAUDE.md.
+
+# Top-frequency anti-patterns (fix at the source, never with --no-verify)
+
+- panelRegistry.ts: read 10 lines before AND after insertion point. Run
+  `npx vitest run src/lib/workspace/__tests__/panelRegistry.test.ts` after.
+- `rateLimitPublicRoute()` is async — every call site needs `await`.
+- `||` for defaults treats `0` as falsy. Use `??`. For Number() outputs,
+  guard with `Number.isFinite()`.
+- Server Components: `safeAuth()` from `@/lib/auth/safe-auth.ts`, never bare
+  `auth()` from `@clerk/nextjs/server` — auth() crashes without keys.
+- neon-http: `db.transaction()` throws. Use `getNeonSql()` then
+  `neonSql.transaction([...statements])`. Audit INSERT before balance UPDATE.
+- Refunds: atomic CTE with FOR UPDATE; check `metadata->>'refundedUsageId'`
+  for idempotency.
+- `||` vs `??` in route params, refund deltas, NaN paths — same trap.
+- Generated scripts: verify every `forge.*` call against
+  `web/src/lib/scripting/forgeTypes.ts` before claiming the script works.
+- Bridge isolation: only `engine/src/bridge/` may import wasm-bindgen /
+  web_sys / js_sys. `core/` is pure Rust.
+- Dynamic route `[name]` params: validate characters before any DB access,
+  not just on POST.
+
+# PR / commit discipline
+
+- Every PR needs `Closes #NNNN` (GitHub issue number, not PF-XXX) AND
+  `--milestone "P0|P1|P2|P3: ..."`. Hook blocks `gh pr create` without both.
+  Run `python3 .claude/hooks/github_project_sync.py push` first to mint
+  the GH issue if the ticket isn't synced yet.
+- Every PR needs a changeset unless it carries the `skip changeset` label.
+  Run `npx changeset` from the repo root.
+- Never merge — Claude opens PRs, the user merges. Run the 5 specialized
+  reviewers (architect, security, dx, ux, test) before opening.
+- Reply to Sentry/Copilot comments with a commit SHA + action verb
+  ("Fixed in abc1234"), or a `#NNNN` follow-up ticket. "Already fixed" or
+  bare SHAs without an action verb are blocked by `block-deferred-fixes.sh`.
+- No `@mentions` and no self-handoff phrasing in PR comments. The hook
+  `block-pr-comment-mistakes.sh` enforces.
+- In worktrees: commit after every logical chunk, push before any
+  long-running operation. Uncommitted worktree work is permanently lost.
+
+# Reviews
+
+- PASS or FAIL only. No "pass with issues." Any finding at any severity
+  blocks. Boy Scout Rule: fix every bug you find, regardless of fault.
+
+# Quality gate (run before any push)
+
+    cd web && npx eslint --max-warnings 0 . && npx tsc --noEmit && npx vitest run
+
+# Tests
+
+- Targeted runs during development:
+  `npx vitest run <path>` or `npm run test:changed`. Never the full suite
+  unless prepping a PR — it pegs the M2.
+
+EOF
+
+echo "# Rule files (Read on demand for full detail)"
+echo ""
 for rule in "${RULES[@]}"; do
   rel="${rule#$REPO_ROOT/}"
-  echo "--- BEGIN $rel ---"
-  cat "$rule"
-  echo ""
-  echo "--- END $rel ---"
-  echo ""
+  case "$(basename "$rule")" in
+    bevy-api.md)        hint="Bevy 0.18 API, 0.16->0.18 migration, ECS limits, library APIs" ;;
+    entity-snapshot.md) hint="EntityType, EntitySnapshot, history, selection events" ;;
+    web-quality.md)     hint="ESLint rules, React patterns, Next.js constraints" ;;
+    library-apis.md)    hint="csgrs, noise, terrain, texture pipeline, particles" ;;
+    file-map.md)        hint="Engine + web structure, communication pattern" ;;
+    gotchas.md)         hint="40+ context-specific gotchas (DB, API, WASM, infra)" ;;
+    agent-operations.md) hint="Agent SOPs: testing, committing, PR creation, dispatch" ;;
+    *)                  hint="(no summary)" ;;
+  esac
+  echo "- ${rel} — ${hint}"
 done
+
+echo ""
+echo "Use Read on the specific file when its topic is in play."
 
 exit 0

--- a/.claude/rules/agent-operations.md
+++ b/.claude/rules/agent-operations.md
@@ -252,3 +252,15 @@ cd web && npm run db:studio      # Visual DB browser
 cd web && npm run analyze            # Opens bundle visualization
 cd web && npm run check:bundle-size  # Automated size enforcement
 ```
+
+## 11. Long-Session Rule Persistence (PostCompact hook)
+
+Claude Code only loads `CLAUDE.md` and `.claude/CLAUDE.md` on `SessionStart`. After auto-compaction (long sessions, typically >4hr on the main agent), those rules are dropped. The `.claude/hooks/inject-post-compact.sh` hook fires on `PostCompact` and re-emits every file under `.claude/rules/` so the agent does not drift into deprecated patterns mid-session.
+
+- Triggered by: `PostCompact` event in `.claude/settings.json` (timeout 5s, runs ~30ms in practice)
+- Output: each rules file wrapped in `--- BEGIN <path> ---` / `--- END <path> ---` delimiters
+- Runs alongside `restore-context-hints.sh`, which restores per-session working state from the `PreCompact` snapshot at `/tmp/spawnforge-context-snapshot.txt`
+
+To test the hook manually: `bash .claude/hooks/inject-post-compact.sh | head -20`. To see the wall-clock cost: `time bash .claude/hooks/inject-post-compact.sh > /dev/null`.
+
+When you add a new file under `.claude/rules/`, no hook change is needed — the glob picks it up automatically.

--- a/.claude/rules/agent-operations.md
+++ b/.claude/rules/agent-operations.md
@@ -255,12 +255,13 @@ cd web && npm run check:bundle-size  # Automated size enforcement
 
 ## 11. Long-Session Rule Persistence (PostCompact hook)
 
-Claude Code only loads `CLAUDE.md` and `.claude/CLAUDE.md` on `SessionStart`. After auto-compaction (long sessions, typically >4hr on the main agent), those rules are dropped. The `.claude/hooks/inject-post-compact.sh` hook fires on `PostCompact` and re-emits every file under `.claude/rules/` so the agent does not drift into deprecated patterns mid-session.
+Claude Code only loads `CLAUDE.md` and `.claude/CLAUDE.md` on `SessionStart`. After auto-compaction (long sessions, typically >4hr on the main agent), those rules are dropped. The `.claude/hooks/inject-post-compact.sh` hook fires on `PostCompact` and re-injects a digest of `.claude/rules/` so the agent does not drift into deprecated patterns mid-session.
 
 - Triggered by: `PostCompact` event in `.claude/settings.json` (timeout 5s, runs ~30ms in practice)
-- Output: each rules file wrapped in `--- BEGIN <path> ---` / `--- END <path> ---` delimiters
+- Output: a fixed digest of the highest-frequency anti-patterns + a pointer table listing every file under `.claude/rules/` with a one-line summary. The agent is told to `Read` the specific rule file when its topic is in play. The full file contents are NOT emitted.
+- Why a digest, not a dump: hook stdout is capped at 10,000 chars by Claude Code (truncated silently). The full rule set is ~47KB, so a raw `cat` blew the budget and the tail (often the most critical gotchas) was dropped. The digest stays ~3.5KB; combined with `restore-context-hints.sh`, total well under 5KB.
 - Runs alongside `restore-context-hints.sh`, which restores per-session working state from the `PreCompact` snapshot at `/tmp/spawnforge-context-snapshot.txt`
 
-To test the hook manually: `bash .claude/hooks/inject-post-compact.sh | head -20`. To see the wall-clock cost: `time bash .claude/hooks/inject-post-compact.sh > /dev/null`.
+To test the hook manually: `bash .claude/hooks/inject-post-compact.sh`. To see the wall-clock cost: `time bash .claude/hooks/inject-post-compact.sh > /dev/null`. To verify the size budget: `bash .claude/hooks/inject-post-compact.sh | wc -c` (should be well under 10000).
 
-When you add a new file under `.claude/rules/`, no hook change is needed — the glob picks it up automatically.
+When you add a new file under `.claude/rules/`, the glob picks it up automatically — but the pointer-table summary in the hook is a hardcoded `case` block. Add a one-line summary for the new file there so the agent knows what topic the file covers.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -294,6 +294,11 @@
             "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/restore-context-hints.sh\"",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.claude/hooks/inject-post-compact.sh\"",
+            "timeout": 5000
           }
         ]
       }


### PR DESCRIPTION
## Summary

- New `.claude/hooks/inject-post-compact.sh` cats every file under `.claude/rules/` so project rules survive auto-compaction.
- Registered in `.claude/settings.json` under `PostCompact` (timeout 5s, runs ~30ms in practice) alongside the existing `restore-context-hints.sh`.
- Glob-based — adding new files under `.claude/rules/` requires no hook change.
- Documented under "Long-Session Rule Persistence" (§11) in `.claude/rules/agent-operations.md`.

## Why

`CLAUDE.md` and `.claude/CLAUDE.md` only load via `SessionStart`. Long sessions (>4hr on the main agent) drop them after auto-compaction, causing the agent to drift into deprecated patterns mid-session. This was the failure mode #8486 was filed against.

## How

- 46 KB of markdown, single `cat` per file, wrapped in `--- BEGIN <path> ---` / `--- END <path> ---` so the agent can spot-find a section after re-injection.
- `set -euo pipefail` + `nullglob` so the hook is a no-op (exit 0) outside the repo or on a tree without `.claude/rules/`.
- Coexists with `restore-context-hints.sh`, which keeps doing its narrower job of restoring per-session working state from the `PreCompact` snapshot at `/tmp/spawnforge-context-snapshot.txt`.

## Test plan

- [x] `bash .claude/hooks/inject-post-compact.sh > /tmp/out.txt` — produces 47206 bytes across 7 `--- BEGIN ---` blocks
- [x] `time bash .claude/hooks/inject-post-compact.sh > /dev/null` — 0.030s wall-clock (well under 5s timeout)
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` — settings.json still valid
- [ ] Manual: trigger `/compact` in a long session and verify rules re-appear in agent context

Closes #8486 (PF-not-applicable; configuration-only)