### PR TITLE
chore: hoist @vitest/coverage-v8 to workspace root (nightly quality gate)

### DIFF
--- a/.changeset/vitest-coverage-v8-workspace-hoist.md
+++ b/.changeset/vitest-coverage-v8-workspace-hoist.md
@@ -1,0 +1,5 @@
+---
+"spawnforge": patch
+---
+
+Hoist `@vitest/coverage-v8` to workspace root so the root `vitest` binary can resolve it during `--coverage` runs, fixing the nightly quality gate `ERR_MODULE_NOT_FOUND` failure (see #8533).

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@changesets/cli": "^2.30.0",
         "@storybook/react": "^8.6",
         "@storybook/react-vite": "^8.6",
+        "@vitest/coverage-v8": "^4.1.5",
         "storybook": "^8.6",
         "turbo": "^2.5.4",
         "vitest": "^4.1.4"
@@ -10294,6 +10295,44 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -22289,35 +22328,6 @@
         }
       }
     },
-    "web/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "web/node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -22345,13 +22355,6 @@
     },
     "web/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "web/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@changesets/cli": "^2.30.0",
     "@storybook/react": "^8.6",
     "@storybook/react-vite": "^8.6",
+    "@vitest/coverage-v8": "^4.1.5",
     "storybook": "^8.6",
     "turbo": "^2.5.4",
     "vitest": "^4.1.4"


### PR DESCRIPTION
## Summary
- Hoisted `@vitest/coverage-v8` from `web/node_modules` to the workspace root `node_modules`
- Root vitest binary (`/node_modules/.bin/vitest`) resolves coverage provider from its own location; the package being only in `web/node_modules` made it unreachable, causing all `--coverage` runs to fail with `ERR_MODULE_NOT_FOUND`
- Coverage now runs cleanly: **statements 80.0% / branches 69.8% / functions 74.8% / lines 81.4%** — all above thresholds (75/65/70/77)

Closes #8533

## Test plan
- [x] `npx eslint --max-warnings 0 .` — 0 warnings
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 756 passed, 1 skipped, 0 failures (15,385 tests)
- [x] `npx vitest run --coverage` — all thresholds pass

https://claude.ai/code/session_01WyxMqrayU3xwqZ9tpiiSQy

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyxMqrayU3xwqZ9tpiiSQy)_