### PR TITLE
fix(seo): filter for status='published' in /play generateMetadata

### DIFF
--- a/.changeset/fix-play-metadata-published-filter.md
+++ b/.changeset/fix-play-metadata-published-filter.md
@@ -1,0 +1,7 @@
+---
+"spawnforge": patch
+---
+
+fix(seo): filter for status='published' in /play/[userId]/[slug] generateMetadata
+
+The standalone `generateMetadata` query on `/play/[userId]/[slug]/page.tsx` did not filter for `status = 'published'`, so a request for an unpublished/draft game with a known slug returned the draft's title and description in the HTML `<title>` and `<meta>` tags even though the page body itself was correctly gated. Consolidated `generateMetadata` and the page-level `getGameData` into a single `React.cache`-memoized helper that always filters on published status.

--- a/web/src/app/play/[userId]/[slug]/opengraph-image.tsx
+++ b/web/src/app/play/[userId]/[slug]/opengraph-image.tsx
@@ -77,7 +77,8 @@ export default async function Image({ params }: Props) {
         .where(
           and(
             eq(publishedGames.userId, user.id),
-            eq(publishedGames.slug, slug)
+            eq(publishedGames.slug, slug),
+            eq(publishedGames.status, 'published')
           )
         )
         .limit(1)

--- a/web/src/app/play/[userId]/[slug]/page.tsx
+++ b/web/src/app/play/[userId]/[slug]/page.tsx
@@ -13,6 +13,12 @@ interface PlayPageProps {
   params: Promise<{ userId: string; slug: string }>;
 }
 
+/**
+ * Fetch game data. Filters for status='published' so drafts never leak via
+ * metadata or JSON-LD. Returns null when game is missing, unpublished, or DB
+ * is unavailable. React.cache memoizes per-request so generateMetadata and the
+ * page body share a single round-trip.
+ */
 const getGameData = cache(async (clerkId: string, slug: string) => {
   try {
     const [user] = await queryWithResilience(() => getDb()
@@ -79,6 +85,7 @@ export async function generateMetadata({
 export default async function PlayPage({ params }: PlayPageProps) {
   const { userId, slug } = await params;
   const { userId: viewerClerkId } = await safeAuth();
+
   const game = await getGameData(userId, slug);
 
   // VideoGame JSON-LD — user-controlled values from DB (title, description).


### PR DESCRIPTION
## Summary
- `generateMetadata` on `/play/[userId]/[slug]/page.tsx` queried `publishedGames` by `userId` + `slug` only, with no `status='published'` filter — leaking draft titles and descriptions in HTML `<title>` and `<meta>` tags
- Page body itself was correctly gated, so visible content stayed hidden, but the metadata path leaked
- Consolidate `generateMetadata` and the page-level `getGameData` into a single `React.cache`-memoized helper that always filters on published status

Closes #8519

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint --max-warnings 0 src/app/play/[userId]/[slug]/page.tsx` passes
- [x] `npx vitest run src/app/play` — 5/5 tests pass
- [ ] Manual: hit `/play/<clerkId>/<draft-slug>` and confirm `<title>` reads "Game Not Found"