### PR TITLE
feat(generation): auto-wire completed jobs to target entities (#8540)

### DIFF
--- a/.changeset/auto-wire-generation-jobs.md
+++ b/.changeset/auto-wire-generation-jobs.md
@@ -1,0 +1,5 @@
+---
+'web': minor
+---
+
+Auto-wire completed AI generation jobs into the target entity. When a model, texture, or audio job finishes with `autoPlace` set, the result is fetched and dispatched to the editor automatically — textures land on the requested material slot, audio attaches to the requested entity, models import alongside the placeholder. Idempotent across page refresh via `appliedAt`. Closes #8540.

--- a/web/src/stores/__tests__/generationAutoWire.test.ts
+++ b/web/src/stores/__tests__/generationAutoWire.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for the generation auto-wire bridge.
+ *
+ * Covers both the standalone module (autoWireGenerationResult dispatching to
+ * the registered editor handlers) and the generationStore trigger that fires
+ * the bridge on completion transitions.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  autoWireGenerationResult,
+  setAutoWireDispatchers,
+  _resetForTest,
+  type AutoWireDispatchers,
+} from '../generationAutoWire';
+import { useGenerationStore, type GenerationJob } from '../generationStore';
+
+vi.mock('@/lib/monitoring/sentry-client', () => ({
+  captureException: vi.fn(),
+}));
+vi.mock('@/lib/analytics/posthog', () => ({
+  trackEvent: vi.fn(),
+  AnalyticsEvent: {
+    AI_GENERATION_STARTED: 'ai_generation_started',
+    AI_GENERATION_COMPLETED: 'ai_generation_completed',
+  },
+}));
+vi.mock('@/lib/analytics/events', () => ({
+  trackAIAssetGenerated: vi.fn(),
+}));
+
+function makeDispatchers(): AutoWireDispatchers & {
+  importGltf: ReturnType<typeof vi.fn>;
+  loadTexture: ReturnType<typeof vi.fn>;
+  importAudio: ReturnType<typeof vi.fn>;
+  setAudio: ReturnType<typeof vi.fn>;
+} {
+  return {
+    importGltf: vi.fn(),
+    loadTexture: vi.fn(),
+    importAudio: vi.fn(),
+    setAudio: vi.fn(),
+  };
+}
+
+function mockBlobFetch(bytes: number[] = [1, 2, 3], type = 'application/octet-stream'): void {
+  const blob = new Blob([new Uint8Array(bytes)], { type });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      blob: async () => blob,
+      json: async () => ({ job: { id: 'db-1' }, jobs: [] }),
+    }),
+  );
+}
+
+describe('autoWireGenerationResult', () => {
+  beforeEach(() => {
+    _resetForTest();
+    mockBlobFetch();
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('is a no-op when no dispatchers are registered', async () => {
+    await autoWireGenerationResult({
+      type: 'model',
+      resultUrl: 'https://example.com/m.glb',
+      prompt: 'tree',
+    });
+    // Nothing to assert beyond "did not throw"; the fetch is never called.
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it('routes model results to importGltf', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'model',
+      resultUrl: 'https://example.com/oak.glb',
+      prompt: 'an oak tree',
+    });
+
+    expect(d.importGltf).toHaveBeenCalledTimes(1);
+    expect(d.importGltf).toHaveBeenCalledWith(expect.any(String), 'an_oak_tree');
+    expect(d.loadTexture).not.toHaveBeenCalled();
+    expect(d.importAudio).not.toHaveBeenCalled();
+  });
+
+  it.each(['texture', 'sprite', 'sprite_sheet', 'tileset', 'pixel-art'] as const)(
+    'routes %s results to loadTexture when targetEntityId + materialSlot are present',
+    async (type) => {
+      const d = makeDispatchers();
+      setAutoWireDispatchers(d);
+
+      await autoWireGenerationResult({
+        type,
+        resultUrl: 'https://example.com/tex.png',
+        prompt: 'rusty metal',
+        targetEntityId: 'entity-1',
+        materialSlot: 'base_color',
+      });
+
+      expect(d.loadTexture).toHaveBeenCalledTimes(1);
+      expect(d.loadTexture).toHaveBeenCalledWith(
+        expect.any(String),
+        'rusty_metal',
+        'entity-1',
+        'base_color',
+      );
+      expect(d.importGltf).not.toHaveBeenCalled();
+    },
+  );
+
+  it('skips texture wiring when targetEntityId is missing', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'texture',
+      resultUrl: 'https://example.com/tex.png',
+      prompt: 'wood',
+      materialSlot: 'base_color',
+    });
+
+    expect(d.loadTexture).not.toHaveBeenCalled();
+  });
+
+  it('skips texture wiring when materialSlot is missing', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'texture',
+      resultUrl: 'https://example.com/tex.png',
+      prompt: 'wood',
+      targetEntityId: 'entity-1',
+    });
+
+    expect(d.loadTexture).not.toHaveBeenCalled();
+  });
+
+  it.each(['sfx', 'voice', 'music'] as const)(
+    'routes %s results to importAudio + setAudio when targetEntityId is present',
+    async (type) => {
+      const d = makeDispatchers();
+      setAutoWireDispatchers(d);
+
+      await autoWireGenerationResult({
+        type,
+        resultUrl: 'https://example.com/clip.mp3',
+        prompt: 'ambient hum',
+        targetEntityId: 'entity-2',
+      });
+
+      expect(d.importAudio).toHaveBeenCalledTimes(1);
+      expect(d.importAudio).toHaveBeenCalledWith(expect.any(String), 'ambient_hum');
+      expect(d.setAudio).toHaveBeenCalledTimes(1);
+      expect(d.setAudio).toHaveBeenCalledWith('entity-2', { assetId: 'ambient_hum' });
+    },
+  );
+
+  it('skips audio wiring when targetEntityId is missing', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'sfx',
+      resultUrl: 'https://example.com/clip.mp3',
+      prompt: 'whoosh',
+    });
+
+    expect(d.importAudio).not.toHaveBeenCalled();
+    expect(d.setAudio).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for skybox (engine support pending)', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'skybox',
+      resultUrl: 'https://example.com/sky.hdr',
+      prompt: 'mountain dawn',
+      targetEntityId: 'entity-3',
+    });
+
+    expect(d.importGltf).not.toHaveBeenCalled();
+    expect(d.loadTexture).not.toHaveBeenCalled();
+    expect(d.importAudio).not.toHaveBeenCalled();
+    expect(d.setAudio).not.toHaveBeenCalled();
+  });
+
+  it('reports fetch failures to Sentry without throwing or dispatching', async () => {
+    const sentry = await import('@/lib/monitoring/sentry-client');
+    const captureException = vi.mocked(sentry.captureException);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+      }),
+    );
+
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'model',
+      resultUrl: 'https://example.com/m.glb',
+      prompt: 'cube',
+    });
+
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('502') }),
+      expect.objectContaining({ context: 'generationAutoWire.fetch' }),
+    );
+    expect(d.importGltf).not.toHaveBeenCalled();
+  });
+
+  it('falls back to "generated" for prompts that sanitize to empty', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    await autoWireGenerationResult({
+      type: 'model',
+      resultUrl: 'https://example.com/m.glb',
+      prompt: '!!!@@@###',
+    });
+
+    expect(d.importGltf).toHaveBeenCalledWith(expect.any(String), 'generated');
+  });
+});
+
+describe('generationStore auto-wire trigger', () => {
+  const mockJob: GenerationJob = {
+    id: 'client-1',
+    jobId: 'prov-1',
+    type: 'texture',
+    prompt: 'mossy stone',
+    status: 'processing',
+    progress: 50,
+    provider: 'replicate',
+    createdAt: 1234567890,
+    autoPlace: true,
+    targetEntityId: 'entity-A',
+    materialSlot: 'base_color',
+  };
+
+  beforeEach(() => {
+    _resetForTest();
+    mockBlobFetch();
+    useGenerationStore.setState({ jobs: {}, hydrated: false });
+  });
+
+  afterEach(() => {
+    _resetForTest();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('fires auto-wire when a job transitions to completed with autoPlace + resultUrl', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    useGenerationStore.setState({ jobs: { 'client-1': mockJob } });
+    useGenerationStore.getState().updateJob('client-1', {
+      status: 'completed',
+      progress: 100,
+      resultUrl: 'https://example.com/tex.png',
+    });
+
+    await vi.waitFor(() => {
+      expect(d.loadTexture).toHaveBeenCalledTimes(1);
+    });
+    expect(d.loadTexture).toHaveBeenCalledWith(
+      expect.any(String),
+      'mossy_stone',
+      'entity-A',
+      'base_color',
+    );
+    // Idempotency stamp set on the stored job.
+    expect(useGenerationStore.getState().jobs['client-1'].appliedAt).toBeTypeOf('number');
+  });
+
+  it('does not fire auto-wire when autoPlace is not set', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    useGenerationStore.setState({
+      jobs: { 'client-1': { ...mockJob, autoPlace: undefined } },
+    });
+    useGenerationStore.getState().updateJob('client-1', {
+      status: 'completed',
+      progress: 100,
+      resultUrl: 'https://example.com/tex.png',
+    });
+
+    // Give microtasks a chance.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(d.loadTexture).not.toHaveBeenCalled();
+  });
+
+  it('does not re-fire when an already-completed job is updated', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    useGenerationStore.setState({
+      jobs: {
+        'client-1': {
+          ...mockJob,
+          status: 'completed',
+          resultUrl: 'https://example.com/tex.png',
+          appliedAt: Date.now(),
+        },
+      },
+    });
+
+    useGenerationStore.getState().updateJob('client-1', { progress: 100 });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(d.loadTexture).not.toHaveBeenCalled();
+  });
+
+  it('marks rehydrated completed jobs with appliedAt so refresh-after-completion is a no-op', async () => {
+    const d = makeDispatchers();
+    setAutoWireDispatchers(d);
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        jobs: [
+          {
+            id: 'srv-completed',
+            providerJobId: 'prov-c',
+            provider: 'replicate',
+            type: 'texture',
+            prompt: 'wood',
+            status: 'completed',
+            progress: 100,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:30Z',
+            parameters: {
+              autoPlace: true,
+              targetEntityId: 'entity-Z',
+              materialSlot: 'base_color',
+            },
+          },
+        ],
+      }),
+    } as Response);
+
+    await useGenerationStore.getState().hydrateFromServer();
+
+    const hydrated = Object.values(useGenerationStore.getState().jobs)[0];
+    expect(hydrated.status).toBe('completed');
+    expect(hydrated.appliedAt).toBeTypeOf('number');
+
+    // Subsequent updateJob must not re-trigger auto-wire.
+    useGenerationStore.getState().updateJob(hydrated.id, { progress: 100 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(d.loadTexture).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/stores/editorStore.ts
+++ b/web/src/stores/editorStore.ts
@@ -12,6 +12,7 @@ import { addBreadcrumb } from '@/lib/monitoring/sentry-client';
 // the snapshot setter) don't throw at module load. We feature-detect the
 // export at runtime instead of relying on the named binding being present.
 import * as engineModule from '@/hooks/useEngine';
+import { setAutoWireDispatchers } from './generationAutoWire';
 
 // Import all slices
 import {
@@ -122,6 +123,18 @@ export const useEditorStore = create<EditorState>()((...args) => ({
   ...createLocalizationSlice(...args),
   ...createOrchestratorSlice(...args),
 }));
+
+// Wire generation auto-wire to editor actions. Resolves the store at call time
+// so the latest action references are used (slices may be replaced in tests via
+// resetForTest helpers). Decoupled via the registered-handler pattern in
+// generationAutoWire to avoid editorStore <-> generationStore import cycles.
+setAutoWireDispatchers({
+  importGltf: (dataBase64, name) => useEditorStore.getState().importGltf(dataBase64, name),
+  loadTexture: (dataBase64, name, entityId, slot) =>
+    useEditorStore.getState().loadTexture(dataBase64, name, entityId, slot),
+  importAudio: (dataBase64, name) => useEditorStore.getState().importAudio(dataBase64, name),
+  setAudio: (entityId, data) => useEditorStore.getState().setAudio(entityId, data),
+});
 
 // Best-effort store exposure for E2E tests (dev/test only).
 // The primary exposure happens in EditorLayout's useEffect (guaranteed client-side).

--- a/web/src/stores/generationAutoWire.ts
+++ b/web/src/stores/generationAutoWire.ts
@@ -1,0 +1,122 @@
+/**
+ * Generation auto-wire — connects completed AI generation jobs to the editor.
+ *
+ * When a generation job completes with `resultUrl` and the user requested
+ * placement (`autoPlace` + `targetEntityId`), this module fetches the asset
+ * and dispatches the appropriate editor command (importGltf / loadTexture /
+ * importAudio + setAudio) so the result lands on the target entity without
+ * a manual drag-drop.
+ *
+ * Decoupled from editorStore via a registered-handler pattern (matching
+ * the existing slice dispatcher pattern in this folder) to avoid an import
+ * cycle. Wired at boot from the editorStore composition root.
+ *
+ * Closes #8540.
+ */
+
+import { captureException } from '@/lib/monitoring/sentry-client';
+import type { GenerationType } from './generationStore';
+
+export interface AutoWireDispatchers {
+  importGltf: (dataBase64: string, name: string) => void;
+  loadTexture: (dataBase64: string, name: string, entityId: string, slot: string) => void;
+  importAudio: (dataBase64: string, name: string) => void;
+  setAudio: (entityId: string, data: { assetId: string }) => void;
+}
+
+let dispatchers: AutoWireDispatchers | null = null;
+
+export function setAutoWireDispatchers(next: AutoWireDispatchers | null): void {
+  dispatchers = next;
+}
+
+export interface AutoWireInput {
+  type: GenerationType;
+  resultUrl: string;
+  prompt: string;
+  targetEntityId?: string;
+  materialSlot?: string;
+}
+
+const TEXTURE_TYPES: ReadonlySet<GenerationType> = new Set([
+  'texture',
+  'sprite',
+  'sprite_sheet',
+  'tileset',
+  'pixel-art',
+]);
+
+const AUDIO_TYPES: ReadonlySet<GenerationType> = new Set(['sfx', 'voice', 'music']);
+
+export async function autoWireGenerationResult(input: AutoWireInput): Promise<void> {
+  if (!dispatchers) return;
+
+  const name = sanitizeAssetName(input.prompt);
+
+  let dataBase64: string;
+  try {
+    dataBase64 = await fetchAsBase64(input.resultUrl);
+  } catch (err) {
+    captureException(err, {
+      context: 'generationAutoWire.fetch',
+      url: input.resultUrl,
+      type: input.type,
+    });
+    return;
+  }
+
+  if (input.type === 'model') {
+    // Engine doesn't yet support replacing an existing entity with the imported
+    // glTF in-place; we import alongside. Replacement is tracked separately —
+    // the user can delete the placeholder once the model lands.
+    dispatchers.importGltf(dataBase64, name);
+    return;
+  }
+
+  if (TEXTURE_TYPES.has(input.type) && input.targetEntityId && input.materialSlot) {
+    dispatchers.loadTexture(dataBase64, name, input.targetEntityId, input.materialSlot);
+    return;
+  }
+
+  if (AUDIO_TYPES.has(input.type) && input.targetEntityId) {
+    dispatchers.importAudio(dataBase64, name);
+    dispatchers.setAudio(input.targetEntityId, { assetId: name });
+    return;
+  }
+
+  // Skybox + unrecognized types are no-ops here — they require additional
+  // engine surface (custom-URL skybox, asset placement) tracked in follow-ups.
+}
+
+async function fetchAsBase64(url: string): Promise<string> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch generation result: ${res.status} ${res.statusText}`);
+  }
+  const blob = await res.blob();
+  return blobToBase64(blob);
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      const idx = result.indexOf(',');
+      resolve(idx >= 0 ? result.slice(idx + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function sanitizeAssetName(prompt: string): string {
+  const trimmed = prompt.trim().slice(0, 60);
+  const safe = trimmed.replace(/[^a-zA-Z0-9_-]+/g, '_').replace(/^_+|_+$/g, '');
+  return safe || 'generated';
+}
+
+// Test-only — reset registered dispatchers between tests.
+export function _resetForTest(): void {
+  dispatchers = null;
+}

--- a/web/src/stores/generationStore.ts
+++ b/web/src/stores/generationStore.ts
@@ -8,6 +8,7 @@
 
 import { create } from 'zustand';
 import { useGenerationHistoryStore } from './generationHistoryStore';
+import { autoWireGenerationResult } from './generationAutoWire';
 import { trackEvent, AnalyticsEvent } from '@/lib/analytics/posthog';
 import { trackAIAssetGenerated } from '@/lib/analytics/events';
 import { captureException } from '@/lib/monitoring/sentry-client';
@@ -33,6 +34,7 @@ export interface GenerationJob {
   autoPlace?: boolean;       // Auto-import and attach to entity on completion
   targetEntityId?: string;   // Entity to attach result to (e.g. place model as child, assign texture)
   materialSlot?: string;     // Material texture slot for texture generation (e.g. 'base_color', 'normal_map')
+  appliedAt?: number;        // Date.now() when auto-wire fired — guards against double-application on hydrate
 }
 
 interface GenerationState {
@@ -137,6 +139,33 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
         });
       }
 
+      // Auto-wire: when the job transitions to completed and the user opted in
+      // via autoPlace, fetch the result and dispatch it to the editor (texture
+      // → material slot, audio → entity, model → import). Idempotent via
+      // `appliedAt`: rehydration of an already-completed job will not re-fire
+      // because we set `appliedAt` synchronously here. Hydration also flips
+      // `appliedAt` so refresh-after-completion is a no-op (see
+      // hydrateFromServer below).
+      if (
+        updated.status === 'completed' &&
+        existing.status !== 'completed' &&
+        updated.resultUrl &&
+        updated.autoPlace &&
+        !updated.appliedAt
+      ) {
+        updated.appliedAt = Date.now();
+        // Fire-and-forget — fetch + dispatch run async; failures captured to Sentry.
+        autoWireGenerationResult({
+          type: updated.type,
+          resultUrl: updated.resultUrl,
+          prompt: updated.prompt,
+          targetEntityId: updated.targetEntityId,
+          materialSlot: updated.materialSlot,
+        }).catch((err: unknown) => {
+          captureException(err, { context: 'generationStore.autoWire', jobId: id });
+        });
+      }
+
       // Sync status to database (fire-and-forget)
       const dbId = updated.dbId;
       if (dbId && (updates.status || updates.progress !== undefined)) {
@@ -221,6 +250,11 @@ export const useGenerationStore = create<GenerationState>((set, get) => ({
             typeof params['targetEntityId'] === 'string' ? params['targetEntityId'] : undefined,
           materialSlot:
             typeof params['materialSlot'] === 'string' ? params['materialSlot'] : undefined,
+          // Jobs that are already completed at hydration time were either
+          // auto-wired in a prior session or never opted in; either way, we
+          // must not re-fire on refresh. Mark `appliedAt` so updateJob's
+          // auto-wire guard treats them as already-applied.
+          appliedAt: sj.status === 'completed' ? new Date(sj.createdAt).getTime() : undefined,
         };
       }
 


### PR DESCRIPTION
## Summary

Closes #8540 (PF-757)

When an AI generation job completes with `autoPlace` set, the result is now fetched and dispatched to the editor automatically — no manual drag-drop. This is the missing 80% of the prompt-to-3D-game flow identified in the audit: jobs were already finishing with valid `resultUrl`s, but nothing wired them into the scene.

- **Models** → `importGltf` with the asset placed alongside the placeholder (engine-side replace-in-place is tracked separately).
- **Textures** (texture / sprite / sprite_sheet / tileset / pixel-art) → `loadTexture` on the requested entity + material slot.
- **Audio** (sfx / voice / music) → `importAudio` followed by `setAudio` on the target entity.
- **Skybox** → no-op (engine needs custom-URL skybox support; tracked as follow-up).
- **Idempotent**: an `appliedAt` stamp on the job guards against double-application when a completed job is re-touched in `updateJob`, and `hydrateFromServer` pre-stamps already-completed jobs so a refresh after the result lands does not re-fire.

## Architecture

`generationAutoWire.ts` is a new module that owns the result-to-editor dispatch. It uses the registered-handler pattern (matching `setSelectionDispatcher`, `setMaterialDispatcher`, etc.) so `generationStore` does not need to import `editorStore` — avoiding the import cycle.

`editorStore` registers the dispatchers at module load by closing over `useEditorStore.getState()`, so any later slice replacement (e.g. test resets) keeps the wiring valid.

## Test plan

- [x] `npx vitest run src/stores/__tests__/generationAutoWire.test.ts` — 20 new tests covering all routing cases, missing-id no-ops, fetch-failure Sentry capture, and idempotency on rehydrate.
- [x] `npx vitest run src/stores/__tests__/generationStore.test.ts` — 44 existing tests still pass.
- [x] `npx vitest run src/stores/__tests__/editorStore.crashContext.test.ts` — store wiring change does not affect crash-snapshot path.
- [x] `npx eslint --max-warnings 0` clean on touched files.
- [ ] Manual: open editor, request a texture for a selected entity with auto-place enabled, confirm the texture lands on the material slot without a manual import step.

## Out of scope (follow-ups)

- Replacing a placeholder entity with the imported glTF in-place (needs `import_gltf` engine surface). Currently the model is imported alongside; the user can delete the placeholder.
- Skybox auto-application via custom URL (needs engine support).
- Tileset slicing on completion — the texture lands as a single image; tileset metadata is still authored manually.