### PR TITLE
chore: add coverage/ to root gitignore and hoist @vitest/coverage-v8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ web/out/
 web/test-results/
 web/playwright-report/
 
+# ----- Coverage -----
+coverage/
+
 # ----- Packages -----
 packages/ui/dist/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10295,6 +10295,44 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -22289,35 +22327,6 @@
         }
       }
     },
-    "web/node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "web/node_modules/ajv": {
       "version": "6.15.0",
       "dev": true,
@@ -22345,13 +22354,6 @@
     },
     "web/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "web/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     }


### PR DESCRIPTION
## Summary

- Adds `coverage/` to root `.gitignore` — the nightly quality gate runs `vitest --coverage` from the workspace root, which writes a `coverage/` directory at repo root that wasn't covered by the existing `web/.gitignore` entry
- Hoists `@vitest/coverage-v8` from `web/node_modules` to root `node_modules` via workspace install so vitest can resolve it when invoked from the workspace root (ESM package resolution doesn't traverse up past the package boundary)

Closes #8567

## Test plan

- [x] `npx eslint --max-warnings 0 .` — clean (0 warnings)
- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] Full vitest suite — 15,385 tests passed, 0 failed (two independent runs)
- [x] Coverage thresholds all met: statements 80% > 75%, branches 69.82% > 65%, functions 74.83% > 70%, lines 81.4% > 77%

https://claude.ai/code/session_01TawEQmLVwaTyJ17yYUc7pw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TawEQmLVwaTyJ17yYUc7pw)_