### PR TITLE
perf(chat): raise MAX_INPUT_CHARS to 2M for Sonnet 4.6 1M context

### DIFF
--- a/.changeset/raise-max-input-chars.md
+++ b/.changeset/raise-max-input-chars.md
@@ -1,0 +1,8 @@
+---
+"spawnforge": minor
+---
+
+Raise the chat conversation size limit from ~150k tokens to ~500k tokens to
+leverage Sonnet 4.6's 1M-token context window. Body limit goes from 1MB to 4MB
+to fit the new content budget plus image data and tool results. Long
+game-design conversations no longer hit a premature 413 wall mid-session.

--- a/web/src/app/api/chat/__tests__/negative-cases.test.ts
+++ b/web/src/app/api/chat/__tests__/negative-cases.test.ts
@@ -234,13 +234,13 @@ describe('POST /api/chat — negative cases', () => {
   // Conversation token budget (413)
   // -------------------------------------------------------------------------
   describe('conversation token budget', () => {
-    it('returns 413 when total string content exceeds 600K chars', async () => {
-      // Build a conversation that exceeds MAX_INPUT_CHARS (600000)
+    it('returns 413 when total string content exceeds the conversation budget', async () => {
+      // Build a conversation that exceeds MAX_INPUT_CHARS (2,000,000)
       const longContent = 'x'.repeat(3500); // Under per-message 4000 limit
-      const messages = Array.from({ length: 200 }, () => ({
+      const messages = Array.from({ length: 600 }, () => ({
         role: 'user',
         content: longContent,
-      })); // 200 * 3500 = 700,000 chars > 600K
+      })); // 600 * 3500 = 2,100,000 chars > 2,000,000
 
       const res = await POST(makeRequest({
         messages,
@@ -254,10 +254,10 @@ describe('POST /api/chat — negative cases', () => {
 
     it('counts text blocks within content arrays for budget', async () => {
       const longText = 'y'.repeat(3000);
-      const messages = Array.from({ length: 250 }, () => ({
+      const messages = Array.from({ length: 700 }, () => ({
         role: 'assistant',
         content: [{ type: 'text', text: longText }],
-      })); // 250 * 3000 = 750K chars via array content
+      })); // 700 * 3000 = 2,100,000 chars via array content > 2,000,000
 
       const res = await POST(makeRequest({
         messages,

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -504,13 +504,16 @@ describe('POST /api/chat', () => {
     });
 
     it('refunds tokens when conversation exceeds token budget (413)', async () => {
-      // Build a body where totalChars > 600_000 (MAX_INPUT_CHARS)
-      const longContent = 'x'.repeat(3999); // under per-message limit
-      const messages = Array.from({ length: 200 }, (_, i) => ({
+      // Build a body where totalChars > 2_000_000 (MAX_INPUT_CHARS).
+      // sanitizeUserMessage caps each user message at ~4k chars, so this test
+      // mocks it through to keep the per-message content intact and lets the
+      // body-size + budget check fire naturally.
+      const longContent = 'x'.repeat(3999); // under per-message sanitize cap
+      const messages = Array.from({ length: 600 }, (_, i) => ({
         role: i % 2 === 0 ? 'user' : 'assistant',
         content: longContent,
       }));
-      // 200 * 3999 = 799_800 > 600_000
+      // 600 * 3999 = 2_399_400 > 2_000_000
 
       const res = await POST(makeRequest({
         messages,

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -279,12 +279,14 @@ export async function POST(request: NextRequest) {
   const tierError = assertTier(auth.ctx.user, ['hobbyist', 'creator', 'pro']);
   if (tierError) return tierError;
 
-  // 2. Validate request size (max 1MB — generous limit for conversation history + scene context;
-  //    the more precise MAX_INPUT_CHARS check below enforces the actual token budget)
+  // 2. Validate request size (max 4MB — sized to fit MAX_INPUT_CHARS=2M plus
+  //    JSON overhead, base64 image data, and tool results. Sits well under
+  //    Vercel's 4.5MB serverless body limit. The MAX_INPUT_CHARS check below
+  //    enforces the actual text-content token budget.)
   const bodyText = await request.text();
-  if (!validateBodySize(bodyText, 1024 * 1024)) {
+  if (!validateBodySize(bodyText, 4 * 1024 * 1024)) {
     return Response.json(
-      { error: 'Request too large. Maximum 1MB allowed.' },
+      { error: 'Request too large. Maximum 4MB allowed.' },
       { status: 413 }
     );
   }
@@ -366,8 +368,12 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // 5b. Server-side token budget validation
-  const MAX_INPUT_CHARS = 600000; // ~150k tokens (well within Claude's window)
+  // 5b. Server-side token budget validation.
+  // 2M chars ~= 500k tokens at 4 chars/token, leaving ~500k of Sonnet's 1M
+  // window for output and tool round-trips. Larger limits would push close to
+  // the model cap with no headroom; smaller limits unnecessarily 413 long
+  // game-design conversations (#8484).
+  const MAX_INPUT_CHARS = 2_000_000;
   let totalChars = 0;
   for (const msg of messages) {
     if (typeof msg.content === 'string') {
@@ -397,7 +403,11 @@ export async function POST(request: NextRequest) {
       });
     }
     return Response.json(
-      { error: 'Conversation too long. Please start a new conversation or clear older messages.' },
+      {
+        error:
+          'Conversation too long for the model context window. Start a new chat, ' +
+          'or clear older messages to free up space.',
+      },
       { status: 413 }
     );
   }
@@ -430,7 +440,7 @@ export async function POST(request: NextRequest) {
     // sceneContext is client-supplied structured data (engine scene state).
     // Strip control characters (security) but do NOT apply the 10k system
     // prompt length cap — scene context for complex scenes can legitimately
-    // be 50k+ chars. The total input budget (MAX_INPUT_CHARS = 600k) at
+    // be 50k+ chars. The total input budget (MAX_INPUT_CHARS = 2M) at
     // step 5b is the real size guard for the entire conversation.
     const sanitizedContext = sceneContext.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
     systemText += '\n\n' + sanitizedContext;


### PR DESCRIPTION
## Summary
- Raise `MAX_INPUT_CHARS` from 600k to 2M (~150k → ~500k tokens) to leverage Sonnet 4.6's 1M context window
- Raise body-size limit from 1MB to 4MB so the new content budget is actually reachable (sits under Vercel's 4.5MB serverless cap)
- Tighten the 413 error message to point users at starting a new chat
- Update unit test to exercise the new threshold

Closes #8484

## Why this size
- 2M chars × 4 chars/token ≈ 500k input tokens
- Leaves ~500k of the 1M budget for output + tool round-trips
- Pushing higher (4M ≈ 1M tok) would leave no headroom and risks degraded recall near the cap

## Test plan
- [x] `npx vitest run src/app/api/chat/__tests__/route.test.ts` — 25/25 pass
- [x] `npx eslint --max-warnings 0` on changed files — clean
- [ ] Manual check after deploy: send a long conversation that previously 413'd, confirm it streams