### PR TITLE
chore(deps): bump stripe 22.1.0 + apiVersion 2026-04-22.dahlia

### DIFF
--- a/.changeset/stripe-22-1-0.md
+++ b/.changeset/stripe-22-1-0.md
@@ -1,0 +1,9 @@
+---
+"spawnforge": patch
+---
+
+Bump `stripe` from 22.0.1 to 22.1.0 and pin Stripe API version to `2026-04-22.dahlia` (was `2026-03-25.dahlia`).
+
+The 22.1.0 release adds support for new account capabilities (`app_distribution`, `sunbit_payments`), new account-session components (`balance_report`, `payout_reconciliation_report`), and new `BalanceTransaction.type` enum values (`fee_credit_funding`, `inbound_transfer_reversal`, `inbound_transfer`). None of those surfaces are consumed by SpawnForge today, so the bump is non-breaking for current usage.
+
+Tests in `web/src/app/api/billing/{checkout,portal,status}/route.test.ts` were updated to assert the new pinned version. The webhook route comment about `invoice.parent` vs `invoice.subscription` was retargeted to the new pin date.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20381,6 +20381,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
@@ -22233,7 +22250,7 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
-        "stripe": "~22.0.1",
+        "stripe": "^22.1.0",
         "svix": "^1.89.0",
         "web-vitals": "^5.1.0",
         "zod": "^4.3.6",
@@ -22410,23 +22427,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
-    },
-    "web/node_modules/stripe": {
-      "version": "22.0.2",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.2.tgz",
-      "integrity": "sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/node": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -82,7 +82,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
-    "stripe": "~22.0.1",
+    "stripe": "^22.1.0",
     "svix": "^1.89.0",
     "web-vitals": "^5.1.0",
     "zod": "^4.3.6",

--- a/web/src/app/api/billing/checkout/route.test.ts
+++ b/web/src/app/api/billing/checkout/route.test.ts
@@ -193,7 +193,7 @@ describe('POST /api/billing/checkout', () => {
     const { POST } = await import('./route');
     await POST(makeReq({ tier: 'hobbyist' }));
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-03-25.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-04-22.dahlia');
   });
 
   it('returns 500 when Stripe checkout creation fails', async () => {

--- a/web/src/app/api/billing/portal/route.test.ts
+++ b/web/src/app/api/billing/portal/route.test.ts
@@ -118,7 +118,7 @@ describe('POST /api/billing/portal', () => {
     const { POST } = await import('./route');
     await POST(makeReq());
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-03-25.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-04-22.dahlia');
   });
 
   it('returns 500 when Stripe portal creation fails', async () => {

--- a/web/src/app/api/billing/status/route.test.ts
+++ b/web/src/app/api/billing/status/route.test.ts
@@ -124,7 +124,7 @@ describe('GET /api/billing/status', () => {
     const { GET } = await import('./route');
     await GET(makeReq());
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-03-25.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-04-22.dahlia');
   });
 
   it('returns subscriptionStatus from Stripe', async () => {

--- a/web/src/app/api/stripe/webhook/route.ts
+++ b/web/src/app/api/stripe/webhook/route.ts
@@ -168,7 +168,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
       if (!customerId) break;
 
       // v22 (dahlia) nests subscription under invoice.parent; pre-dahlia uses top-level invoice.subscription.
-      // Keep both reads until Dashboard webhook endpoint is confirmed on 2026-03-25.dahlia.
+      // Keep both reads until Dashboard webhook endpoint is confirmed on 2026-04-22.dahlia.
       const subField = invoice.parent?.subscription_details?.subscription
         ?? (invoice as unknown as { subscription?: string | { id: string } | null }).subscription
         ?? null;

--- a/web/src/lib/billing/stripe-client.ts
+++ b/web/src/lib/billing/stripe-client.ts
@@ -3,5 +3,5 @@ import Stripe from 'stripe';
 export function getStripe(): Stripe {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) throw new Error('STRIPE_SECRET_KEY environment variable is not set');
-  return new Stripe(key, { apiVersion: '2026-03-25.dahlia' });
+  return new Stripe(key, { apiVersion: '2026-04-22.dahlia' });
 }


### PR DESCRIPTION
## Summary

- Bump `stripe` from `^22.0.1` to `^22.1.0`
- Update pinned API version from `2026-03-25.dahlia` to `2026-04-22.dahlia` in `stripe-client.ts`
- Update billing route tests (checkout/portal/status) to assert the new pin
- Retarget the `invoice.parent` vs `invoice.subscription` comment in the webhook route

## What 22.1.0 adds

- New `Account.capabilities`: `app_distribution`, `sunbit_payments`
- New `AccountSession.components`: `balance_report`, `payout_reconciliation_report`
- ⚠️ New `BalanceTransaction.type` enum values: `fee_credit_funding`, `inbound_transfer_reversal`, `inbound_transfer`

None of those surfaces are consumed by SpawnForge today (verified — grep shows zero matches for `BalanceTransaction.type` in `web/src`). The enum widening is the only "potential" breaking change and we don't switch on the type.

## Why bump now

The new pin includes server-side Dahlia API improvements that ship without action; staying current avoids a larger jump later. Patch release, fully type-compatible with our existing usage.

Closes #8509

## Test plan

- [x] `npx vitest run src/app/api/billing/ src/lib/billing/ src/app/api/stripe/` — 164/164 pass locally
- [x] `npx eslint --max-warnings 0` clean on touched files
- [x] `npx tsc --noEmit` clean
- [ ] CI quality gate green
- [ ] Live verification deferred to user (production webhook traffic is the only true integration test)