### PR TITLE
fix: durably hoist @vitest/coverage-v8 to root package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@changesets/cli": "^2.30.0",
         "@storybook/react": "^8.6",
         "@storybook/react-vite": "^8.6",
+        "@vitest/coverage-v8": "^4.1.5",
         "storybook": "^8.6",
         "turbo": "^2.5.4",
         "vitest": "^4.1.4"
@@ -10294,6 +10295,44 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -22289,35 +22328,6 @@
         }
       }
     },
-    "web/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "web/node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -22345,13 +22355,6 @@
     },
     "web/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "web/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@storybook/react": "^8.6",
     "@storybook/react-vite": "^8.6",
     "storybook": "^8.6",
+    "@vitest/coverage-v8": "^4.1.5",
     "turbo": "^2.5.4",
     "vitest": "^4.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "@changesets/cli": "^2.30.0",
     "@storybook/react": "^8.6",
     "@storybook/react-vite": "^8.6",
-    "storybook": "^8.6",
     "@vitest/coverage-v8": "^4.1.5",
+    "storybook": "^8.6",
     "turbo": "^2.5.4",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Summary

- Added `@vitest/coverage-v8: ^4.1.5` to root `package.json` devDependencies so the monorepo-root `vitest` binary can find it via standard module resolution.

## Root cause

PR #8534 (closes #8533) described hoisting `@vitest/coverage-v8` to root but only updated `package-lock.json`. Without a matching entry in root `package.json`, any subsequent `npm install` / `npm ci` drops the entry — npm only hoists packages that are explicitly declared somewhere. The lock-file-only approach was not durable.

The result: every `npx vitest run --coverage` invocation from the workspace root silently failed with `ERR_MODULE_NOT_FOUND: Cannot find package '@vitest/coverage-v8'`. The CI quality-gates step swallows this with `set +e`, so coverage thresholds have been silently unenforced since #8534 merged.

## Coverage (confirmed passing after fix)

| Metric | Actual | Threshold |
|---|---|---|
| Statements | 79.99% | 75% |
| Branches | 69.82% | 65% |
| Functions | 74.81% | 70% |
| Lines | 81.39% | 77% |

## Test plan

- [x] `npx vitest run --coverage` runs successfully from repo root after fix
- [x] Coverage thresholds all pass with comfortable margin
- [x] ESLint zero warnings
- [x] TypeScript clean

https://claude.ai/code/session_01BUbKBie1swzbcr9PWU8B8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUbKBie1swzbcr9PWU8B8i)_