### PR TITLE
fix(deps): sync package-lock.json drift that broke npm ci (Vercel preview)

### DIFF
--- a/.changeset/fix-lockfile-sync-anthropic-portless.md
+++ b/.changeset/fix-lockfile-sync-anthropic-portless.md
@@ -1,0 +1,10 @@
+---
+"web": patch
+---
+
+fix(deps): resolve `package-lock.json` drift that broke `npm ci` (used by the Vercel preview-deploy job) repo-wide with EUSAGE.
+
+- `@anthropic-ai/sdk`: lockfile still resolved `0.93.0` while `web/package.json` declared `^0.100.1` — synced the lockfile to `0.100.1` (no `engines` constraint; no runtime code imports it directly, the Anthropic path goes through `@ai-sdk/anthropic`).
+- `portless`: a Dependabot bump set `web/package.json` to `^0.13.1`, but `portless@0.13.1` requires Node `>=24` while this repo targets Node 20 (`.nvmrc`, `engines ">=20 <25"`, all CI `node-version: 20`). The lockfile had never moved off the Node-20-compatible `0.12.0`. Reverted the declaration to `^0.12.0` to match, and added a `dependabot.yml` ignore for `portless >=0.13.1` so it can still advance to `0.13.0` (Node `>=20`) but won't re-grab the Node-24-only line until the repo adopts Node 24.
+
+No source change.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # portless >=0.13.1 requires Node >=24; this repo targets Node 20
+      # (.nvmrc, engines ">=20 <25", all CI node-version: 20). Allow 0.13.0
+      # (engines ">=20") but block the Node-24-only line until we adopt Node 24.
+      - dependency-name: "portless"
+        versions: [">=0.13.1"]
 
   # npm dependencies (mcp-server)
   - package-ecosystem: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,6 +270,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
@@ -20470,6 +20491,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -21867,7 +21889,7 @@
         "@ai-sdk/anthropic": "^3.0.69",
         "@ai-sdk/gateway": "^3.0.95",
         "@ai-sdk/react": "^3.0.158",
-        "@anthropic-ai/sdk": "^0.93.0",
+        "@anthropic-ai/sdk": "^0.100.1",
         "@aws-sdk/client-s3": "^3.1004.0",
         "@aws-sdk/s3-request-presigner": "^3.1014.0",
         "@clerk/nextjs": "^7.4.2",
@@ -21980,26 +22002,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "web/node_modules/@anthropic-ai/sdk": {
-      "version": "0.93.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
-      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
       }
     },
     "web/node_modules/@vercel/analytics": {

--- a/web/package.json
+++ b/web/package.json
@@ -108,7 +108,7 @@
     "eslint": "^9",
     "eslint-config-next": "^16.2.3",
     "jsdom": "^29.0.1",
-    "portless": "^0.13.1",
+    "portless": "^0.12.0",
     "tailwindcss": "^4",
     "typescript": "^6",
     "vitest": "^4.1.7"


### PR DESCRIPTION
## Summary

Resolves pre-existing `package-lock.json` drift on `main` that broke `npm ci` repo-wide with `EUSAGE`. `npm ci` is a frozen install — it aborts when `package.json` disagrees with the lockfile. The **Vercel preview-deploy job** runs `cd .. && npm ci && npm run build --workspace=packages/ui`, so the drift surfaced there as a failed preview deployment. (CI's production build uses a non-frozen install, which tolerated the drift — so this was invisible until the preview job ran.)

Two declared-vs-locked mismatches:

- **`@anthropic-ai/sdk`** — `web/package.json` declared `^0.100.1` but the lockfile still resolved `0.93.0`. Synced the lockfile to `0.100.1`. The package has no `engines` constraint and **no runtime code in `web/src` imports it directly** (the Anthropic path goes through `@ai-sdk/anthropic`), so the bump carries effectively zero regression risk — only test-file `vi.mock` stubs reference it.
- **`portless`** — a Dependabot bump (#8571) set `web/package.json` to `^0.13.1`, but **`portless@0.13.1` requires Node `>=24`** while this repo targets Node 20 (`.nvmrc`, `engines ">=20 <25"`, all CI `node-version: 20`). The lockfile had correctly never moved off the Node-20-compatible `0.12.0`. Reverted the declaration to `^0.12.0` to match the lockfile (the manifest was the side that was wrong), rather than dragging a Node-24-only version into the lockfile.

Also added a `dependabot.yml` `ignore` for `portless >=0.13.1` so Dependabot can still advance it to `0.13.0` (which declares Node `>=20`) but won't re-grab the Node-24-only line until the repo adopts Node 24 — preventing a recurrence.

No source change. `portless` is a devDependency used only by the `dev` script; it is not in the build/test/e2e paths.

## Validation (Node 20.20.2, npm 10.8.2 — matches CI)

- `npm ci` → clean (1330 packages, **0 vulnerabilities**, no `EUSAGE`)
- `tsc --noEmit` → exit 0
- SDK-touching tests → 54/54 pass
- `dependabot.yml` → valid YAML; changeset valid

Closes #8654 (PF-836)

## Test plan

- [ ] Vercel preview deployment succeeds (the regression this fixes)
- [ ] CI green