### PR TITLE
feat(observability): enrich WASM panic capture with editor state context

### DIFF
--- a/.changeset/wasm-panic-context.md
+++ b/.changeset/wasm-panic-context.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Enrich WASM panic capture with editor state context. When the engine panics, Sentry now receives entity count, current selection, undo/redo flags, engine mode, and the last 20 dispatched commands alongside the stack trace — enough context to diagnose state-dependent crashes like #8462 from a single report. Each engine command also leaves a Sentry breadcrumb.

--- a/web/src/hooks/useEngine.ts
+++ b/web/src/hooks/useEngine.ts
@@ -61,6 +61,30 @@ let wasmModule: WasmModule | null = null;
 let initPromise: Promise<WasmModule> | null = null;
 let panicInterceptorInstalled = false;
 
+// --- Engine snapshot provider (registered by editorStore for crash diagnostics) ---
+type EngineSnapshotProvider = () => Record<string, unknown>;
+let _engineSnapshotProvider: EngineSnapshotProvider | null = null;
+
+/**
+ * Register a synchronous provider that returns a snapshot of editor state.
+ * Called by `installPanicInterceptor` to enrich WASM crash reports with scene
+ * context (entity count, selection, undo state, recent commands). Must be
+ * sync — the panic path runs inside `console.error`, which is invoked on the
+ * stack frame of the panicking caller. Async lookups would race the crash.
+ */
+export function setEngineSnapshotProvider(provider: EngineSnapshotProvider | null): void {
+  _engineSnapshotProvider = provider;
+}
+
+function snapshotEngineState(): Record<string, unknown> {
+  if (!_engineSnapshotProvider) return {};
+  try {
+    return _engineSnapshotProvider();
+  } catch {
+    return { snapshotError: 'provider threw' };
+  }
+}
+
 // --- Engine crash state (module-level for cross-component access) ---
 let _engineCrashed = false;
 let _engineCrashMessage: string | null = null;
@@ -140,6 +164,7 @@ function installPanicInterceptor(): void {
         source: 'console_error_panic_hook',
         fullMessage: msg.slice(0, 2000),
         engineBackend: resolvedBackend,
+        engineState: snapshotEngineState(),
       });
       setEngineCrashed(msg.slice(0, 500));
     }
@@ -154,6 +179,7 @@ function installPanicInterceptor(): void {
         source: 'unhandled_wasm_runtime_error',
         fullMessage: msg.slice(0, 2000),
         engineBackend: resolvedBackend,
+        engineState: snapshotEngineState(),
       });
       if (!_engineCrashed) {
         setEngineCrashed(`WASM RuntimeError: ${msg.slice(0, 500)}`);

--- a/web/src/stores/__tests__/editorStore.crashContext.test.ts
+++ b/web/src/stores/__tests__/editorStore.crashContext.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Coverage for the WASM-panic enrichment wiring on editorStore:
+ *  - command dispatch records into a 20-entry ring buffer (FIFO),
+ *  - each dispatch emits a Sentry breadcrumb,
+ *  - the snapshot provider registered with useEngine returns live state.
+ *
+ * The aim is to prove the diagnostic context is actually populated so the
+ * next #8462 panic surfaces with engine state attached, not just a stack.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addBreadcrumbMock = vi.fn();
+const setSnapshotProviderMock = vi.fn();
+
+vi.mock('@/lib/monitoring/sentry-client', () => ({
+  addBreadcrumb: (...args: unknown[]) => addBreadcrumbMock(...args),
+  // unused in these tests but exported by the real module
+  captureException: vi.fn(),
+  setTag: vi.fn(),
+}));
+
+vi.mock('@/hooks/useEngine', () => ({
+  setEngineSnapshotProvider: (...args: unknown[]) => setSnapshotProviderMock(...args),
+}));
+
+vi.mock('@/lib/analytics/events', () => ({
+  trackCommandDispatched: vi.fn(),
+}));
+
+let getRecentCommands: typeof import('../editorStore')['getRecentCommands'];
+let setCommandDispatcher: typeof import('../editorStore')['setCommandDispatcher'];
+let getCommandDispatcher: typeof import('../editorStore')['getCommandDispatcher'];
+let useEditorStore: typeof import('../editorStore')['useEditorStore'];
+
+beforeEach(async () => {
+  vi.resetModules();
+  addBreadcrumbMock.mockClear();
+  setSnapshotProviderMock.mockClear();
+
+  const mod = await import('../editorStore');
+  getRecentCommands = mod.getRecentCommands;
+  setCommandDispatcher = mod.setCommandDispatcher;
+  getCommandDispatcher = mod.getCommandDispatcher;
+  useEditorStore = mod.useEditorStore;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('editorStore crash-context wiring', () => {
+  it('registers a snapshot provider with useEngine on import', () => {
+    expect(setSnapshotProviderMock).toHaveBeenCalledTimes(1);
+    expect(setSnapshotProviderMock.mock.calls[0][0]).toBeTypeOf('function');
+  });
+
+  it('records each dispatched command in a ring and emits a breadcrumb', () => {
+    setCommandDispatcher(() => { /* engine no-op for test */ });
+    const dispatch = getCommandDispatcher();
+    expect(dispatch).not.toBeNull();
+
+    dispatch!('spawn_entity', { type: 'cube' });
+    dispatch!('set_transform', { id: 'e1' });
+
+    expect(getRecentCommands()).toEqual(['spawn_entity', 'set_transform']);
+    expect(addBreadcrumbMock).toHaveBeenCalledTimes(2);
+    expect(addBreadcrumbMock.mock.calls[0][0]).toMatchObject({
+      category: 'engine.command',
+      message: 'spawn_entity',
+      level: 'info',
+    });
+  });
+
+  it('caps the ring at 20 entries (oldest evicted first)', () => {
+    setCommandDispatcher(() => { /* no-op */ });
+    const dispatch = getCommandDispatcher()!;
+
+    for (let i = 0; i < 25; i++) dispatch(`cmd_${i}`, {});
+
+    const recent = getRecentCommands();
+    expect(recent).toHaveLength(20);
+    expect(recent[0]).toBe('cmd_5');
+    expect(recent[19]).toBe('cmd_24');
+  });
+
+  it('snapshot provider returns live editor state', () => {
+    const provider = setSnapshotProviderMock.mock.calls[0][0] as () => Record<string, unknown>;
+
+    setCommandDispatcher(() => { /* no-op */ });
+    const dispatch = getCommandDispatcher()!;
+    dispatch('rename_entity', { id: 'e1', name: 'Cube' });
+    dispatch('select_entity', { id: 'e1' });
+
+    useEditorStore.getState().setHistoryState(true, false, 'rename', null);
+    useEditorStore.getState().setSelection(['e1'], 'e1', 'Cube');
+
+    const snapshot = provider();
+    expect(snapshot).toMatchObject({
+      entityCount: 0, // sceneGraph not populated in this isolated test
+      selectionSize: 1,
+      primarySelection: 'e1',
+      canUndo: true,
+      canRedo: false,
+      undoDescription: 'rename',
+    });
+    expect(snapshot.recentCommands).toEqual(['rename_entity', 'select_entity']);
+  });
+});

--- a/web/src/stores/editorStore.ts
+++ b/web/src/stores/editorStore.ts
@@ -7,6 +7,11 @@
 
 import { create } from 'zustand';
 import { trackCommandDispatched } from '@/lib/analytics/events';
+import { addBreadcrumb } from '@/lib/monitoring/sentry-client';
+// Namespace import so partial test mocks of `@/hooks/useEngine` (which omit
+// the snapshot setter) don't throw at module load. We feature-detect the
+// export at runtime instead of relying on the named binding being present.
+import * as engineModule from '@/hooks/useEngine';
 
 // Import all slices
 import {
@@ -125,15 +130,69 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
   (window as unknown as Record<string, unknown>).__EDITOR_STORE = useEditorStore;
 }
 
+// Register a synchronous snapshot of editor state with the WASM panic
+// interceptor. The interceptor runs on the panicking caller's stack frame
+// (inside `console.error`), so the provider must be sync — async lookups
+// would race the crash. The provider is best-effort: if any field is missing
+// or throws, the interceptor falls back to an empty snapshot.
+//
+// Wrapped in try/catch so partial test mocks of `@/hooks/useEngine` that omit
+// the setter (vitest 4 raises on missing-export access via a Proxy) don't
+// crash module evaluation. In production all exports are present.
+try {
+  const setter = engineModule.setEngineSnapshotProvider;
+  if (typeof setter === 'function') {
+    setter(() => {
+      const state = useEditorStore.getState();
+      const sceneNodes = state.sceneGraph?.nodes;
+      return {
+        entityCount: sceneNodes ? Object.keys(sceneNodes).length : 0,
+        selectionSize: state.selectedIds?.size ?? 0,
+        primarySelection: state.primaryId ?? null,
+        canUndo: state.canUndo,
+        canRedo: state.canRedo,
+        undoDescription: state.undoDescription,
+        engineMode: state.engineMode,
+        recentCommands: _recentCommands.slice(),
+      };
+    });
+  }
+} catch {
+  /* useEngine mocked without snapshot setter — diagnostics off in this test only */
+}
+
+// Ring buffer of the most recent engine commands. Surfaced in WASM panic
+// reports so a crash includes the trail of commands that led to it.
+const COMMAND_RING_SIZE = 20;
+const _recentCommands: string[] = [];
+
+function recordCommand(command: string): void {
+  _recentCommands.push(command);
+  if (_recentCommands.length > COMMAND_RING_SIZE) {
+    _recentCommands.shift();
+  }
+  addBreadcrumb({
+    category: 'engine.command',
+    message: command,
+    level: 'info',
+  });
+}
+
+/** Last N engine commands dispatched (oldest first). For crash diagnostics. */
+export function getRecentCommands(): readonly string[] {
+  return _recentCommands;
+}
+
 // Command dispatcher type - will be set by useEngine hook
 type CommandDispatcher = (command: string, payload: unknown) => void;
 let _dispatchCommand: CommandDispatcher | null = null;
 
 export function setCommandDispatcher(dispatcher: CommandDispatcher): void {
-  // Wrap dispatcher to emit Vercel analytics for every engine command.
-  // Tracking is fire-and-forget and never blocks the dispatch path.
+  // Wrap dispatcher to emit Vercel analytics + Sentry breadcrumb for every
+  // engine command. Tracking is fire-and-forget and never blocks dispatch.
   const tracked: CommandDispatcher = (command, payload) => {
     trackCommandDispatched(command);
+    recordCommand(command);
     dispatcher(command, payload);
   };
   _dispatchCommand = tracked;
@@ -172,7 +231,10 @@ export function setCommandBatchDispatcher(dispatcher: BatchCommandDispatcher | u
     return;
   }
   _dispatchCommandBatch = (commands) => {
-    for (const { command } of commands) trackCommandDispatched(command);
+    for (const { command } of commands) {
+      trackCommandDispatched(command);
+      recordCommand(command);
+    }
     return dispatcher(commands);
   };
 }


### PR DESCRIPTION
## Summary

Diagnostic enrichment for the WASM panic interceptor in `web/src/hooks/useEngine.ts`. State-dependent crashes like #8462 currently surface in Sentry with only a stack trace and the backend tag — no scene context. After this PR, each panic report carries:

- entity count, selection size + primary id
- canUndo / canRedo + undo description
- engine mode (edit / play / paused)
- the last 20 dispatched commands (oldest first)

Plus a Sentry breadcrumb per engine command, so even crashes that arrive without the snapshot still ship a command trail.

## Design

- Ring buffer + breadcrumb emission live in `editorStore.setCommandDispatcher` so every code path that goes through the dispatcher (slice actions and batch dispatch) is covered automatically.
- A synchronous snapshot provider is registered from editorStore via a setter on `useEngine.installPanicInterceptor`. Sync because the panic handler runs inside `console.error` on the panicking caller's frame — async lookups would race the crash.
- The registration is wrapped in try/catch + namespace-import access. Vitest 4 wraps mocked exports in a Proxy that throws on missing keys; the guards keep partial mocks of `@/hooks/useEngine` from crashing module load.

## Test plan

- [x] `src/stores/__tests__/editorStore.crashContext.test.ts` covers: provider registration, ring eviction at 20, breadcrumb shape, snapshot fields.
- [x] `npx vitest run src/hooks src/stores src/components` — 293 files / 4434 tests pass.
- [x] `npx eslint --max-warnings 0` clean on touched files.
- [x] `npx tsc --noEmit` — only pre-existing stripe-client error (already fixed in #8510).

## Refs

Closes #8514. Refs #8462 — does not close it. That bug stays open until the next reproduction with these breadcrumbs attached gives us a root cause.