### PR TITLE
fix: nightly quality gate — tsc clean-checkout failures and coverage hoisting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22194,7 +22194,7 @@
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "@vitest/coverage-v8": "^4.1.4",
+        "@vitest/coverage-v8": "^4.1.5",
         "ajv": "^6.14.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",

--- a/web/package.json
+++ b/web/package.json
@@ -101,7 +101,7 @@
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@vitest/coverage-v8": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.5",
     "ajv": "^6.14.0",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -28,6 +28,10 @@
     // where array access is guaranteed safe (e.g., after length checks, Map.get with existence guard).
     "noUncheckedIndexedAccess": false,
     "incremental": true,
+    // Resolve @spawnforge/ui from TS source (via "development" export condition)
+    // so tsc works in clean checkouts where packages/ui hasn't been built yet.
+    // Matches the conditions list in vitest.config.jsdom.ts.
+    "customConditions": ["development"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary

- Added `"customConditions": ["development"]` to `web/tsconfig.json` so `tsc --noEmit` resolves `@spawnforge/ui` from TypeScript source in clean checkouts (no pre-built `dist/` required). Fixes 3 type errors in `EditorLayout.tsx` and `AppearanceTab.tsx`.
- Hoisted `@vitest/coverage-v8` to root `node_modules` so the monorepo root `vitest` binary can run coverage without `ERR_MODULE_NOT_FOUND`.

Closes #8533

## Root cause

`packages/ui/package.json` exports `"types": "./dist/index.d.ts"` (requires a build) **and** `"development": "./src/index.ts"` (points to TS source). `vitest.config.jsdom.ts` already used `conditions: ['development', ...]` so tests always passed. `web/tsconfig.json` was missing `customConditions: ["development"]`, so `tsc` fell through to the `types` condition and failed when `dist/` was absent.

## Test plan

- [x] `tsc --noEmit` — 0 errors (was 3)
- [x] `eslint --max-warnings 0` — 0 warnings
- [x] `vitest run` — 15329 passed, 4 skipped, 0 failed (753 files)
- [x] Coverage: Statements 80.0% / Branches 69.7% / Functions 74.9% / Lines 81.4% — all above thresholds (75/65/70/77)
- [x] `AutoSaveRecovery.test.tsx` confirmed non-flaky (passes in isolation)