### PR TITLE
fix(ci): two ci.yml reliability fixes — preview-reachability false positive + stale Playwright cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,13 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('web/package-lock.json') }}
+          # Key on the REAL root lockfile. This is a single-root-lockfile
+          # monorepo: web/package-lock.json does not exist, so the old key
+          # hashFiles('web/package-lock.json') returned '' — a constant
+          # `playwright-` key that never invalidated, leaving stale browser
+          # caches that intermittently failed with "Executable doesn't exist"
+          # when Playwright's required browser revision changed. (#8589)
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,27 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         run: |
-          curl -sf "$PREVIEW_URL" -o /dev/null --retry 3 --retry-delay 5 || echo "::warning::Preview URL not reachable"
+          # Preview deployments sit behind Vercel Deployment Protection (#7994):
+          # an unauthenticated request is answered by the SSO gate with HTTP 401
+          # (server: Vercel, _vercel_sso_nonce cookie). That 401 PROVES the
+          # deployment is live and serving — it is not an outage. A plain
+          # `curl -sf` fails on any 4xx (exit 56), so it emitted false
+          # "Preview URL not reachable" warnings on every protected preview.
+          # Inspect the status code instead: only a missing response (000) or a
+          # 5xx means the preview is genuinely unreachable.
+          code=$(curl -s -o /dev/null -w "%{http_code}" --retry 3 --retry-delay 5 --max-time 30 "$PREVIEW_URL" || true)
+          echo "Preview responded with HTTP $code"
+          case "$code" in
+            000|5??)
+              echo "::warning::Preview URL not reachable (HTTP $code)"
+              ;;
+            401|403)
+              echo "Preview is reachable — HTTP $code is the expected Vercel Deployment Protection (SSO) gate."
+              ;;
+            *)
+              echo "Preview is reachable (HTTP $code)."
+              ;;
+          esac
 
   # Engine-dependent E2E tests (@engine) require WASM + GPU which CI runners lack.
   # Only UI-only E2E tests (@ui) run in CI — they test React shell without WASM.


### PR DESCRIPTION
## Summary
The `Verify preview is reachable` step in `ci.yml` used `curl -sf`, which fails on any HTTP 4xx (exit 56). Preview deployments sit behind **Vercel Deployment Protection** (SSO, enabled in #7994), so an unauthenticated request is answered by the SSO gate with **HTTP 401** — and the step emitted a misleading `Preview URL not reachable` warning on **every** protected preview, even though the deployment was live and serving. This caused user concern on the #8580 preview.

## Validation (empirical)
```
$ curl -s -o /dev/null -w '%{http_code}' https://spawnforge-staging-…-tnolan.vercel.app
401
# HTTP/2 401 · server: Vercel · set-cookie: _vercel_sso_nonce=…
```
A 401 from the SSO gate **proves** reachability — not an outage.

## Fix
Inspect the HTTP status code instead of relying on `curl -f`:
- `000` (no response) or `5xx` → genuine outage → warning
- `401`/`403` → expected Vercel Deployment Protection gate → reachable
- everything else (`2xx`/`3xx`/other) → reachable

The unprotected `localhost` reachability checks in `quality-gates.yml` hit non-protected servers and are unaffected (left as-is).

Closes #8587

## Test plan
- [x] `ci.yml` parses as valid YAML
- [x] `shellcheck` clean on the new run block
- [x] Status-code logic unit-tested: 000/500/503 → warning; 401/403 → reachable (SSO gate); 200/301/404 → reachable
- [ ] Next preview deploy in CI logs "Preview is reachable — HTTP 401 …" instead of the false warning

---
## Second fix: Playwright browser cache never invalidates (Closes #8589)
`ci.yml` keyed the Playwright browser cache on `hashFiles('web/package-lock.json')`, but this is a single-root-lockfile monorepo — `web/package-lock.json` does not exist, so `hashFiles` returned `''` and the key was a constant `playwright-` that **never invalidated**. Stale browser caches then intermittently failed E2E shards with `Executable doesn't exist at .../chromium_headless_shell-1223/...` (observed on run 26659163519: shard 1/3 passed, 2/3 & 3/3 failed). This is the actual cause of the flaky E2E UI failures seen on #8585.

Fixed by keying on the real root `package-lock.json` (+ `runner.os`), so the cache invalidates whenever dependencies — including Playwright — change.

Both changes are in the same workflow file and both fix misleading/flaky CI signals; bundled as one CI-reliability PR.

Closes #8587
Closes #8589