### PR TITLE
fix(generate): send mode field on 3d-model handlers (#8544)

### DIFF
--- a/.changeset/fix-generate-3d-model-mode.md
+++ b/.changeset/fix-generate-3d-model-mode.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Fix `generate_3d_model` and `generate_3d_from_image` chat handlers always returning HTTP 400. Both omitted the required `mode` field on the request body to `/api/generate/model`. The route's validator hard-requires `mode ∈ {text-to-3d, image-to-3d}`, so every text-to-3D call from chat failed before reaching Meshy. Closes #8544.

--- a/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
@@ -140,6 +140,14 @@ describe('generationHandlers', () => {
       expect(r.jobId).toBe('job-123');
     });
 
+    // Regression: route requires `mode` and rejects without it (#8544).
+    it('sends mode: text-to-3d to the model route', async () => {
+      mockFetchSuccess();
+      await invoke('generate_3d_model', { prompt: 'a sword' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.mode).toBe('text-to-3d');
+    });
+
     it('passes quality and artStyle', async () => {
       mockFetchSuccess();
       await invoke('generate_3d_model', {
@@ -204,6 +212,14 @@ describe('generationHandlers', () => {
       expect(result.success).toBe(true);
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.imageBase64).toBe('base64data');
+    });
+
+    // Regression: route requires `mode` and rejects without it (#8544).
+    it('sends mode: image-to-3d to the model route', async () => {
+      mockFetchSuccess();
+      await invoke('generate_3d_from_image', { imageBase64: 'base64data' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.mode).toBe('image-to-3d');
     });
 
     it('works without optional prompt', async () => {

--- a/web/src/lib/chat/handlers/generationHandlers.ts
+++ b/web/src/lib/chat/handlers/generationHandlers.ts
@@ -127,6 +127,7 @@ export const generationHandlers: Record<string, ToolHandler> = {
     if (p.error) return p.error;
 
     const result = await generateFetch('/api/generate/model', {
+      mode: 'text-to-3d',
       prompt: enrichPrompt(p.data.prompt, 'model', ctx.store),
       quality: p.data.quality ?? 'standard',
       artStyle: p.data.artStyle ?? 'realistic',
@@ -172,6 +173,7 @@ export const generationHandlers: Record<string, ToolHandler> = {
       ? enrichPrompt(p.data.prompt, 'model', ctx.store)
       : undefined;
     const result = await generateFetch('/api/generate/model', {
+      mode: 'image-to-3d',
       imageBase64: p.data.imageBase64,
       prompt: enrichedPrompt,
     });


### PR DESCRIPTION
## Summary

- `generate_3d_model` (text-to-3D) now sends `mode: 'text-to-3d'` on the model-route fetch body.
- `generate_3d_from_image` (image-to-3D) now sends `mode: 'image-to-3d'`.
- Two regression tests added that JSON-parse the request body and assert the correct `mode`.

## Why

The model route at `web/src/app/api/generate/model/route.ts:52-53` hard-requires `mode ∈ {text-to-3d, image-to-3d}`. Both handlers omitted it, so every chat-driven 3D-model generation returned HTTP 400 before reaching Meshy. Discovered during the audit of #8540 / closed PR #8543.

This is the headline blocker on "single prompt → 3D game with assets" — with this fix the job actually reaches Meshy and the existing polling/auto-attach paths take over.

Closes #8544

## Test plan

- [x] `npx vitest run src/lib/chat/handlers/__tests__/generationHandlers.test.ts` — 60/60 pass, including the two new `mode` assertions
- [x] `npx eslint --max-warnings 0` on changed files — clean
- [x] `npx tsc --noEmit` — only pre-existing `stripe-client.ts` API-version error on main, unrelated
- [ ] Manual: type "generate a 3D model of a tree" in chat (post-merge), confirm Meshy job is created not a 400

## Notes

The pre-existing tsc error in `src/lib/billing/stripe-client.ts` (`'2026-04-22.dahlia' is not assignable to type '2026-03-25.dahlia'`) is also present on `main` — Stripe SDK pinned an older API version in its types than the literal in the source. Tracking separately.