### PR TITLE
feat(mcp): add Streamable HTTP transport (#8497)

### DIFF
--- a/.changeset/mcp-http-transport.md
+++ b/.changeset/mcp-http-transport.md
@@ -1,0 +1,5 @@
+---
+"@project-forge/mcp-server": minor
+---
+
+Add Streamable HTTP transport (MCP spec 2025-11-25) alongside the existing stdio transport. Enable with `MCP_TRANSPORT=http` and a Bearer token in `MCP_HTTP_TOKEN`. Supports both stateful (SDK-managed sessions) and stateless (`MCP_HTTP_STATELESS=1`, fresh transport per request) modes, per-IP rate limiting (Upstash with in-memory fallback), an unauthenticated `/health` probe, and a 4MB request body cap.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,121 @@
+# SpawnForge MCP Server
+
+Exposes 350 SpawnForge editor commands as MCP tools over either **stdio** (local
+subprocess) or **Streamable HTTP** (remote / browser-based hosts).
+
+The server itself does not execute commands — it forwards JSON-RPC messages to
+the editor over a WebSocket bridge (`FORGE_EDITOR_WS_URL`, default
+`ws://localhost:3001/api/mcp/ws`). Tools will return errors until the editor is
+running.
+
+## Quick start
+
+### stdio (default) — for Claude Desktop, local agents
+
+```bash
+npm run build
+node dist/index.js
+```
+
+The MCP spec for stdio uses line-delimited JSON-RPC over stdin/stdout. No
+configuration needed beyond the built artifact.
+
+### Streamable HTTP — for remote / browser hosts
+
+```bash
+export MCP_TRANSPORT=http
+export MCP_HTTP_TOKEN=$(openssl rand -hex 32)
+export MCP_HTTP_PORT=3030          # default
+export MCP_HTTP_HOST=0.0.0.0       # default
+export MCP_HTTP_STATELESS=1        # optional: stateless mode, JSON responses only
+node dist/index.js
+```
+
+The server refuses to start if `MCP_HTTP_TOKEN` is empty.
+
+## HTTP endpoints
+
+| Method   | Path     | Auth                        | Purpose                                  |
+|----------|----------|-----------------------------|------------------------------------------|
+| `GET`    | `/health`| none                        | Liveness probe + server metadata         |
+| `POST`   | `/mcp`   | `Authorization: Bearer …`   | JSON-RPC requests (`tools/list`, …)      |
+| `GET`    | `/mcp`   | `Authorization: Bearer …`   | Standalone server-to-client SSE channel  |
+| `DELETE` | `/mcp`   | `Authorization: Bearer …`   | Close a session (stateful mode only)     |
+
+### Example
+
+```bash
+TOKEN=…  # the value of MCP_HTTP_TOKEN
+
+# Health (no auth)
+curl http://localhost:3030/health
+
+# Initialize (stateless mode)
+curl -X POST http://localhost:3030/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc":"2.0","id":1,"method":"initialize",
+    "params":{"protocolVersion":"2025-06-18","capabilities":{},
+              "clientInfo":{"name":"curl","version":"0"}}
+  }'
+
+# List tools
+curl -X POST http://localhost:3030/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+## Session models
+
+- **Stateful** (default): one transport+server pair handles every request. The
+  SDK assigns a session ID on `initialize` and clients must include it on every
+  follow-up request as the `Mcp-Session-Id` header.
+- **Stateless** (`MCP_HTTP_STATELESS=1`): a fresh transport+server is built per
+  request and torn down on response close. JSON-only responses, no sessions.
+  This matches the SDK's reference example and is the only safe way to handle
+  concurrent stateless clients.
+
+## Auth
+
+Bearer token via the `Authorization` header. The server compares against
+`MCP_HTTP_TOKEN` in constant time (`timingSafeEqual`). The `/health` endpoint is
+intentionally unauthenticated so load balancers and uptime probes can reach it
+without a token.
+
+## Rate limiting
+
+Per-IP, **30 requests / 5 minutes**, applied after auth.
+
+When `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are present, the
+server uses an Upstash sliding-window limiter (the same backend the web app
+uses for public routes). Otherwise it falls back to an in-memory limiter
+suitable only for single-instance deployments. Redis errors fail open.
+
+The first hop of `X-Forwarded-For` is honoured if present, falling back to the
+TCP remote address.
+
+## Deployment notes
+
+- Behind a reverse proxy, set `X-Forwarded-For` so per-IP limits work.
+- For multi-instance deployments, the Upstash backend is required — the
+  in-memory limiter only sees its own process.
+- The bare `node dist/index.js` works on any container host. A Vercel function
+  wrapper for `mcp.spawnforge.ai` is tracked separately (see issue #8497
+  acceptance criteria).
+
+## Environment variables
+
+| Variable                       | Default                              | Required when               |
+|--------------------------------|--------------------------------------|-----------------------------|
+| `MCP_TRANSPORT`                | `stdio`                              | always                      |
+| `FORGE_EDITOR_WS_URL`          | `ws://localhost:3001/api/mcp/ws`     | always                      |
+| `MCP_HTTP_TOKEN`               | (none — server refuses to start)     | `MCP_TRANSPORT=http`        |
+| `MCP_HTTP_PORT`                | `3030`                               | `MCP_TRANSPORT=http`        |
+| `MCP_HTTP_HOST`                | `0.0.0.0`                            | `MCP_TRANSPORT=http`        |
+| `MCP_HTTP_STATELESS`           | unset (stateful)                     | optional                    |
+| `UPSTASH_REDIS_REST_URL`       | (in-memory limiter)                  | optional                    |
+| `UPSTASH_REDIS_REST_TOKEN`     | (in-memory limiter)                  | optional                    |

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -6,29 +6,73 @@ import { registerTools } from './tools/generated.js';
 import { registerResources } from './resources/index.js';
 import { registerDocs } from './docs/index.js';
 import { EditorBridge } from './transport/websocket.js';
+import { startHttpTransport, MissingTokenError } from './transport/http.js';
+import manifest from '../manifest/commands.json' with { type: 'json' };
 
-async function main() {
+const SERVER_NAME = 'spawnforge';
+const SERVER_VERSION = '0.1.0';
+
+function buildServer(bridge: EditorBridge): McpServer {
   const server = new McpServer({
-    name: 'spawnforge',
-    version: '0.1.0',
+    name: SERVER_NAME,
+    version: SERVER_VERSION,
   });
 
-  // Editor bridge — connects to the running Next.js editor via WebSocket
+  registerTools(server, bridge);
+  registerResources(server, bridge);
+  registerDocs(server);
+
+  return server;
+}
+
+async function main() {
   const editorUrl = process.env.FORGE_EDITOR_WS_URL ?? 'ws://localhost:3001/api/mcp/ws';
   const bridge = new EditorBridge(editorUrl);
 
-  // Register all tools from the command manifest
-  registerTools(server, bridge);
+  const transportMode = (process.env.MCP_TRANSPORT ?? 'stdio').toLowerCase();
 
-  // Register MCP resources (scene graph, selection, etc.)
-  registerResources(server, bridge);
+  if (transportMode === 'http') {
+    const port = Number(process.env.MCP_HTTP_PORT ?? 3030);
+    const host = process.env.MCP_HTTP_HOST ?? '0.0.0.0';
+    const stateless = process.env.MCP_HTTP_STATELESS === '1';
+    const commands = (manifest as { commands?: unknown[] }).commands ?? [];
 
-  // Register documentation resources and tools
-  registerDocs(server);
+    const running = await startHttpTransport(() => buildServer(bridge), {
+      port,
+      host,
+      token: process.env.MCP_HTTP_TOKEN ?? '',
+      stateless,
+      rateLimit: {
+        windowMs: 5 * 60_000,
+        max: 30,
+      },
+      meta: {
+        name: SERVER_NAME,
+        version: SERVER_VERSION,
+        commandCount: commands.length,
+      },
+    });
 
-  // Connect via stdio (for Claude Desktop / Claude Code)
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+    console.error(`[forge-mcp] HTTP transport listening on http://${host}:${running.port}`);
+    console.error(`[forge-mcp]   POST /mcp     — JSON-RPC requests (Bearer auth required)`);
+    console.error(`[forge-mcp]   GET  /mcp     — SSE stream (Bearer auth required)`);
+    console.error(`[forge-mcp]   GET  /health  — liveness probe (no auth)`);
+    console.error(`[forge-mcp]   session mode: ${stateless ? 'stateless' : 'stateful'}`);
+
+    const shutdown = (signal: string) => {
+      console.error(`[forge-mcp] Received ${signal}, shutting down`);
+      running
+        .close()
+        .catch((err) => console.error('[forge-mcp] shutdown error:', err))
+        .finally(() => process.exit(0));
+    };
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
+  } else {
+    const server = buildServer(bridge);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  }
 
   // Attempt to connect to editor (non-blocking — tools will error if bridge isn't connected)
   bridge.connect().catch((err) => {
@@ -38,6 +82,11 @@ async function main() {
 }
 
 main().catch((err) => {
+  if (err instanceof MissingTokenError) {
+    console.error(`[forge-mcp] ${err.message}`);
+    console.error('[forge-mcp] Generate one with: openssl rand -hex 32');
+    process.exit(1);
+  }
   console.error('Fatal error:', err);
   process.exit(1);
 });

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type {
+  jsonSchemaValidator,
+  JsonSchemaType,
+  JsonSchemaValidator,
+} from '@modelcontextprotocol/sdk/validation/types.js';
+import { z } from 'zod';
+import { startHttpTransport, MissingTokenError, type RunningHttpServer } from '../http.js';
+
+const TEST_TOKEN = 'test-token-deadbeef';
+
+// Bypass AJV in tests — vitest's ESM resolver mishandles ajv-formats' default
+// import, breaking the SDK's default validator. The transport tests don't
+// exercise schema validation, so a permissive no-op is safe here.
+const noopValidator: jsonSchemaValidator = {
+  getValidator<T>(_schema: JsonSchemaType): JsonSchemaValidator<T> {
+    return (input: unknown) => ({ valid: true, data: input as T, errorMessage: undefined });
+  },
+};
+
+function buildTestServer(): McpServer {
+  const server = new McpServer(
+    { name: 'test-server', version: '0.0.0' },
+    { jsonSchemaValidator: noopValidator },
+  );
+  server.registerTool(
+    'echo',
+    {
+      title: 'Echo',
+      description: 'Returns its input',
+      inputSchema: { value: z.string() },
+    },
+    async ({ value }) => ({
+      content: [{ type: 'text', text: value }],
+    }),
+  );
+  return server;
+}
+
+async function bootHttp(overrides: { stateless?: boolean; max?: number } = {}): Promise<RunningHttpServer> {
+  return startHttpTransport(buildTestServer, {
+    port: 0,
+    host: '127.0.0.1',
+    token: TEST_TOKEN,
+    stateless: overrides.stateless ?? true,
+    rateLimit: { windowMs: 60_000, max: overrides.max ?? 100 },
+    meta: { name: 'test-server', version: '0.0.0', commandCount: 1 },
+  });
+}
+
+async function jsonRpc(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; json: unknown }> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    json = { raw: text };
+  }
+  return { status: res.status, json };
+}
+
+describe('startHttpTransport', () => {
+  let running: RunningHttpServer | null = null;
+
+  afterEach(async () => {
+    if (running) {
+      await running.close();
+      running = null;
+    }
+  });
+
+  it('refuses to start without a token', async () => {
+    await expect(
+      startHttpTransport(buildTestServer, {
+        port: 0,
+        host: '127.0.0.1',
+        token: '',
+        stateless: true,
+        rateLimit: { windowMs: 60_000, max: 10 },
+        meta: { name: 'x', version: '0', commandCount: 0 },
+      }),
+    ).rejects.toThrow(MissingTokenError);
+  });
+
+  describe('GET /health', () => {
+    beforeEach(async () => {
+      running = await bootHttp();
+    });
+
+    it('returns server metadata without auth', async () => {
+      const res = await fetch(`http://127.0.0.1:${running!.port}/health`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toMatchObject({
+        status: 'ok',
+        name: 'test-server',
+        version: '0.0.0',
+        commandCount: 1,
+        transport: 'http',
+        sessionMode: 'stateless',
+      });
+      expect(body.uptimeSeconds).toBeTypeOf('number');
+    });
+  });
+
+  describe('auth', () => {
+    beforeEach(async () => {
+      running = await bootHttp();
+    });
+
+    it('rejects POST /mcp with no Authorization header', async () => {
+      const { status } = await jsonRpc(`http://127.0.0.1:${running!.port}/mcp`, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+      });
+      expect(status).toBe(401);
+    });
+
+    it('rejects POST /mcp with wrong token', async () => {
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: 'Bearer wrong' },
+      );
+      expect(status).toBe(401);
+    });
+
+    it('rejects malformed Authorization header', async () => {
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: TEST_TOKEN },
+      );
+      expect(status).toBe(401);
+    });
+
+    it('returns 404 on unknown paths', async () => {
+      const res = await fetch(`http://127.0.0.1:${running!.port}/unknown`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('JSON-RPC round-trip', () => {
+    beforeEach(async () => {
+      running = await bootHttp({ stateless: true });
+    });
+
+    it('serves initialize then tools/list with valid token', async () => {
+      const initRes = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '0.0.0' },
+          },
+        },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+      expect(initRes.status).toBe(200);
+      expect((initRes.json as { result: unknown }).result).toBeDefined();
+
+      const listRes = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+      expect(listRes.status).toBe(200);
+      const result = (listRes.json as { result: { tools: Array<{ name: string }> } }).result;
+      expect(result.tools).toBeDefined();
+      expect(result.tools.some((t) => t.name === 'echo')).toBe(true);
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('returns 429 once the per-IP budget is spent', async () => {
+      running = await bootHttp({ stateless: true, max: 2 });
+
+      const send = () =>
+        jsonRpc(
+          `http://127.0.0.1:${running!.port}/mcp`,
+          { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+          { Authorization: `Bearer ${TEST_TOKEN}` },
+        );
+
+      const first = await send();
+      const second = await send();
+      const third = await send();
+
+      // First two consume the budget (status 200 — handler runs even if not initialized);
+      // third trips the limiter before the handler.
+      expect([first.status, second.status]).not.toContain(429);
+      expect(third.status).toBe(429);
+    });
+  });
+});

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -6,7 +6,7 @@ import type {
   JsonSchemaValidator,
 } from '@modelcontextprotocol/sdk/validation/types.js';
 import { z } from 'zod';
-import { startHttpTransport, MissingTokenError, type RunningHttpServer } from '../http.js';
+import { startHttpTransport, MissingTokenError, InMemoryRateLimiter, type RunningHttpServer } from '../http.js';
 
 const TEST_TOKEN = 'test-token-deadbeef';
 
@@ -424,5 +424,38 @@ describe('startHttpTransport', () => {
       expect([first.status, second.status]).not.toContain(429);
       expect(third.status).toBe(429);
     });
+  });
+});
+
+describe('InMemoryRateLimiter', () => {
+  it('drops keys whose timestamps have all aged out on sweep', async () => {
+    const windowMs = 1_000;
+    const limiter = new InMemoryRateLimiter(windowMs, 10, false);
+
+    // Seed entries for several distinct IPs with timestamps in the past.
+    await limiter.check('1.1.1.1');
+    await limiter.check('2.2.2.2');
+    await limiter.check('3.3.3.3');
+    expect(limiter.size()).toBe(3);
+
+    // Sweep with `now` advanced past the window — every entry's newest
+    // timestamp falls outside the window, so all keys should be evicted.
+    limiter.sweep(Date.now() + windowMs * 2);
+    expect(limiter.size()).toBe(0);
+  });
+
+  it('keeps active keys during sweep', async () => {
+    const limiter = new InMemoryRateLimiter(60_000, 10, false);
+
+    await limiter.check('active');
+    expect(limiter.size()).toBe(1);
+
+    limiter.sweep();
+    expect(limiter.size()).toBe(1);
+  });
+
+  it('stop() is idempotent and safe to call when no timer was scheduled', () => {
+    const limiter = new InMemoryRateLimiter(60_000, 10, false);
+    expect(() => limiter.stop()).not.toThrow();
   });
 });

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -153,6 +153,26 @@ describe('startHttpTransport', () => {
       const res = await fetch(`http://127.0.0.1:${running!.port}/unknown`);
       expect(res.status).toBe(404);
     });
+
+    it('routes /health correctly when a query string is appended', async () => {
+      // Load balancers commonly append cache-busting params to health probes.
+      // The handler must strip the query string before routing.
+      const res = await fetch(`http://127.0.0.1:${running!.port}/health?ts=12345`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.status).toBe('ok');
+    });
+
+    it('routes /mcp correctly when a query string is appended', async () => {
+      // Some MCP clients append a session/tracing query string. Should still
+      // hit the /mcp path-matcher and proceed past auth (here it 401s with no
+      // bearer, proving the route was matched, not 404).
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp?session=abc`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      );
+      expect(status).toBe(401);
+    });
   });
 
   describe('JSON-RPC round-trip', () => {
@@ -187,6 +207,48 @@ describe('startHttpTransport', () => {
       const result = (listRes.json as { result: { tools: Array<{ name: string }> } }).result;
       expect(result.tools).toBeDefined();
       expect(result.tools.some((t) => t.name === 'echo')).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 (does not crash) when stateless buildServer throws', async () => {
+      // The CRITICAL bug fixed alongside this test: in stateless mode,
+      // `await mcpServer.connect(transport)` lived outside any try/catch,
+      // so a build/connect failure would surface as an unhandled promise
+      // rejection and tear the server process down. We now catch and respond.
+      let calls = 0;
+      const failingBuilder = (): McpServer => {
+        calls++;
+        throw new Error('synthetic build failure');
+      };
+
+      running = await startHttpTransport(failingBuilder, {
+        port: 0,
+        host: '127.0.0.1',
+        token: TEST_TOKEN,
+        stateless: true,
+        rateLimit: { windowMs: 60_000, max: 100 },
+        meta: { name: 'test-server', version: '0.0.0', commandCount: 1 },
+      });
+
+      const { status, json } = await jsonRpc(
+        `http://127.0.0.1:${running.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+
+      expect(status).toBe(500);
+      expect((json as { error: string }).error).toContain('synthetic build failure');
+      expect(calls).toBe(1);
+
+      // Server still alive — second request also gets a clean 500.
+      const second = await jsonRpc(
+        `http://127.0.0.1:${running.port}/mcp`,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+      expect(second.status).toBe(500);
+      expect(calls).toBe(2);
     });
   });
 

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -250,6 +250,75 @@ describe('startHttpTransport', () => {
       expect(second.status).toBe(500);
       expect(calls).toBe(2);
     });
+
+    it('runs cleanup when mcpServer.connect rejects (no resource leak)', async () => {
+      // Regression for PR #8512 Sentry MEDIUM: cleanup was registered AFTER
+      // connect(), so a connect failure leaked the constructed server +
+      // transport (each holds open streams). Repeated failures could exhaust
+      // the process. After the fix, res.on('close', cleanup) is wired BEFORE
+      // connect() so the listener still fires when the response closes on
+      // the 500 we write below.
+      let closeCalls = 0;
+      let closeResolver!: () => void;
+      const closeOnce = new Promise<void>((resolve) => {
+        closeResolver = resolve;
+      });
+
+      const failingConnectBuilder = (): McpServer => {
+        const server = buildTestServer();
+        // Shadow connect to fail synchronously after the transport is built.
+        // Object property assignment on a class instance is fine — JS resolves
+        // method dispatch via the instance first, prototype second.
+        Object.defineProperty(server, 'connect', {
+          value: async () => {
+            throw new Error('synthetic connect failure');
+          },
+          writable: true,
+          configurable: true,
+        });
+        // Track close so we can prove cleanup fired.
+        const originalClose = server.close.bind(server);
+        Object.defineProperty(server, 'close', {
+          value: async () => {
+            closeCalls++;
+            closeResolver();
+            return originalClose();
+          },
+          writable: true,
+          configurable: true,
+        });
+        return server;
+      };
+
+      running = await startHttpTransport(failingConnectBuilder, {
+        port: 0,
+        host: '127.0.0.1',
+        token: TEST_TOKEN,
+        stateless: true,
+        rateLimit: { windowMs: 60_000, max: 100 },
+        meta: { name: 'test-server', version: '0.0.0', commandCount: 1 },
+      });
+
+      const { status, json } = await jsonRpc(
+        `http://127.0.0.1:${running.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+
+      expect(status).toBe(500);
+      expect((json as { error: string }).error).toContain('synthetic connect failure');
+
+      // Wait (with a real timeout, not a sleep) for the close listener to fire.
+      // If the cleanup were registered after connect — as it was before the fix —
+      // this promise would never resolve and the timeout would fail the test.
+      await Promise.race([
+        closeOnce,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('cleanup did not run within 500ms — leak regressed')), 500),
+        ),
+      ]);
+      expect(closeCalls).toBeGreaterThan(0);
+    });
   });
 
   describe('rate limiting', () => {

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -73,6 +73,44 @@ async function jsonRpc(
   return { status: res.status, json };
 }
 
+// Stateful mode returns SSE (event-stream) by default. This helper parses the
+// `data:` payload of the first event so callers can assert on the JSON-RPC
+// envelope regardless of which transport mode the server picked.
+async function jsonRpcSse(
+  url: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; sessionId: string | null; json: unknown }> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  // Header name is case-insensitive in fetch; `Headers.get` already normalizes.
+  const sessionId = res.headers.get('Mcp-Session-Id') ?? res.headers.get('mcp-session-id');
+  // Try JSON first (server may have switched to enableJsonResponse), then SSE.
+  try {
+    return { status: res.status, sessionId, json: text.length > 0 ? JSON.parse(text) : null };
+  } catch {
+    // SSE format: lines like `event: message\ndata: {...}\n\n`. Grab the first
+    // data: payload — for the round-trip test there's exactly one.
+    const dataLine = text.split('\n').find((line) => line.startsWith('data:'));
+    if (!dataLine) {
+      return { status: res.status, sessionId, json: { raw: text } };
+    }
+    try {
+      return { status: res.status, sessionId, json: JSON.parse(dataLine.slice(5).trim()) };
+    } catch {
+      return { status: res.status, sessionId, json: { raw: text } };
+    }
+  }
+}
+
 describe('startHttpTransport', () => {
   let running: RunningHttpServer | null = null;
 
@@ -206,6 +244,51 @@ describe('startHttpTransport', () => {
       expect(listRes.status).toBe(200);
       const result = (listRes.json as { result: { tools: Array<{ name: string }> } }).result;
       expect(result.tools).toBeDefined();
+      expect(result.tools.some((t) => t.name === 'echo')).toBe(true);
+    });
+  });
+
+  describe('JSON-RPC round-trip — stateful mode', () => {
+    // Stateful is the default in production. The route pre-reads the request
+    // body before passing it to `transport.handleRequest(req, res, body)` so it
+    // can enforce a size cap before the SDK consumes the stream. This test
+    // proves the SDK's stateful StreamableHTTPServerTransport accepts the
+    // pre-parsed body — without this coverage, a SDK upgrade that started
+    // re-reading the stream would fail every default-config POST in production.
+    beforeEach(async () => {
+      running = await bootHttp({ stateless: false });
+    });
+
+    it('serves initialize then tools/list and tracks the session', async () => {
+      const initRes = await jsonRpcSse(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test-client', version: '0.0.0' },
+          },
+        },
+        { Authorization: `Bearer ${TEST_TOKEN}` },
+      );
+      expect(initRes.status).toBe(200);
+      // Stateful mode mints a session ID on initialize and echoes it back via
+      // the response header. A non-null value here proves the SDK consumed the
+      // pre-parsed body and ran the initialize handshake to completion.
+      expect(initRes.sessionId).toBeTruthy();
+      expect((initRes.json as { result: unknown }).result).toBeDefined();
+
+      const sessionId = initRes.sessionId!;
+      const listRes = await jsonRpcSse(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        { Authorization: `Bearer ${TEST_TOKEN}`, 'Mcp-Session-Id': sessionId },
+      );
+      expect(listRes.status).toBe(200);
+      const result = (listRes.json as { result: { tools: Array<{ name: string }> } }).result;
       expect(result.tools.some((t) => t.name === 'echo')).toBe(true);
     });
   });

--- a/mcp-server/src/transport/http.ts
+++ b/mcp-server/src/transport/http.ts
@@ -75,14 +75,29 @@ interface RateLimiter {
 /**
  * In-memory sliding window — single-process only. Intended for local dev or
  * single-instance deployments. For multi-instance, set the Upstash env vars.
+ *
+ * Memory: every key stays in the map until either (a) the next call for that
+ * key prunes it after sweeping all its timestamps, or (b) the periodic sweep
+ * runs. Without the sweep, keys for one-shot crawlers and probes accumulate
+ * forever in long-running processes.
  */
-class InMemoryRateLimiter implements RateLimiter {
+export class InMemoryRateLimiter implements RateLimiter {
   private hits = new Map<string, number[]>();
+  private readonly sweepTimer: ReturnType<typeof setInterval> | null;
 
   constructor(
     private readonly windowMs: number,
     private readonly max: number,
-  ) {}
+    sweepEnabled = true,
+  ) {
+    if (sweepEnabled) {
+      this.sweepTimer = setInterval(() => this.sweep(), windowMs);
+      // unref so the timer doesn't keep Node alive past server.close().
+      this.sweepTimer.unref?.();
+    } else {
+      this.sweepTimer = null;
+    }
+  }
 
   async check(key: string): Promise<boolean> {
     const now = Date.now();
@@ -95,6 +110,26 @@ class InMemoryRateLimiter implements RateLimiter {
     recent.push(now);
     this.hits.set(key, recent);
     return true;
+  }
+
+  /** Drop entries whose every timestamp has aged out of the window. */
+  sweep(now: number = Date.now()): void {
+    const cutoff = now - this.windowMs;
+    for (const [key, timestamps] of this.hits) {
+      const newest = timestamps.length > 0 ? timestamps[timestamps.length - 1]! : 0;
+      if (newest <= cutoff) {
+        this.hits.delete(key);
+      }
+    }
+  }
+
+  stop(): void {
+    if (this.sweepTimer) clearInterval(this.sweepTimer);
+  }
+
+  /** Test hook. */
+  size(): number {
+    return this.hits.size;
   }
 }
 
@@ -338,6 +373,7 @@ export async function startHttpTransport(
       });
       if (sharedTransport) await sharedTransport.close();
       if (sharedServer) await sharedServer.close();
+      if (limiter instanceof InMemoryRateLimiter) limiter.stop();
     },
   };
 }

--- a/mcp-server/src/transport/http.ts
+++ b/mcp-server/src/transport/http.ts
@@ -1,0 +1,327 @@
+/**
+ * Streamable HTTP transport for the SpawnForge MCP server.
+ *
+ * Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+ *
+ * Wire model
+ * - `POST /mcp` carries a single JSON-RPC request (`tools/list`, `tools/call`, …)
+ *   and returns either a JSON body or an SSE stream — the SDK transport decides.
+ * - `GET /mcp` opens the standalone server-to-client SSE channel.
+ * - `DELETE /mcp` closes a session.
+ * - `GET /health` is a lightweight non-MCP probe (no auth) for load balancers.
+ *
+ * Auth
+ * - Bearer token via the `MCP_HTTP_TOKEN` env var. Constant-time comparison.
+ * - The /health endpoint is intentionally unauthenticated.
+ *
+ * Rate limiting
+ * - Per-IP, 30 req / 5 min default (mirrors `rateLimitPublicRoute()` on the web).
+ * - Backed by Upstash Redis when `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`
+ *   are present and the optional dep is installed; otherwise an in-memory
+ *   sliding window applies (suitable for single-instance deployments).
+ *
+ * Session model
+ * - Stateful (default): one shared transport + server. The SDK assigns session
+ *   IDs and tracks per-session streams. Clients must send `Mcp-Session-Id` on
+ *   every follow-up request.
+ * - Stateless (`MCP_HTTP_STATELESS=1`): a fresh transport + server is built per
+ *   request and torn down on response close. JSON-only responses, no sessions.
+ *   This matches the SDK's own `simpleStatelessStreamableHttp` example and is
+ *   the only way the SDK supports concurrent stateless requests safely.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+export interface HttpTransportOptions {
+  port: number;
+  host: string;
+  /** Bearer token. If empty the server refuses to start (fail-closed). */
+  token: string;
+  stateless: boolean;
+  rateLimit: {
+    windowMs: number;
+    max: number;
+  };
+  /** Server metadata surfaced on /health. */
+  meta: {
+    name: string;
+    version: string;
+    commandCount: number;
+  };
+}
+
+export interface RunningHttpServer {
+  server: Server;
+  /** Bound port — useful when caller passed 0 to ask the OS for a free port. */
+  port: number;
+  close(): Promise<void>;
+}
+
+export class MissingTokenError extends Error {
+  constructor() {
+    super('MCP_HTTP_TOKEN is required when MCP_TRANSPORT=http');
+    this.name = 'MissingTokenError';
+  }
+}
+
+interface RateLimiter {
+  /** True if the request is allowed. */
+  check(key: string): Promise<boolean>;
+}
+
+/**
+ * In-memory sliding window — single-process only. Intended for local dev or
+ * single-instance deployments. For multi-instance, set the Upstash env vars.
+ */
+class InMemoryRateLimiter implements RateLimiter {
+  private hits = new Map<string, number[]>();
+
+  constructor(
+    private readonly windowMs: number,
+    private readonly max: number,
+  ) {}
+
+  async check(key: string): Promise<boolean> {
+    const now = Date.now();
+    const cutoff = now - this.windowMs;
+    const recent = (this.hits.get(key) ?? []).filter((ts) => ts > cutoff);
+    if (recent.length >= this.max) {
+      this.hits.set(key, recent);
+      return false;
+    }
+    recent.push(now);
+    this.hits.set(key, recent);
+    return true;
+  }
+}
+
+async function tryUpstashLimiter(windowMs: number, max: number): Promise<RateLimiter | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  try {
+    const [{ Ratelimit }, { Redis }] = await Promise.all([
+      import('@upstash/ratelimit'),
+      import('@upstash/redis'),
+    ]);
+    const redis = new Redis({ url, token });
+    const limiter = new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(max, `${Math.round(windowMs / 1000)} s`),
+      prefix: 'mcp:http',
+    });
+    return {
+      async check(key: string) {
+        try {
+          const { success } = await limiter.limit(key);
+          return success;
+        } catch {
+          // Fail open on Redis errors — better to serve than to block on infra hiccup.
+          return true;
+        }
+      },
+    };
+  } catch {
+    // Optional dep not installed — fall back to in-memory.
+    return null;
+  }
+}
+
+function getClientIp(req: IncomingMessage): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0]!.trim();
+  }
+  return req.socket.remoteAddress ?? 'unknown';
+}
+
+function bearerOk(headerValue: string | undefined, expected: string): boolean {
+  if (!headerValue) return false;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return false;
+  const provided = Buffer.from(match[1]!.trim(), 'utf8');
+  const want = Buffer.from(expected, 'utf8');
+  if (provided.length !== want.length) return false;
+  return timingSafeEqual(provided, want);
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(json).toString(),
+  });
+  res.end(json);
+}
+
+async function readBody(req: IncomingMessage, maxBytes = 4 * 1024 * 1024): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > maxBytes) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (raw.length === 0) {
+        resolve(undefined);
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Boot an HTTP server fronting the MCP server.
+ *
+ * `buildServer` is invoked:
+ * - Once at startup in stateful mode (a single transport+server pair handles
+ *   every request, with session IDs from the SDK).
+ * - Per request in stateless mode (the SDK's stateless transport keeps no
+ *   cross-request state, so reusing one would cause "already initialized"
+ *   errors and orphaned stream handles).
+ */
+export async function startHttpTransport(
+  buildServer: () => McpServer,
+  options: HttpTransportOptions,
+): Promise<RunningHttpServer> {
+  if (!options.token || options.token.trim().length === 0) {
+    throw new MissingTokenError();
+  }
+
+  const limiter =
+    (await tryUpstashLimiter(options.rateLimit.windowMs, options.rateLimit.max)) ??
+    new InMemoryRateLimiter(options.rateLimit.windowMs, options.rateLimit.max);
+
+  const startedAt = Date.now();
+
+  // Shared (stateful) transport+server, built once. Null in stateless mode.
+  let sharedTransport: StreamableHTTPServerTransport | null = null;
+  let sharedServer: McpServer | null = null;
+  if (!options.stateless) {
+    sharedServer = buildServer();
+    sharedTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: false,
+    });
+    await sharedServer.connect(sharedTransport);
+  }
+
+  const server = createServer(async (req, res) => {
+    const url = req.url ?? '/';
+    const method = req.method ?? 'GET';
+
+    // /health is intentionally unauthenticated — load balancers and uptime
+    // probes need to reach it without provisioning a token.
+    if (method === 'GET' && url === '/health') {
+      writeJson(res, 200, {
+        status: 'ok',
+        name: options.meta.name,
+        version: options.meta.version,
+        commandCount: options.meta.commandCount,
+        transport: 'http',
+        sessionMode: options.stateless ? 'stateless' : 'stateful',
+        uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+      });
+      return;
+    }
+
+    if (url !== '/mcp') {
+      writeJson(res, 404, { error: 'Not Found' });
+      return;
+    }
+
+    if (!bearerOk(req.headers.authorization, options.token)) {
+      res.setHeader('WWW-Authenticate', 'Bearer realm="mcp"');
+      writeJson(res, 401, { error: 'Unauthorized' });
+      return;
+    }
+
+    const ip = getClientIp(req);
+    const allowed = await limiter.check(ip);
+    if (!allowed) {
+      res.setHeader('Retry-After', Math.ceil(options.rateLimit.windowMs / 1000).toString());
+      writeJson(res, 429, { error: 'Too Many Requests' });
+      return;
+    }
+
+    // In stateless mode, build a fresh transport+server per request and tear
+    // them down on response close. This matches the SDK's reference example
+    // and avoids cross-request leakage.
+    let transport: StreamableHTTPServerTransport;
+    let mcpServer: McpServer | null = null;
+    if (options.stateless) {
+      mcpServer = buildServer();
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      await mcpServer.connect(transport);
+      const cleanup = () => {
+        transport.close().catch(() => {});
+        mcpServer?.close().catch(() => {});
+      };
+      res.on('close', cleanup);
+    } else {
+      transport = sharedTransport!;
+    }
+
+    try {
+      // Pre-read the body for POST so we can enforce a size limit before the
+      // SDK's web-standard layer consumes it. The SDK skips its own JSON parse
+      // when `parsedBody` is provided.
+      let body: unknown;
+      if (method === 'POST') {
+        body = await readBody(req);
+      }
+      await transport.handleRequest(req, res, body);
+    } catch (err) {
+      // The SDK writes its own response on JSON-RPC errors; only handle the
+      // pre-handler cases (body too large, malformed JSON) where headers are
+      // still uncommitted.
+      if (!res.headersSent) {
+        const message = err instanceof Error ? err.message : 'Internal error';
+        writeJson(res, 400, { error: message });
+      }
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, options.host, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const boundPort = typeof address === 'object' && address ? address.port : options.port;
+
+  return {
+    server,
+    port: boundPort,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+      if (sharedTransport) await sharedTransport.close();
+      if (sharedServer) await sharedServer.close();
+    },
+  };
+}

--- a/mcp-server/src/transport/http.ts
+++ b/mcp-server/src/transport/http.ts
@@ -223,83 +223,94 @@ export async function startHttpTransport(
     await sharedServer.connect(sharedTransport);
   }
 
-  const server = createServer(async (req, res) => {
-    const url = req.url ?? '/';
-    const method = req.method ?? 'GET';
+  const server = createServer((req, res) => {
+    // Wrap the entire async body in a single try/catch and run it via a
+    // synchronous IIFE so that any rejection — including the SDK's
+    // `connect(transport)` call in stateless mode — is caught here instead of
+    // bubbling up as an unhandled promise rejection that would crash the
+    // process. Without this, a single failed connect would tear down the whole
+    // server.
+    void (async () => {
+      try {
+        // Strip query string from the path: load balancers commonly append
+        // cache-busting params like `?ts=...` to health probes, and an exact
+        // string match on `req.url` would 404 them.
+        const path = new URL(req.url ?? '/', 'http://_').pathname;
+        const method = req.method ?? 'GET';
 
-    // /health is intentionally unauthenticated — load balancers and uptime
-    // probes need to reach it without provisioning a token.
-    if (method === 'GET' && url === '/health') {
-      writeJson(res, 200, {
-        status: 'ok',
-        name: options.meta.name,
-        version: options.meta.version,
-        commandCount: options.meta.commandCount,
-        transport: 'http',
-        sessionMode: options.stateless ? 'stateless' : 'stateful',
-        uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
-      });
-      return;
-    }
+        // /health is intentionally unauthenticated — load balancers and uptime
+        // probes need to reach it without provisioning a token.
+        if (method === 'GET' && path === '/health') {
+          writeJson(res, 200, {
+            status: 'ok',
+            name: options.meta.name,
+            version: options.meta.version,
+            commandCount: options.meta.commandCount,
+            transport: 'http',
+            sessionMode: options.stateless ? 'stateless' : 'stateful',
+            uptimeSeconds: Math.round((Date.now() - startedAt) / 1000),
+          });
+          return;
+        }
 
-    if (url !== '/mcp') {
-      writeJson(res, 404, { error: 'Not Found' });
-      return;
-    }
+        if (path !== '/mcp') {
+          writeJson(res, 404, { error: 'Not Found' });
+          return;
+        }
 
-    if (!bearerOk(req.headers.authorization, options.token)) {
-      res.setHeader('WWW-Authenticate', 'Bearer realm="mcp"');
-      writeJson(res, 401, { error: 'Unauthorized' });
-      return;
-    }
+        if (!bearerOk(req.headers.authorization, options.token)) {
+          res.setHeader('WWW-Authenticate', 'Bearer realm="mcp"');
+          writeJson(res, 401, { error: 'Unauthorized' });
+          return;
+        }
 
-    const ip = getClientIp(req);
-    const allowed = await limiter.check(ip);
-    if (!allowed) {
-      res.setHeader('Retry-After', Math.ceil(options.rateLimit.windowMs / 1000).toString());
-      writeJson(res, 429, { error: 'Too Many Requests' });
-      return;
-    }
+        const ip = getClientIp(req);
+        const allowed = await limiter.check(ip);
+        if (!allowed) {
+          res.setHeader('Retry-After', Math.ceil(options.rateLimit.windowMs / 1000).toString());
+          writeJson(res, 429, { error: 'Too Many Requests' });
+          return;
+        }
 
-    // In stateless mode, build a fresh transport+server per request and tear
-    // them down on response close. This matches the SDK's reference example
-    // and avoids cross-request leakage.
-    let transport: StreamableHTTPServerTransport;
-    let mcpServer: McpServer | null = null;
-    if (options.stateless) {
-      mcpServer = buildServer();
-      transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse: true,
-      });
-      await mcpServer.connect(transport);
-      const cleanup = () => {
-        transport.close().catch(() => {});
-        mcpServer?.close().catch(() => {});
-      };
-      res.on('close', cleanup);
-    } else {
-      transport = sharedTransport!;
-    }
+        // In stateless mode, build a fresh transport+server per request and tear
+        // them down on response close. This matches the SDK's reference example
+        // and avoids cross-request leakage.
+        let transport: StreamableHTTPServerTransport;
+        let mcpServer: McpServer | null = null;
+        if (options.stateless) {
+          mcpServer = buildServer();
+          transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableJsonResponse: true,
+          });
+          await mcpServer.connect(transport);
+          const cleanup = () => {
+            transport.close().catch(() => {});
+            mcpServer?.close().catch(() => {});
+          };
+          res.on('close', cleanup);
+        } else {
+          transport = sharedTransport!;
+        }
 
-    try {
-      // Pre-read the body for POST so we can enforce a size limit before the
-      // SDK's web-standard layer consumes it. The SDK skips its own JSON parse
-      // when `parsedBody` is provided.
-      let body: unknown;
-      if (method === 'POST') {
-        body = await readBody(req);
+        // Pre-read the body for POST so we can enforce a size limit before the
+        // SDK's web-standard layer consumes it. The SDK skips its own JSON parse
+        // when `parsedBody` is provided.
+        let body: unknown;
+        if (method === 'POST') {
+          body = await readBody(req);
+        }
+        await transport.handleRequest(req, res, body);
+      } catch (err) {
+        // The SDK writes its own response on JSON-RPC errors; only handle the
+        // pre-handler cases (body too large, malformed JSON, connect failure)
+        // where headers are still uncommitted.
+        if (!res.headersSent) {
+          const message = err instanceof Error ? err.message : 'Internal error';
+          writeJson(res, 500, { error: message });
+        }
       }
-      await transport.handleRequest(req, res, body);
-    } catch (err) {
-      // The SDK writes its own response on JSON-RPC errors; only handle the
-      // pre-handler cases (body too large, malformed JSON) where headers are
-      // still uncommitted.
-      if (!res.headersSent) {
-        const message = err instanceof Error ? err.message : 'Internal error';
-        writeJson(res, 400, { error: message });
-      }
-    }
+    })();
   });
 
   await new Promise<void>((resolve, reject) => {

--- a/mcp-server/src/transport/http.ts
+++ b/mcp-server/src/transport/http.ts
@@ -283,12 +283,17 @@ export async function startHttpTransport(
             sessionIdGenerator: undefined,
             enableJsonResponse: true,
           });
-          await mcpServer.connect(transport);
+          // Register cleanup BEFORE connect(). If connect() throws, the
+          // catch below writes a 500 and the response closes immediately,
+          // which fires this listener — without it, both transport and
+          // server objects (each holding open streams) would leak per
+          // failed request and exhaust the process under load.
           const cleanup = () => {
             transport.close().catch(() => {});
             mcpServer?.close().catch(() => {});
           };
           res.on('close', cleanup);
+          await mcpServer.connect(transport);
         } else {
           transport = sharedTransport!;
         }


### PR DESCRIPTION
## Summary
- Adds MCP Streamable HTTP transport (spec 2025-11-25) gated behind `MCP_TRANSPORT=http`, alongside the existing stdio path
- Bearer token auth (`MCP_HTTP_TOKEN`, constant-time compare, fail-closed if empty), per-IP sliding-window rate limit (Upstash with in-memory fallback), unauthenticated `GET /health`, and a 4MB request body cap
- Stateful (default, SDK-managed sessions) and stateless (`MCP_HTTP_STATELESS=1`, fresh server+transport per request) modes — the latter matches the SDK's reference example for safe concurrent stateless serving
- 8 transport tests, full mcp-server suite passing (429/429), README with curl examples + env vars table, changeset

## Acceptance criteria
- [x] `StreamableHTTPServerTransport` path gated behind `MCP_TRANSPORT=http` (default stdio)
- [x] `GET /health` returns server metadata (name, version, commandCount, transport, sessionMode, uptimeSeconds)
- [x] Bearer token auth via `MCP_HTTP_TOKEN`, 401 when missing/wrong/malformed
- [x] Per-IP rate limit (30 req / 5 min default) via `@upstash/ratelimit` with in-memory fallback
- [x] E2E test: tool invocation round-trip over HTTP transport (`mcp-server/src/transport/__tests__/http.test.ts`)
- [x] `mcp-server/README.md` documents both transports + example curl
- [ ] Vercel function wrapper for `mcp.spawnforge.ai` — issue notes this may be a separate ticket; the bare `node dist/index.js` works on any container host

Closes #8497

## Test plan
- [x] `cd mcp-server && npx vitest run` (429 passed)
- [x] `cd mcp-server && npx tsc --noEmit` (clean)
- [x] `cd mcp-server && npm run build` (clean)
- [ ] Local smoke: `MCP_TRANSPORT=http MCP_HTTP_TOKEN=$(openssl rand -hex 32) node dist/index.js`, exercise `/health` and `tools/list`