### PR TITLE
fix: migrate contracts.test.ts to ajv v8 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22130,7 +22130,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^4.1.5",
-        "ajv": "^6.14.0",
+        "ajv": "^8.20.0",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",
         "eslint-config-next": "^16.2.3",
@@ -22272,21 +22272,6 @@
         }
       }
     },
-    "web/node_modules/ajv": {
-      "version": "6.15.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "web/node_modules/dockview": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/dockview/-/dockview-6.0.5.tgz",
@@ -22323,11 +22308,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "web/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "web/node_modules/portless": {
       "version": "0.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22131,6 +22131,7 @@
         "@types/react-dom": "^19",
         "@vitest/coverage-v8": "^4.1.5",
         "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "drizzle-kit": "^0.31.10",
         "eslint": "^9",
         "eslint-config-next": "^16.2.3",

--- a/web/package.json
+++ b/web/package.json
@@ -103,6 +103,7 @@
     "@types/react-dom": "^19",
     "@vitest/coverage-v8": "^4.1.5",
     "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "drizzle-kit": "^0.31.10",
     "eslint": "^9",
     "eslint-config-next": "^16.2.3",

--- a/web/src/app/api/__tests__/contracts.test.ts
+++ b/web/src/app/api/__tests__/contracts.test.ts
@@ -14,6 +14,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 
 // ---------------------------------------------------------------------------
 // Global mocks (hoisted before any dynamic import)
@@ -359,10 +361,42 @@ describe('POST /api/chat — invalid body contract', () => {
 // Part 2: OpenAPI spec schema validation with Ajv
 // ===========================================================================
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const Ajv = require('ajv') as typeof import('ajv');
 import { readFileSync } from 'fs';
 import path from 'path';
+
+/**
+ * Convert OpenAPI 3.0 schemas to JSON Schema that Ajv v8 understands.
+ *
+ * OpenAPI uses `nullable: true` to permit null, but that keyword does not
+ * exist in JSON Schema — Ajv v8 (unlike the v6 we used before) has no
+ * `nullable` option. We rewrite `{ type: 'X', nullable: true }` into the
+ * equivalent `{ type: ['X', 'null'] }` and drop the `nullable` key so the
+ * spec's nullable fields (e.g. TokenBalance.nextRefillDate) still validate
+ * against null. The walk is generic, so it also covers nested properties,
+ * array items, and composed schemas.
+ */
+function openApiToJsonSchema(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(openApiToJsonSchema);
+  if (node === null || typeof node !== 'object') return node;
+
+  const src = node as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(src)) {
+    if (key === 'nullable') continue;
+    out[key] = openApiToJsonSchema(value);
+  }
+
+  if (src.nullable === true && 'type' in out) {
+    const type = out.type;
+    if (typeof type === 'string') {
+      out.type = [type, 'null'];
+    } else if (Array.isArray(type) && !type.includes('null')) {
+      out.type = [...type, 'null'];
+    }
+  }
+
+  return out;
+}
 
 /**
  * Load the OpenAPI spec and compile its component schemas into Ajv validators.
@@ -378,15 +412,17 @@ function loadOpenApiSchemas() {
     paths?: Record<string, Record<string, Record<string, unknown>>>;
   };
 
-  // Ajv v6 from webpack transitive dep — unknownFormats ignores OpenAPI
-  // format keywords like "float", "uuid", "date-time" that Ajv doesn't
-  // validate by default.
-  const ajv = new Ajv({ allErrors: true, unknownFormats: 'ignore', nullable: true }) as InstanceType<typeof import('ajv')>;
+  // Ajv v8: `strict: false` tolerates OpenAPI-isms (e.g. `example`) that
+  // aren't valid JSON Schema, and ajv-formats registers the format keywords
+  // ("date-time", "uuid", etc.) so they validate instead of throwing.
+  // Nullable is handled by the openApiToJsonSchema() transform below.
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
 
   const schemas = spec.components?.schemas ?? {};
   const validators: Record<string, ReturnType<typeof ajv.compile>> = {};
   for (const [name, schema] of Object.entries(schemas)) {
-    validators[name] = ajv.compile(schema);
+    validators[name] = ajv.compile(openApiToJsonSchema(schema) as object);
   }
 
   return { spec, ajv, validators };


### PR DESCRIPTION
## Summary

The ajv 6→8 dependabot bump (#8554) broke `web/src/app/api/__tests__/contracts.test.ts` at **both** type-check and runtime, turning the shared `tsc` + `vitest` gate red on `main` for **every** branch:

- ajv v8 removed the `unknownFormats` and `nullable` constructor options the test used.
- ajv v8's CommonJS export is no longer directly constructable via `require('ajv')` → `TS2351: This expression is not constructable`.
- At runtime: `Error: unknown format "uuid" ignored in schema`.

This migrates the test to the ajv v8 API without weakening any assertion:

- Default import `import Ajv from 'ajv'` (constructable under `esModuleInterop`) instead of `require()`.
- `ajv-formats` (already a dependency, 3.0.1) registers the OpenAPI format keywords (`date-time`, `uuid`, …) so they validate instead of throwing; `strict: false` tolerates OpenAPI-isms like `example`/`nullable` that aren't strict JSON Schema.
- An `openApiToJsonSchema()` transform replaces the dropped `nullable: true` option by rewriting `{ type: 'X', nullable: true }` → `{ type: ['X', 'null'] }` recursively. This preserves the spec's 14 nullable fields — notably `TokenBalance.nextRefillDate` and `GenerationStatus.resultUrl` validating against `null` (test lines 477-486).

## Why this is first in the queue

This is the root cause of the red gate blocking all open PRs. Merging it should turn `main` (and rebased PRs) green on type-check + unit tests.

Closes #8578

## Test plan

- [x] `vitest run contracts.test.ts` — **38/38 passing** (was 0, suite failed to load)
- [x] `eslint --max-warnings 0` clean
- [x] `tsc --noEmit` — no error for this file (the only local tsc error is a `stripe-client.ts` node_modules drift to 22.2.0; CI's `npm ci` uses the lockfile-pinned 22.1.0 where the literal is correct — not introduced here)
- [x] No assertions weakened — null/format/enum/wrong-field cases all still enforced

## Note

Test-only change, no runtime/user-facing impact → `skip changeset`.