### PR TITLE
fix(engine): push_redo enforces max_size and sets dirty flag

### DIFF
--- a/.changeset/history-redo-consistency.md
+++ b/.changeset/history-redo-consistency.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix `HistoryStack::push_redo()` to enforce `max_size` and set the `dirty` flag, restoring symmetry with `push()` and `push_undo_only()`. Editor "unsaved changes" indicator now reflects redo-state changes after an undo. The cap was previously bounded only implicitly by the in-flight undo flow; making it an explicit invariant of the type narrows the search space for future state-dependent engine panics. Resolves #8531.

--- a/engine/src/core/history.rs
+++ b/engine/src/core/history.rs
@@ -535,6 +535,15 @@ impl HistoryStack {
     /// Push an action onto the redo stack (after undo).
     pub fn push_redo(&mut self, action: UndoableAction) {
         self.redo_stack.push(action);
+        self.dirty = true;
+
+        // Enforce max size — same invariant as push() and push_undo_only().
+        // In the in-flight undo flow this is bounded by undo_stack <= max_size,
+        // but enforcing it here makes the cap an explicit invariant of the type
+        // rather than a property of the caller.
+        while self.redo_stack.len() > self.max_size {
+            self.redo_stack.remove(0);
+        }
     }
 
     /// Push an action onto the undo stack without clearing the redo stack.
@@ -639,4 +648,59 @@ pub fn push_action_from_bridge(action: UndoableAction) -> bool {
             false
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rename_action(suffix: usize) -> UndoableAction {
+        UndoableAction::Rename {
+            entity_id: format!("e{suffix}"),
+            old_name: "old".into(),
+            new_name: format!("new{suffix}"),
+        }
+    }
+
+    #[test]
+    fn push_redo_sets_dirty() {
+        let mut history = HistoryStack::default();
+        history.dirty = false;
+
+        history.push_redo(rename_action(0));
+
+        assert!(history.dirty, "push_redo must mark history dirty");
+    }
+
+    #[test]
+    fn push_redo_caps_at_max_size() {
+        let mut history = HistoryStack::default();
+        history.max_size = 3;
+
+        for i in 0..5 {
+            history.push_redo(rename_action(i));
+        }
+
+        assert_eq!(history.redo_stack.len(), 3, "redo stack must respect max_size");
+        // Oldest entries dropped — newest survive.
+        let last = history.redo_stack.last().expect("non-empty");
+        match last {
+            UndoableAction::Rename { entity_id, .. } => assert_eq!(entity_id, "e4"),
+            other => panic!("unexpected action: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn push_clears_redo_after_new_action() {
+        // Regression guard: enforcing max_size on push_redo must not break the
+        // invariant that any new action wipes the redo stack.
+        let mut history = HistoryStack::default();
+        history.push_redo(rename_action(0));
+        history.push_redo(rename_action(1));
+
+        history.push(rename_action(2));
+
+        assert!(history.redo_stack.is_empty(), "push() must clear redo_stack");
+        assert_eq!(history.undo_stack.len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

- `HistoryStack::push_redo()` now enforces `max_size` and sets `dirty = true`, matching `push()` and `push_undo_only()`.
- Adds three unit tests covering the dirty bit, the size cap, and the existing invariant that `push()` clears the redo stack.
- Updates the redo path so the editor's "unsaved changes" indicator no longer falls behind after an undo.

## Why

`push_redo` was the only push method on `HistoryStack` not setting `dirty` or capping the stack. In the in-flight undo flow `redo_stack` is bounded by `undo_stack ≤ max_size = 100`, so the practical impact is small — but the cap was implicit and architectural. Making it an invariant of the type closes a defense-in-depth gap and narrows the search space for the next state-dependent engine panic (see #8462).

## Test plan
- [x] `cargo test --lib core::history` — 3/3 new tests pass on host
- [ ] CI: Quality Gates / Lint, TypeScript, Web Tests, Editor Boot, E2E — green
- [ ] CI: Quality Gates / Coverage Ratchet — no regression

Closes #8531