### PR TITLE
perf(ai): add effort param for non-chat generators (reviewer, tutorial, gdd)

### DIFF
--- a/.changeset/ai-effort-non-chat-generators.md
+++ b/.changeset/ai-effort-non-chat-generators.md
@@ -1,0 +1,7 @@
+---
+"spawnforge": patch
+---
+
+Add `effort: 'low' | 'medium' | 'high'` parameter to `createSpawnforgeAgent` and the `/api/chat` body, mirroring the Anthropic provider's reasoning-effort hint. Non-chat generators (`gameReviewer`, `tutorialGenerator`, `gddGenerator`) now opt in to `effort: 'medium'` instead of passing `thinking: false`, letting the SDK pick a sensible reasoning budget instead of guessing token counts.
+
+The chat route gates `effort` behind the same creator/pro tier check used for `thinking` mode and rejects unknown values with a 400. Both fields are emitted independently into `providerOptions.anthropic` and only on the direct backend; gateway routes ignore them.

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -772,6 +772,42 @@ describe('POST /api/chat', () => {
         expect.objectContaining({ model: 'claude-opus-4-7' }),
       );
     });
+
+    it('passes effort flag to agent factory for creator tier', async () => {
+      vi.mocked(withApiMiddleware).mockResolvedValue({
+        error: null,
+        authContext: { clerkId: 'clerk-1', user: { id: 'user-1', tier: 'creator' } as never },
+        rateLimit: { allowed: true, remaining: 9, resetAt: Date.now() + 60_000 },
+      } as never);
+
+      const res = await POST(makeRequest({ ...validBody(), effort: 'medium' }));
+      await res.text();
+      expect(createSpawnforgeAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ effort: 'medium' }),
+      );
+    });
+
+    it('blocks effort for non-creator/pro tiers', async () => {
+      vi.mocked(withApiMiddleware).mockResolvedValue({
+        error: null,
+        authContext: { clerkId: 'clerk-1', user: { id: 'user-1', tier: 'starter' } as never },
+        rateLimit: { allowed: true, remaining: 9, resetAt: Date.now() + 60_000 },
+      } as never);
+
+      const res = await POST(makeRequest({ ...validBody(), effort: 'medium' }));
+      await res.text();
+      const lastCallArgs = vi.mocked(createSpawnforgeAgent).mock.calls.at(-1)?.[0];
+      expect(lastCallArgs).not.toHaveProperty('effort');
+    });
+
+    it('rejects requests with invalid effort value', async () => {
+      const res = await POST(
+        makeRequest({ ...validBody(), effort: 'extreme' as unknown as 'low' }),
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toMatch(/effort/);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -622,11 +622,18 @@ describe('POST /api/chat', () => {
       const userOneScene = userOneBlocks.find((b) => b.text.includes('<!-- session:'));
       expect(userOneScene?.text).toContain('<!-- session:user-1 -->');
 
-      // Switch to a second user with byte-identical scene context.
+      // Switch to a second user with byte-identical scene context. The route
+      // reads user.id from withApiMiddleware (not authenticateRequest), so we
+      // override that mock here.
       vi.mocked(authenticateRequest).mockResolvedValue({
         ok: true,
         ctx: { clerkId: 'clerk-2', user: { id: 'user-2', tier: 'pro' } as never },
       });
+      vi.mocked(withApiMiddleware).mockResolvedValue({
+        error: null,
+        authContext: { clerkId: 'clerk-2', user: { id: 'user-2', tier: 'pro' } as never },
+        rateLimit: { allowed: true, remaining: 9, resetAt: Date.now() + 60_000 },
+      } as never);
       await (await POST(makeRequest(validBody()))).text();
       const userTwoCall = vi.mocked(createSpawnforgeAgent).mock.calls.at(-1)?.[0];
       const userTwoBlocks = (userTwoCall?.instructions ?? []) as Array<{ text: string; tier?: string }>;
@@ -657,17 +664,17 @@ describe('POST /api/chat', () => {
     });
 
     it('counts sceneContext.length toward the MAX_INPUT_CHARS budget', async () => {
-      // sceneContext alone is well under 600k, but combined with messages
-      // the total exceeds the 600k MAX_INPUT_CHARS guard. Without summing
+      // sceneContext alone is well under 2M, but combined with messages
+      // the total exceeds the 2M MAX_INPUT_CHARS guard. Without summing
       // sceneContext.length into totalChars (the bug fixed in this change),
       // the request would slip past the size check.
-      const longScene = 'x'.repeat(500_000);
+      const longScene = 'x'.repeat(1_900_000);
       const longContent = 'y'.repeat(3999);
       const messages = Array.from({ length: 30 }, (_, i) => ({
         role: i % 2 === 0 ? 'user' : 'assistant',
         content: longContent,
       }));
-      // 30 * 3999 = 119_970; combined with 500_000 sceneContext → 619_970 > 600_000.
+      // 30 * 3999 = 119_970; combined with 1_900_000 sceneContext → 2_019_970 > 2_000_000.
 
       const res = await POST(makeRequest({
         messages,

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -299,6 +299,7 @@ export async function POST(request: NextRequest) {
     model: string;
     sceneContext: string;
     thinking?: boolean;
+    effort?: 'low' | 'medium' | 'high';
     systemOverride?: string;
   };
 
@@ -308,7 +309,15 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { messages, model, sceneContext, thinking, systemOverride } = body;
+  const { messages, model, sceneContext, thinking, effort, systemOverride } = body;
+  // Validate effort enum — reject unknown values rather than passing them through
+  // to the SDK (which would surface as a less helpful runtime error).
+  if (effort !== undefined && effort !== 'low' && effort !== 'medium' && effort !== 'high') {
+    return Response.json(
+      { error: "effort must be one of: 'low', 'medium', 'high'" },
+      { status: 400 },
+    );
+  }
   if (!messages || !Array.isArray(messages)) {
     return Response.json({ error: 'messages array required' }, { status: 400 });
   }
@@ -506,11 +515,15 @@ export async function POST(request: NextRequest) {
   // Sonnet inside createSpawnforgeAgent — but billing already deducted at the
   // higher tier. Direct backends pass-through the canonical name unchanged.
   const resolvedModelId = chatRoute?.modelId ?? model ?? '';
+  // Effort piggybacks the same tier gate as thinking — both consume extra reasoning
+  // tokens and must be off by default for free/starter tiers.
+  const resolvedEffort = canUseThinking && effort ? effort : undefined;
   const agent = createSpawnforgeAgent({
     isDirectBackend: usingDirect,
     model: resolvedModelId,
     instructions: instructionBlocks,
     thinking: canUseThinking && thinking === true,
+    ...(resolvedEffort ? { effort: resolvedEffort } : {}),
   });
 
   // 8. Convert messages

--- a/web/src/lib/ai/__tests__/spawnforgeAgent.test.ts
+++ b/web/src/lib/ai/__tests__/spawnforgeAgent.test.ts
@@ -1,5 +1,55 @@
-import { describe, it, expect } from 'vitest';
-import { buildAgentInstructions } from '../spawnforgeAgent';
+/**
+ * Tests for the SpawnForge agent module:
+ *
+ * 1. buildAgentInstructions — pure function, exercises the cache_control / tier
+ *    routing logic for direct vs gateway backends.
+ * 2. createSpawnforgeAgent — providerOptions construction (thinking + effort).
+ *    Mocks ToolLoopAgent so we can assert constructor args without spinning up
+ *    a real agent.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockToolLoopAgent = vi.fn();
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return {
+    ...actual,
+    ToolLoopAgent: class {
+      constructor(args: unknown) {
+        mockToolLoopAgent(args);
+      }
+    },
+    stepCountIs: vi.fn((n: number) => ({ _stop: 'stepCount', n })),
+  };
+});
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  anthropic: vi.fn((id: string) => ({ _provider: 'anthropic', id })),
+}));
+
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: vi.fn((id: string) => ({ _provider: 'gateway', id })),
+}));
+
+vi.mock('@/lib/ai/toolAdapter', () => ({
+  convertManifestToolsToSdkTools: vi.fn(() => ({})),
+}));
+
+vi.mock('@/lib/ai/models', () => ({
+  AI_MODEL_PRIMARY: 'claude-sonnet-4.5',
+  AI_MODELS: { gatewayChat: 'anthropic/claude-sonnet-4.6' },
+}));
+
+vi.mock('@/data/commands.json', () => ({
+  default: { version: '1', commands: [] },
+}));
+
+import {
+  buildAgentInstructions,
+  createSpawnforgeAgent,
+} from '@/lib/ai/spawnforgeAgent';
 
 describe('buildAgentInstructions', () => {
   it('passes a plain string through unchanged', () => {
@@ -86,5 +136,76 @@ describe('buildAgentInstructions', () => {
       Record<string, unknown>
     >;
     expect(out[0]).not.toHaveProperty('providerOptions');
+  });
+});
+
+const baseOptions = {
+  isDirectBackend: true,
+  model: 'claude-sonnet-4.5',
+  instructions: 'system text',
+};
+
+describe('createSpawnforgeAgent — providerOptions', () => {
+  beforeEach(() => {
+    mockToolLoopAgent.mockClear();
+  });
+
+  it('omits providerOptions when neither thinking nor effort is set', () => {
+    createSpawnforgeAgent(baseOptions);
+    const args = mockToolLoopAgent.mock.calls[0][0] as { providerOptions?: unknown };
+    expect(args.providerOptions).toBeUndefined();
+  });
+
+  it('emits anthropic.thinking when thinking=true on direct backend', () => {
+    createSpawnforgeAgent({ ...baseOptions, thinking: true });
+    const args = mockToolLoopAgent.mock.calls[0][0] as { providerOptions?: { anthropic: unknown } };
+    expect(args.providerOptions).toEqual({
+      anthropic: { thinking: { type: 'enabled', budgetTokens: 10000 } },
+    });
+  });
+
+  it('emits anthropic.effort when effort is set on direct backend', () => {
+    createSpawnforgeAgent({ ...baseOptions, effort: 'medium' });
+    const args = mockToolLoopAgent.mock.calls[0][0] as { providerOptions?: { anthropic: unknown } };
+    expect(args.providerOptions).toEqual({
+      anthropic: { effort: 'medium' },
+    });
+  });
+
+  it('emits both thinking and effort together when both are set', () => {
+    createSpawnforgeAgent({ ...baseOptions, thinking: true, effort: 'high' });
+    const args = mockToolLoopAgent.mock.calls[0][0] as { providerOptions?: { anthropic: unknown } };
+    expect(args.providerOptions).toEqual({
+      anthropic: {
+        thinking: { type: 'enabled', budgetTokens: 10000 },
+        effort: 'high',
+      },
+    });
+  });
+
+  it('does not emit providerOptions for gateway backend even with thinking/effort', () => {
+    createSpawnforgeAgent({
+      ...baseOptions,
+      isDirectBackend: false,
+      thinking: true,
+      effort: 'medium',
+    });
+    const args = mockToolLoopAgent.mock.calls[0][0] as { providerOptions?: unknown };
+    expect(args.providerOptions).toBeUndefined();
+  });
+
+  it('forwards effort=low and effort=high without modification', () => {
+    createSpawnforgeAgent({ ...baseOptions, effort: 'low' });
+    expect(
+      (mockToolLoopAgent.mock.calls[0][0] as { providerOptions: { anthropic: { effort: string } } })
+        .providerOptions.anthropic.effort,
+    ).toBe('low');
+
+    mockToolLoopAgent.mockClear();
+    createSpawnforgeAgent({ ...baseOptions, effort: 'high' });
+    expect(
+      (mockToolLoopAgent.mock.calls[0][0] as { providerOptions: { anthropic: { effort: string } } })
+        .providerOptions.anthropic.effort,
+    ).toBe('high');
   });
 });

--- a/web/src/lib/ai/client.ts
+++ b/web/src/lib/ai/client.ts
@@ -24,6 +24,11 @@ export interface AIClientOptions {
   sceneContext?: string;
   /** Enable extended thinking mode (Claude 3.7+). */
   thinking?: boolean;
+  /**
+   * Reasoning effort hint forwarded to providerOptions.anthropic.effort.
+   * Direct backend only — gateway routes ignore it. Independent of `thinking`.
+   */
+  effort?: 'low' | 'medium' | 'high';
   /** AbortSignal to cancel the in-flight request. */
   signal?: AbortSignal;
   /**
@@ -110,8 +115,9 @@ export async function fetchAI(prompt: string, options?: AIClientOptions): Promis
   // request cannot poison the cache with a partial result.
   if (!signal) {
     const thinking = options?.thinking ?? false;
+    const effort = options?.effort ?? 'none';
     const cacheKey = await aiResponseCache.computeKey(
-      `${model}:${thinking ? 'thinking' : 'standard'}`,
+      `${model}:${thinking ? 'thinking' : 'standard'}:effort=${effort}`,
       systemOverride ?? '',
       `${sceneContext}\x00${prompt}`,
     );
@@ -127,6 +133,7 @@ async function fetchAIUncached(prompt: string, options?: AIClientOptions): Promi
     systemOverride,
     sceneContext = '',
     thinking = false,
+    effort,
     signal,
     priority = 1,
   } = options ?? {};
@@ -144,6 +151,7 @@ async function fetchAIUncached(prompt: string, options?: AIClientOptions): Promi
           model,
           sceneContext,
           thinking,
+          ...(effort !== undefined ? { effort } : {}),
           ...(systemOverride !== undefined ? { systemOverride } : {}),
         }),
         ...fetchOptions,

--- a/web/src/lib/ai/gameReviewer.ts
+++ b/web/src/lib/ai/gameReviewer.ts
@@ -323,7 +323,7 @@ export async function generateReview(context: ReviewContext): Promise<GameReview
     {
       model: AI_MODEL_FAST,
       sceneContext: '',
-      thinking: false,
+      effort: 'medium',
       systemOverride: REVIEWER_SYSTEM_PROMPT,
       priority: 3,
     },

--- a/web/src/lib/ai/gddGenerator.ts
+++ b/web/src/lib/ai/gddGenerator.ts
@@ -350,7 +350,7 @@ export async function generateGDD(
   const content = await fetchAI(userMessage, {
     model: getDeepGenerationModel('gdd'),
     sceneContext: '',
-    thinking: false,
+    effort: 'medium',
     systemOverride: GDD_SYSTEM_PROMPT,
     priority: 2,
   });

--- a/web/src/lib/ai/spawnforgeAgent.ts
+++ b/web/src/lib/ai/spawnforgeAgent.ts
@@ -100,6 +100,13 @@ export interface SpawnforgeAgentOptions {
   instructions: string | InstructionBlock[];
   /** Enable Claude thinking mode (direct backend only). */
   thinking?: boolean;
+  /**
+   * Reasoning effort hint (direct Anthropic backend only). Replaces hand-tuned
+   * `thinking.budgetTokens` for callers that want the SDK to manage the budget.
+   * Independent of `thinking`; both can be set, though setting `effort` alone is
+   * preferred for non-chat generators.
+   */
+  effort?: 'low' | 'medium' | 'high';
   /** Maximum tool-calling steps before stopping. Default: 10. */
   maxSteps?: number;
 }
@@ -136,7 +143,7 @@ export function buildAgentInstructions(
  * backend (BYOK direct vs gateway). Tools and step limit are shared.
  */
 export function createSpawnforgeAgent(options: SpawnforgeAgentOptions) {
-  const { isDirectBackend, model, instructions, thinking, maxSteps = 10 } = options;
+  const { isDirectBackend, model, instructions, thinking, effort, maxSteps = 10 } = options;
 
   const canonicalModel = model || AI_MODEL_PRIMARY;
 
@@ -146,11 +153,21 @@ export function createSpawnforgeAgent(options: SpawnforgeAgentOptions) {
         canonicalModel.includes('/') ? canonicalModel : AI_MODELS.gatewayChat,
       );
 
-  // Provider options for thinking mode (Anthropic direct only)
+  // Provider options for thinking + effort (Anthropic direct only). Both fields
+  // are independent in the Anthropic provider schema — thinking sets a hard token
+  // budget, effort lets the SDK pick a sensible default. Gateway routes ignore
+  // these fields, so we only emit them on the direct backend.
+  const anthropicOptions: { thinking?: { type: 'enabled'; budgetTokens: number }; effort?: 'low' | 'medium' | 'high' } = {};
+  if (isDirectBackend) {
+    if (thinking) {
+      anthropicOptions.thinking = { type: 'enabled', budgetTokens: 10000 };
+    }
+    if (effort) {
+      anthropicOptions.effort = effort;
+    }
+  }
   const providerOptions =
-    thinking && isDirectBackend
-      ? { anthropic: { thinking: { type: 'enabled' as const, budgetTokens: 10000 } } }
-      : undefined;
+    Object.keys(anthropicOptions).length > 0 ? { anthropic: anthropicOptions } : undefined;
 
   return new ToolLoopAgent({
     id: 'spawnforge',

--- a/web/src/lib/ai/tutorialGenerator.ts
+++ b/web/src/lib/ai/tutorialGenerator.ts
@@ -403,7 +403,7 @@ export async function generateTutorialPlan(
   const content = await fetchAI(userMessage, {
     model: AI_MODEL_PRIMARY,
     sceneContext: '',
-    thinking: false,
+    effort: 'medium',
     systemOverride: TUTORIAL_SYSTEM_PROMPT,
     priority: 2,
   });


### PR DESCRIPTION
## Summary

- Add `effort?: 'low' | 'medium' | 'high'` to `SpawnforgeAgentOptions` and `AIClientOptions`
- Plumb effort through `fetchAI` → `/api/chat` → `createSpawnforgeAgent`
- Switch `gameReviewer.ts:326`, `tutorialGenerator.ts:406`, `gddGenerator.ts:353` from `thinking: false` to `effort: 'medium'`
- Tier-gate effort behind creator/pro (same gate as `thinking`)
- Reject invalid effort enums with 400 at the route level
- Independent of `thinking` — both can be set together; both only emit on the direct backend

The Anthropic SDK exposes `effort` separately from `thinking.budgetTokens`. Letting it pick a sensible budget is preferable for non-chat generators where we previously guessed `10000` token budgets or sent `thinking: false` (no reasoning at all).

Closes #8485

## Test plan

- [x] New `web/src/lib/ai/__tests__/spawnforgeAgent.test.ts` (6 cases): asserts providerOptions shape for all combinations of thinking/effort × direct/gateway
- [x] Updated `web/src/app/api/chat/__tests__/route.test.ts` (+3 cases): creator-tier passthrough, starter-tier blocking, invalid-enum 400
- [x] All existing tests still pass: 147 across client/gameReviewer/tutorial/gdd suites
- [x] `npx eslint --max-warnings 0` clean on all modified files
- [x] `npx tsc --noEmit` introduces no new errors (pre-existing `@spawnforge/ui` resolution noise on main is untouched)