### PR TITLE
feat: pre-launch /sign-up notice + relabel early-access CTAs

### DIFF
--- a/.changeset/signups-in-development-notice.md
+++ b/.changeset/signups-in-development-notice.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Replace the restricted Clerk `<SignUp>` form at `/sign-up` with a clear "SpawnForge is in development" notice and relabel the marketing/pricing CTAs ("Request Early Access" / "Join the Waitlist"). Sign-in is unaffected — approved users still authenticate at `/sign-in`.

--- a/web/src/app/(marketing)/__tests__/page.test.tsx
+++ b/web/src/app/(marketing)/__tests__/page.test.tsx
@@ -79,7 +79,7 @@ describe('LandingPage', () => {
   });
 
   it('renders the primary CTA button linking to sign-up', () => {
-    const ctas = screen.getAllByText('Start Creating Free');
+    const ctas = screen.getAllByText('Request Early Access');
     // At least the hero CTA should link to /sign-up
     const heroLink = ctas[0].closest('a');
     expect(heroLink).not.toBeNull();

--- a/web/src/app/(marketing)/page.tsx
+++ b/web/src/app/(marketing)/page.tsx
@@ -193,7 +193,7 @@ const pricingTiers: PricingTier[] = [
       'Community templates',
       'Basic export',
     ],
-    cta: 'Start Free',
+    cta: 'Join the Waitlist',
     highlighted: false,
   },
   {
@@ -208,7 +208,7 @@ const pricingTiers: PricingTier[] = [
       'Asset generation',
       'Priority support',
     ],
-    cta: 'Get Started',
+    cta: 'Join the Waitlist',
     highlighted: false,
   },
   {
@@ -223,7 +223,7 @@ const pricingTiers: PricingTier[] = [
       'Advanced AI tools',
       'Remove branding',
     ],
-    cta: 'Start Creating',
+    cta: 'Join the Waitlist',
     highlighted: true,
   },
   {
@@ -238,7 +238,7 @@ const pricingTiers: PricingTier[] = [
       'Dedicated support',
       'Custom integrations',
     ],
-    cta: 'Contact Us',
+    cta: 'Join the Waitlist',
     highlighted: false,
   },
 ];
@@ -311,7 +311,7 @@ export default async function LandingPage() {
               href="/sign-up"
               className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-500"
             >
-              Start Creating Free
+              Request Early Access
             </Link>
           </div>
         </div>
@@ -342,7 +342,7 @@ export default async function LandingPage() {
               href="/sign-up"
               className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-500"
             >
-              Start Creating Free
+              Request Early Access
               <ArrowRight className="h-4 w-4" aria-hidden="true" />
             </Link>
             <a
@@ -665,7 +665,7 @@ export default async function LandingPage() {
             href="/sign-up"
             className="mt-8 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-8 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-500"
           >
-            Start Creating Free
+            Request Early Access
             <ArrowRight className="h-4 w-4" aria-hidden="true" />
           </Link>
         </div>

--- a/web/src/app/(marketing)/page.tsx
+++ b/web/src/app/(marketing)/page.tsx
@@ -186,7 +186,7 @@ const pricingTiers: PricingTier[] = [
     name: 'Starter',
     price: '$0',
     period: '/month',
-    description: 'Free forever. Start building immediately.',
+    description: 'Free forever. Reserve your spot for launch.',
     features: [
       'AI chat (limited)',
       '1 published game',

--- a/web/src/app/compare/[competitor]/page.tsx
+++ b/web/src/app/compare/[competitor]/page.tsx
@@ -211,7 +211,7 @@ export default async function CompetitorComparePage({ params }: ComparePageProps
             href="/sign-up"
             className="inline-flex rounded-lg bg-orange-500 px-6 py-3 font-medium text-white transition-colors hover:bg-orange-600"
           >
-            Get Started Free
+            Request Early Access
           </Link>
         </div>
       </div>

--- a/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -1,11 +1,44 @@
-'use client';
+import Link from 'next/link';
 
-import { SignUp } from '@clerk/nextjs';
-
+/**
+ * Pre-launch sign-up notice.
+ *
+ * Sign-ups are intentionally disabled while SpawnForge is in development.
+ * Rather than render Clerk's <SignUp> in restricted mode — which shows a
+ * support-contact error that reads as "action required" and drives a flood
+ * of support emails — we show a clear "coming soon" notice with a single,
+ * optional way to register interest. Sign-in is unaffected; approved users
+ * still authenticate normally at /sign-in.
+ */
 export function SignUpClient() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-950">
-      <SignUp fallbackRedirectUrl="/" />
-    </div>
+    <main className="flex min-h-screen items-center justify-center bg-zinc-950 px-6">
+      <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
+        <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-zinc-700 bg-zinc-900 px-4 py-1.5 text-sm text-zinc-300">
+          SpawnForge
+        </div>
+        <h1 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
+          SpawnForge is in development
+        </h1>
+        <p className="mt-4 text-base leading-relaxed text-zinc-400">
+          Release details and timeline will be published soon.
+        </p>
+        <p className="mt-6 text-sm text-zinc-400">
+          Interested in being an early user?{' '}
+          <a
+            href="mailto:support@spawnforge.ai"
+            className="font-medium text-blue-400 underline-offset-4 transition-colors hover:text-blue-300 hover:underline"
+          >
+            support@spawnforge.ai
+          </a>
+        </p>
+        <Link
+          href="/"
+          className="mt-8 inline-flex items-center justify-center rounded-lg border border-zinc-700 px-5 py-2.5 text-sm font-semibold text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+        >
+          Back to home
+        </Link>
+      </div>
+    </main>
   );
 }

--- a/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for the pre-launch sign-up notice.
+ *
+ * Sign-ups are intentionally disabled while SpawnForge is in development.
+ * The /sign-up route renders an informational notice instead of Clerk's
+ * <SignUp> form, so that prospective users get a clear "coming soon"
+ * message rather than a restricted-mode error that reads like a support
+ * request. See feat/signups-in-development-notice.
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@/test/utils/componentTestUtils';
+import { SignUpClient } from '../SignUpClient';
+
+describe('SignUpClient (in-development notice)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the in-development heading', () => {
+    render(<SignUpClient />);
+    expect(
+      screen.getByRole('heading', { name: /in development/i })
+    ).toBeDefined();
+  });
+
+  it('explains that release details will be published soon', () => {
+    render(<SignUpClient />);
+    expect(
+      screen.getByText(/release details and timeline will be published soon/i)
+    ).toBeDefined();
+  });
+
+  it('offers a mailto link to support for early-user interest', () => {
+    render(<SignUpClient />);
+    const mailto = screen
+      .getAllByRole('link')
+      .find((a) => a.getAttribute('href') === 'mailto:support@spawnforge.ai');
+    expect(mailto).toBeDefined();
+  });
+
+  it('links back to the home page', () => {
+    render(<SignUpClient />);
+    const home = screen
+      .getAllByRole('link')
+      .find((a) => a.getAttribute('href') === '/');
+    expect(home).toBeDefined();
+  });
+
+  it('does not render a Clerk sign-up form', () => {
+    render(<SignUpClient />);
+    // The Clerk widget renders form fields (email/password). The notice has none.
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+});

--- a/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,12 +1,10 @@
 import type { Metadata } from 'next';
 import { SignUpClient } from './SignUpClient';
 
-// Force dynamic rendering — Clerk's <SignUp> calls useSession() during SSR,
-// which requires ClerkProvider context from a real request.
-export const dynamic = 'force-dynamic';
-
 export const metadata: Metadata = {
-  title: 'Sign Up — SpawnForge',
+  title: 'Early Access — SpawnForge',
+  description:
+    'SpawnForge is currently in development. Release details and timeline will be published soon.',
 };
 
 export default function SignUpPage() {

--- a/web/src/app/use-cases/[slug]/page.tsx
+++ b/web/src/app/use-cases/[slug]/page.tsx
@@ -262,7 +262,7 @@ export default async function UseCasePage({ params }: UseCasePageProps) {
             href="/sign-up"
             className="inline-flex rounded-lg bg-orange-500 px-6 py-3 font-medium text-white transition-colors hover:bg-orange-600"
           >
-            Get Started Free
+            Request Early Access
           </Link>
         </div>
       </div>

--- a/web/src/components/pricing/PricingPage.tsx
+++ b/web/src/components/pricing/PricingPage.tsx
@@ -95,7 +95,7 @@ export function PricingPage() {
               onClick={handleGetStarted}
               className="mb-6 w-full rounded bg-zinc-800 py-2 text-sm font-medium hover:bg-zinc-700"
             >
-              Get Started
+              {isSignedIn ? 'Get Started' : 'Join the Waitlist'}
             </button>
             <ul className="space-y-3 text-sm">
               <li className="flex items-start gap-2">

--- a/web/src/components/pricing/__tests__/PricingPage.test.tsx
+++ b/web/src/components/pricing/__tests__/PricingPage.test.tsx
@@ -66,9 +66,11 @@ describe('PricingPage', () => {
     expect(screen.getByText('Studio')).toBeDefined();
   });
 
-  it('renders Get Started button for Free tier', () => {
+  it('renders the Free tier CTA as a waitlist prompt when not signed in', () => {
     render(<PricingPage />);
-    expect(screen.getByText('Get Started')).toBeDefined();
+    // Sign-ups are disabled pre-launch, so the logged-out Free-tier CTA invites
+    // joining the waitlist rather than starting immediately.
+    expect(screen.getByText('Join the Waitlist')).toBeDefined();
   });
 
   it('renders Sign In button when not signed in', () => {


### PR DESCRIPTION
## Summary

Sign-ups are intentionally disabled pre-launch. Clerk's embedded `<SignUp>` rendered in restricted mode, surfacing a "contact support" error that read as *action required* — driving dozens of inbound support emails from interested users.

This replaces that form with a clear, branded notice and relabels the CTAs that route to `/sign-up` so they set the right expectation.

- **`/sign-up`** now renders a static "SpawnForge is in development" notice (no Clerk form, no error), with a `mailto:support@spawnforge.ai` link so genuine early-adopter interest still has a channel. Removed `'use client'`/`force-dynamic` since the page no longer uses hooks or Clerk.
- **CTA relabels:** landing nav/hero/footer + compare + use-cases "Start Creating Free" / "Get Started Free" → **"Request Early Access"**; Free-tier pricing CTA → **"Join the Waitlist"** when signed out (signed-in users still see "Get Started").
- **Sign-in is untouched** — approved users authenticate normally at `/sign-in`.

## Why mailto stays

Reframing the page from "error" to "coming soon" should cut the email volume on its own. The remaining trickle is genuine early-adopter signal worth keeping.

Closes #8581

## Test plan

- [x] `eslint --max-warnings 0` clean on all changed files
- [x] `vitest` — new `SignUpClient.test.tsx` (5) + marketing page + pricing tests, **35 passing**
- [x] No `tsc` errors introduced by this diff
- [ ] Manual: `/sign-up` shows notice, mailto works, `/sign-in` still renders Clerk

## Note on CI

The shared `tsc` / contract-test gate is currently red on `main` due to the ajv 6→8 bump (#8554) breaking `contracts.test.ts` — tracked separately in **#8578**, unrelated to this diff. This PR touches none of those files.