### PR TITLE
fix(security): replace MCP bearer regex with safe slice parser

### DIFF
--- a/.changeset/mcp-bearer-redos.md
+++ b/.changeset/mcp-bearer-redos.md
@@ -1,0 +1,5 @@
+---
+"@project-forge/mcp-server": patch
+---
+
+Replace the bearer-token regex in the MCP HTTP transport with a safe slice/trim parser. The previous `/^Bearer\s+(.+)$/i` pattern was a polynomial-ReDoS vector (CodeQL js/polynomial-redos #59) against attacker-controlled `Authorization` headers with long whitespace runs. The new parser runs in linear time.

--- a/mcp-server/src/transport/__tests__/http.test.ts
+++ b/mcp-server/src/transport/__tests__/http.test.ts
@@ -187,6 +187,43 @@ describe('startHttpTransport', () => {
       expect(status).toBe(401);
     });
 
+    it('rejects Authorization header with empty token after the scheme', async () => {
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: 'Bearer    ' },
+      );
+      expect(status).toBe(401);
+    });
+
+    it('accepts the lowercase "bearer" scheme (case-insensitive)', async () => {
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', clientInfo: { name: 'test', version: '0.0.0' }, capabilities: {} } },
+        { Authorization: `bearer ${TEST_TOKEN}` },
+      );
+      expect(status).toBe(200);
+    });
+
+    it('handles pathological whitespace in the Authorization header without backtracking', async () => {
+      // Regression for CodeQL js/polynomial-redos #59 — the prior regex
+      // /^Bearer\s+(.+)$/i could backtrack on long whitespace runs.
+      // The replacement uses slice/trim and runs in linear time.
+      // Node's HTTP parser caps header size (~16KB) so this stays under the
+      // limit while still being long enough that polynomial regex backtracking
+      // would be observable.
+      const evil = 'Bearer ' + ' '.repeat(8_000) + 'x';
+      const start = Date.now();
+      const { status } = await jsonRpc(
+        `http://127.0.0.1:${running!.port}/mcp`,
+        { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+        { Authorization: evil },
+      );
+      const elapsed = Date.now() - start;
+      expect(status).toBe(401);
+      expect(elapsed).toBeLessThan(1500);
+    });
+
     it('returns 404 on unknown paths', async () => {
       const res = await fetch(`http://127.0.0.1:${running!.port}/unknown`);
       expect(res.status).toBe(404);

--- a/mcp-server/src/transport/http.ts
+++ b/mcp-server/src/transport/http.ts
@@ -176,9 +176,13 @@ function getClientIp(req: IncomingMessage): string {
 
 function bearerOk(headerValue: string | undefined, expected: string): boolean {
   if (!headerValue) return false;
-  const match = headerValue.match(/^Bearer\s+(.+)$/i);
-  if (!match) return false;
-  const provided = Buffer.from(match[1]!.trim(), 'utf8');
+  // Avoid regex-based parsing — `/^Bearer\s+(.+)$/i` is polynomial in `\s+`
+  // against attacker-controlled headers (CodeQL js/polynomial-redos #59).
+  if (headerValue.length < 7) return false;
+  if (headerValue.slice(0, 7).toLowerCase() !== 'bearer ') return false;
+  const token = headerValue.slice(7).trim();
+  if (token.length === 0) return false;
+  const provided = Buffer.from(token, 'utf8');
   const want = Buffer.from(expected, 'utf8');
   if (provided.length !== want.length) return false;
   return timingSafeEqual(provided, want);


### PR DESCRIPTION
## Summary

- Replace `/^Bearer\s+(.+)$/i` in `mcp-server/src/transport/http.ts:bearerOk()` with a constant-time prefix check + `slice()` + `trim()` parser
- The prior regex backtracks polynomially against attacker-controlled `Authorization` headers (long whitespace runs after `Bearer`)
- Adds three regression tests: lowercase `bearer` scheme, empty token after scheme, 8KB pathological whitespace input completes well under 1.5s

Closes #8523

CodeQL alert: https://github.com/Tristan578/project-forge/security/code-scanning/59

## Test plan
- [x] `cd mcp-server && npx vitest run src/transport/__tests__/http.test.ts` — 19/19 pass
- [x] `cd mcp-server && npx tsc --noEmit` — clean
- [ ] CodeQL re-scans on merge and closes alert #59