### PR TITLE
fix(auth): redirect to sign-in instead of 404 on protected routes

### DIFF
--- a/.changeset/clerk-redirect-signin.md
+++ b/.changeset/clerk-redirect-signin.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix protected routes (`/dashboard`, `/dev`, `/settings`, `/editor`, etc.) returning hard 404 to signed-out browser visitors. Clerk v3+ middleware made `auth.protect()` rewrite to `/404` by default (route-enumeration mitigation), which left users with no recovery path. The proxy now calls `redirectToSignIn({ returnBackUrl })` for browser nav and returns 401 JSON for `/api/*` requests, restoring the original UX and unblocking the production smoke test. Resolves #8529.

--- a/web/e2e/tests/production-smoke.spec.ts
+++ b/web/e2e/tests/production-smoke.spec.ts
@@ -72,12 +72,15 @@ test.describe('Production Smoke Tests @smoke @production', () => {
     expect(res.status()).toBe(200);
   });
 
-  test('/dev route does not return 404 or 500 in production', async ({ request }) => {
+  test('/dev redirects unauthenticated users to sign-in (not 404)', async ({ request }) => {
     const res = await request.get(`${PROD_URL}/dev`, { maxRedirects: 0 });
-    // /dev is auth-protected in production. Clerk v7 returns 200 with a page
-    // shell and handles the redirect client-side. Both 200 (client redirect)
-    // and 307 (server redirect) are valid. 404 or 500 means the build is broken.
-    expect([200, 307, 302]).toContain(res.status());
+    // proxy.ts uses redirectToSignIn() for protected routes (#8529).
+    // 307 with a Location pointing at the sign-in page is the only correct
+    // response for a signed-out browser visit. 404 = Clerk's protect-rewrite
+    // default has regressed (poor UX, no recovery path). 500 = SSR crash.
+    expect([307, 302]).toContain(res.status());
+    const location = res.headers()['location'] || '';
+    expect(location).toMatch(/sign-in/);
   });
 
   test('no Clerk test keys in production HTML', async ({ request }) => {
@@ -114,24 +117,20 @@ test.describe('Production Smoke Tests @smoke @production', () => {
 });
 
 test.describe('Production Auth Flow @smoke @production', () => {
-  test('unauthenticated /dashboard does not 404 or 500', async ({ request }) => {
-    const res = await request.get(`${PROD_URL}/dashboard`, { maxRedirects: 0 });
-    // Clerk v7 + Next.js 16: protected routes may return 200 (client-side
-    // redirect) or 307 (server-side redirect). Both are valid.
-    // 404 = route missing from build. 500 = SSR crash. Either is a deploy bug.
-    const status = res.status();
-    expect(
-      status === 200 || status === 307 || status === 302,
-      `Expected 200/307/302 but got ${status}. 404 = broken build, 500 = SSR crash.`
-    ).toBe(true);
-  });
-
-  test('unauthenticated /settings does not 404 or 500', async ({ request }) => {
-    const res = await request.get(`${PROD_URL}/settings`, { maxRedirects: 0 });
-    const status = res.status();
-    expect(
-      status === 200 || status === 307 || status === 302,
-      `Expected 200/307/302 but got ${status}. 404 = broken build, 500 = SSR crash.`
-    ).toBe(true);
-  });
+  // Protected routes must redirect unauthenticated browser visitors to /sign-in,
+  // not rewrite to /404. Clerk's `auth.protect()` default is protect-rewrite-to-404
+  // (route enumeration mitigation), which gives users no recovery path. proxy.ts
+  // calls `redirectToSignIn()` instead — see #8529.
+  for (const path of ['/dashboard', '/settings']) {
+    test(`unauthenticated ${path} redirects to sign-in`, async ({ request }) => {
+      const res = await request.get(`${PROD_URL}${path}`, { maxRedirects: 0 });
+      const status = res.status();
+      expect(
+        status === 307 || status === 302,
+        `Expected 307/302 redirect but got ${status}. 404 = Clerk protect-rewrite regression. 500 = SSR crash.`,
+      ).toBe(true);
+      const location = res.headers()['location'] || '';
+      expect(location, `Location header should point at sign-in: ${location}`).toMatch(/sign-in/);
+    });
+  }
 });

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -44,4 +44,24 @@ describe('proxy public route configuration', () => {
     // Generate endpoints require authentication — they should NOT be in publicRoutes
     expect(proxySource).not.toMatch(/['"]\/api\/generate/);
   });
+
+  it('redirects unauthenticated browser nav instead of rewriting to /404 (#8529)', () => {
+    // Clerk's `auth.protect()` default rewrites to /404 for browser navigations.
+    // That gives users no recovery path. We must call redirectToSignIn() so
+    // unauthenticated visitors land on /sign-in with a return URL.
+    expect(proxySource).toContain('redirectToSignIn');
+    expect(proxySource).toContain('returnBackUrl');
+    // And the proxy should NOT call auth.protect() any more, which would
+    // re-introduce the 404 regression. Strip comments before matching so the
+    // explanatory comment that mentions auth.protect() doesn't trigger this.
+    const codeWithoutComments = proxySource.replace(/\/\/.*$/gm, '');
+    expect(codeWithoutComments).not.toMatch(/auth\.protect\(\)/);
+  });
+
+  it('returns 401 (not 307) for unauthenticated /api/* requests', () => {
+    // Browser nav -> 307 to sign-in. API requests -> 401 JSON so client code
+    // can distinguish "unauthenticated" from "not found" without parsing HTML.
+    expect(proxySource).toMatch(/pathname\.startsWith\(['"]\/api\//);
+    expect(proxySource).toMatch(/status:\s*401/);
+  });
 });

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -156,7 +156,19 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     }
 
     if (!isPublicRoute(req)) {
-      await auth.protect();
+      const { userId, redirectToSignIn } = await auth();
+      if (!userId) {
+        // Browser navigations: redirect to sign-in (preserves the original URL
+        // as `redirect_url` so users land back where they started after auth).
+        // API requests: return 401 so client code can distinguish unauthenticated
+        // from "not found". Clerk's default `auth.protect()` would rewrite browser
+        // requests to /404 — bad UX (no recovery path) and breaks the prod smoke
+        // test. See #8529.
+        if (req.nextUrl.pathname.startsWith('/api/')) {
+          return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+        return redirectToSignIn({ returnBackUrl: req.url });
+      }
     }
 
     return addSecurityHeaders(NextResponse.next(), req);


### PR DESCRIPTION
## Summary
- Replace `auth.protect()` with explicit `redirectToSignIn({ returnBackUrl })` in `proxy.ts` so signed-out browser visits to protected routes land on `/sign-in` instead of a hard 404.
- Return `401` JSON for unauthenticated `/api/*` requests so client code can distinguish "unauthenticated" from "not found" without parsing HTML.
- Harden the production smoke test: assert the redirect target contains `/sign-in` (the old `[200,307,302]` check would silently let Clerk's protect-rewrite-to-404 default pass).

## Why
Clerk v3+ middleware changed `auth.protect()` to rewrite browser navigations to `/404` by default (route-enumeration mitigation). That meant every signed-out visitor to `/dashboard`, `/dev`, `/settings`, `/editor`, etc. landed on a hard 404 with no recovery path — and the production smoke test has been failing nightly since the upgrade.

```
$ curl -sI https://www.spawnforge.ai/dashboard
HTTP/2 404
x-clerk-auth-status: signed-out
x-clerk-auth-reason: protect-rewrite, session-token-and-uat-missing
x-matched-path: /404
```

The "fix" matches Clerk's recommended pattern from their migration guide (`auth.redirectToSignIn()` instead of `auth.protect()`) and restores the historical UX.

Closes #8529

## Test plan
- [x] `npx vitest run src/__tests__/proxy.test.ts` — 8/8 pass (added 2 regression tests)
- [x] `npx eslint --max-warnings 0 src/proxy.ts src/__tests__/proxy.test.ts e2e/tests/production-smoke.spec.ts` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Post-merge: production smoke test passes; signed-out visit to `/dashboard` shows the sign-in page with a `redirect_url` back to `/dashboard`
- [ ] Signed-in users still get the dashboard (auth check still runs, just with a different fallback)

## Impact
- API routes that previously got rewritten to 404 now get a clear 401. Any client code that was checking for `404` from a protected `/api/*` should be updated — but searches show no such code in this repo (all `/api/*` callers either check `res.ok` or the response body).
- Protected page routes get a 307 to `/sign-in?redirect_url=<original>` instead of a 404 — strictly better UX.