### PR TITLE
fix(tests): nightly quality gate — jsdom annotations for 11 browser-API test files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@changesets/cli": "^2.30.0",
         "@storybook/react": "^8.6",
         "@storybook/react-vite": "^8.6",
+        "@vitest/coverage-v8": "^4.1.5",
         "storybook": "^8.6",
         "turbo": "^2.5.4",
         "vitest": "^4.1.4"
@@ -10294,6 +10295,44 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -22289,35 +22328,6 @@
         }
       }
     },
-    "web/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "web/node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -22345,13 +22355,6 @@
     },
     "web/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "web/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@changesets/cli": "^2.30.0",
     "@storybook/react": "^8.6",
     "@storybook/react-vite": "^8.6",
+    "@vitest/coverage-v8": "^4.1.5",
     "storybook": "^8.6",
     "turbo": "^2.5.4",
     "vitest": "^4.1.4"

--- a/web/src/lib/ai/__tests__/artStyleEngine.test.ts
+++ b/web/src/lib/ai/__tests__/artStyleEngine.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   ART_STYLE_PRESETS,

--- a/web/src/lib/ai/__tests__/autoIteration.test.ts
+++ b/web/src/lib/ai/__tests__/autoIteration.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import {
   diagnoseIssues,

--- a/web/src/lib/analytics/__tests__/posthog.test.ts
+++ b/web/src/lib/analytics/__tests__/posthog.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock posthog-js before importing the module under test

--- a/web/src/lib/chat/__tests__/imageUpload.test.ts
+++ b/web/src/lib/chat/__tests__/imageUpload.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   validateImageFile,

--- a/web/src/lib/cutscene/__tests__/player.test.ts
+++ b/web/src/lib/cutscene/__tests__/player.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { applyEasing, buildCommand, CutscenePlayer, type CommandDispatcher } from '../player';
 import type { CutsceneTrack, CutsceneKeyframe } from '@/stores/cutsceneStore';

--- a/web/src/lib/generate/__tests__/spriteClient.test.ts
+++ b/web/src/lib/generate/__tests__/spriteClient.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SpriteClient } from '../spriteClient';
 

--- a/web/src/lib/monitoring/__tests__/cdnAnalytics.test.ts
+++ b/web/src/lib/monitoring/__tests__/cdnAnalytics.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   readCfCacheStatus,

--- a/web/src/lib/monitoring/__tests__/webVitals.test.ts
+++ b/web/src/lib/monitoring/__tests__/webVitals.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock web-vitals at module level so dynamic import() picks it up

--- a/web/src/lib/storage/__tests__/safeLocalStorage.test.ts
+++ b/web/src/lib/storage/__tests__/safeLocalStorage.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { safeGetItem, safeSetItem } from '../safeLocalStorage';
 

--- a/web/src/stores/__tests__/undoRedoChain.test.ts
+++ b/web/src/stores/__tests__/undoRedoChain.test.ts
@@ -14,8 +14,10 @@
  *   4. History state flags reflect what the engine reports after each step.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useEditorStore, setCommandDispatcher } from '@/stores/editorStore';
+
+vi.mock('@/lib/analytics/events');
 import {
   createMockDispatch,
   makeSceneGraph,

--- a/web/src/stores/editorStore.test.ts
+++ b/web/src/stores/editorStore.test.ts
@@ -6,8 +6,10 @@
  * script logs, and entity CRUD actions.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useEditorStore, setCommandDispatcher } from './editorStore';
+
+vi.mock('@/lib/analytics/events');
 import {
   createMockDispatch,
   makeSceneGraph,


### PR DESCRIPTION
## Summary

- 9 test files in `src/lib/**` used browser APIs (`localStorage`, `document`, `canvas`, `requestAnimationFrame`, `FileReader`, `window.location`, PostHog, web-vitals) but had no `// @vitest-environment jsdom` annotation — they ran under `node` environment in `vitest.config.node.ts` and failed with `ReferenceError`.
- 2 store tests (`editorStore`, `undoRedoChain`) failed because `setCommandDispatcher` wraps dispatch with `trackCommandDispatched()` → `@vercel/analytics/track()`, which throws in Node environments (side-effect of #8515). Fixed by adding `vi.mock('@/lib/analytics/events')`.

**Result: 73 tests fixed, 508/508 node-tests files pass (was 11 failing).**

Closes #8558

## Root cause chain

`feat(observability)` #8515 added `trackCommandDispatched()` to the store dispatcher wrapper. The Vercel Analytics client-side `track()` function now throws with `"Please import track from @vercel/analytics/server"` when called outside a browser context, surfacing pre-existing missing `// @vitest-environment jsdom` annotations in tests that were previously only validated under the standalone `vitest.config.ts` (jsdom).

## Test plan

- [x] All 11 files run 1× pass with `npx vitest run --config vitest.config.node.ts <files>`
- [x] Full node-tests suite: `508 passed | 1 skipped` (zero failures)
- [x] ESLint zero warnings on all changed files
- [x] `npx tsc --noEmit` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt6eNmK1Tm1xYMpHesjvWp)_