### PR TITLE
fix(tokens): make token refunds idempotent under concurrency (#8662)

### DIFF
--- a/.changeset/fix-refund-tokens-idempotency-concurrency.md
+++ b/.changeset/fix-refund-tokens-idempotency-concurrency.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Make token refunds idempotent under concurrency. `refundTokens` and `refundTokenAmount` guarded their refund INSERT with `WHERE NOT EXISTS`, a READ COMMITTED snapshot check rather than a lock, so two concurrent refunds for the same usage could both credit the user. The refund INSERTs now use a UNIQUE partial index plus `ON CONFLICT DO NOTHING`, so the credit fires exactly once even under concurrent retries.

--- a/web/drizzle/0004_token_usage_refund_idempotent_index.sql
+++ b/web/drizzle/0004_token_usage_refund_idempotent_index.sql
@@ -1,4 +1,4 @@
--- Idempotency for token refunds under concurrency (#8662, PF-838).
+-- Idempotency for token refunds under concurrency (#8662, PF-838) — STEP 1 of 2.
 -- refundTokens / refundTokenAmount previously guarded their refund INSERT with
 -- WHERE NOT EXISTS. Under READ COMMITTED that is a snapshot check, NOT a lock:
 -- two concurrent refunds for the same usageId can each miss the other's
@@ -7,19 +7,23 @@
 -- so the database serialises the second insert to a no-op and the credit fires
 -- exactly once.
 --
+-- This migration (0004) removes pre-existing duplicate refund rows so the UNIQUE
+-- index can be built. The index itself is created in 0005 with CONCURRENTLY, which
+-- Postgres forbids inside a transaction — hence the two-file split: 0004 is the
+-- transactional dedup, 0005 is the non-transactional index build. Run 0004 before
+-- 0005.
+--
 -- The index is keyed per-operation: a 'refund' and a 'partial_refund' for the
 -- same usageId remain independently idempotent (preserving the prior NOT EXISTS
 -- semantics, which scoped on operation). The partial predicate keeps the index to
 -- the small refund subset of token_usage and excludes the NULL refundedUsageId
 -- rows of no-usageId partial refunds, which are intentionally non-idempotent.
 --
--- Step 1: remove pre-existing duplicate refund rows so the UNIQUE index can be
--- built. A duplicate (user_id, operation, refundedUsageId) row is the audit
--- footprint of the very race being fixed. We keep the earliest row per key (min
--- created_at, then min id) and delete the rest. NOTE: this normalises the refund
--- *records* only — it does NOT reverse any tokens that were over-credited before
--- this migration. Balance reconciliation for affected users is tracked separately
--- (see PR body).
+-- A duplicate (user_id, operation, refundedUsageId) row is the audit footprint of
+-- the very race being fixed. We keep the earliest row per key (min created_at, then
+-- min id) and delete the rest. NOTE: this normalises the refund *records* only — it
+-- does NOT reverse any tokens that were over-credited before this migration. Balance
+-- reconciliation for affected users is tracked separately (see PR body).
 DELETE FROM "token_usage" a
 USING "token_usage" b
 WHERE a."operation" IN ('refund', 'partial_refund')
@@ -33,12 +37,3 @@ WHERE a."operation" IN ('refund', 'partial_refund')
     a."created_at" > b."created_at"
     OR (a."created_at" = b."created_at" AND a."id" > b."id")
   );
---> statement-breakpoint
--- Step 2: enforce one refund row per (user_id, operation, refundedUsageId). The
--- partial predicate restricts the index to refund/partial_refund rows, so this is
--- a small index over a low-volume subset — a plain (non-CONCURRENTLY) index is
--- fine and, unlike CONCURRENTLY, is safe to run inside the migration transaction
--- alongside the Step 1 dedup.
-CREATE UNIQUE INDEX IF NOT EXISTS "uq_token_usage_refund_idempotent"
-  ON "token_usage" ("user_id", "operation", ((metadata->>'refundedUsageId')))
-  WHERE "operation" IN ('refund', 'partial_refund');

--- a/web/drizzle/0004_token_usage_refund_idempotent_index.sql
+++ b/web/drizzle/0004_token_usage_refund_idempotent_index.sql
@@ -1,0 +1,44 @@
+-- Idempotency for token refunds under concurrency (#8662, PF-838).
+-- refundTokens / refundTokenAmount previously guarded their refund INSERT with
+-- WHERE NOT EXISTS. Under READ COMMITTED that is a snapshot check, NOT a lock:
+-- two concurrent refunds for the same usageId can each miss the other's
+-- uncommitted INSERT and both credit the user. The fix mirrors creditAddonTokens
+-- (audit F02 / migration 0003): a UNIQUE partial index + ON CONFLICT DO NOTHING,
+-- so the database serialises the second insert to a no-op and the credit fires
+-- exactly once.
+--
+-- The index is keyed per-operation: a 'refund' and a 'partial_refund' for the
+-- same usageId remain independently idempotent (preserving the prior NOT EXISTS
+-- semantics, which scoped on operation). The partial predicate keeps the index to
+-- the small refund subset of token_usage and excludes the NULL refundedUsageId
+-- rows of no-usageId partial refunds, which are intentionally non-idempotent.
+--
+-- Step 1: remove pre-existing duplicate refund rows so the UNIQUE index can be
+-- built. A duplicate (user_id, operation, refundedUsageId) row is the audit
+-- footprint of the very race being fixed. We keep the earliest row per key (min
+-- created_at, then min id) and delete the rest. NOTE: this normalises the refund
+-- *records* only — it does NOT reverse any tokens that were over-credited before
+-- this migration. Balance reconciliation for affected users is tracked separately
+-- (see PR body).
+DELETE FROM "token_usage" a
+USING "token_usage" b
+WHERE a."operation" IN ('refund', 'partial_refund')
+  AND b."operation" IN ('refund', 'partial_refund')
+  AND a."user_id" = b."user_id"
+  AND a."operation" = b."operation"
+  AND (a."metadata"->>'refundedUsageId') IS NOT NULL
+  AND (b."metadata"->>'refundedUsageId') IS NOT NULL
+  AND (a."metadata"->>'refundedUsageId') = (b."metadata"->>'refundedUsageId')
+  AND (
+    a."created_at" > b."created_at"
+    OR (a."created_at" = b."created_at" AND a."id" > b."id")
+  );
+--> statement-breakpoint
+-- Step 2: enforce one refund row per (user_id, operation, refundedUsageId). The
+-- partial predicate restricts the index to refund/partial_refund rows, so this is
+-- a small index over a low-volume subset — a plain (non-CONCURRENTLY) index is
+-- fine and, unlike CONCURRENTLY, is safe to run inside the migration transaction
+-- alongside the Step 1 dedup.
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_token_usage_refund_idempotent"
+  ON "token_usage" ("user_id", "operation", ((metadata->>'refundedUsageId')))
+  WHERE "operation" IN ('refund', 'partial_refund');

--- a/web/drizzle/0005_token_usage_refund_idempotent_index_concurrent.sql
+++ b/web/drizzle/0005_token_usage_refund_idempotent_index_concurrent.sql
@@ -1,0 +1,20 @@
+-- Idempotency for token refunds under concurrency (#8662, PF-838) — STEP 2 of 2.
+-- Enforce one refund row per (user_id, operation, refundedUsageId) over the
+-- refund/partial_refund subset of token_usage. The matching ON CONFLICT clause in
+-- refundTokens / refundTokenAmount (lib/tokens/service.ts) makes concurrent refunds
+-- for the same usageId credit exactly once.
+--
+-- token_usage is a high-write table (every AI generation appends a row). A plain
+-- CREATE UNIQUE INDEX takes a SHARE lock for the duration of a full table scan,
+-- blocking all writes for the lock window — proportional to TABLE size, not to the
+-- small partial-predicate result. CONCURRENTLY avoids that lock, mirroring
+-- 0002_credit_txn_idempotent_index. The trade-offs of CONCURRENTLY:
+--   - It must NOT run inside a transaction (Postgres requirement). The neon-http
+--     migrator issues each .sql file as stateless HTTP statements (no surrounding
+--     BEGIN/COMMIT), so this runs un-wrapped — same as 0002.
+--   - If duplicate keys still exist it leaves an INVALID index. 0004 dedups first;
+--     run 0004 before this file.
+-- @see https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "uq_token_usage_refund_idempotent"
+  ON "token_usage" ("user_id", "operation", ((metadata->>'refundedUsageId')))
+  WHERE "operation" IN ('refund', 'partial_refund');

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1780185600000,
       "tag": "0003_token_purchases_idempotent_index",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1780272000000,
+      "tag": "0004_token_usage_refund_idempotent_index",
+      "breakpoints": true
     }
   ]
 }

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780272000000,
       "tag": "0004_token_usage_refund_idempotent_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780358400000,
+      "tag": "0005_token_usage_refund_idempotent_index_concurrent",
+      "breakpoints": true
     }
   ]
 }

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -16,7 +16,6 @@ import {
   index,
   pgEnum,
 } from 'drizzle-orm/pg-core';
-import { sql } from 'drizzle-orm';
 import { DEFAULT_API_KEY_SCOPES } from '@/lib/config/scopes';
 
 // --- Enums ---
@@ -122,17 +121,14 @@ export const tokenUsage = pgTable(
   },
   (table) => [
     index('idx_token_usage_user_date').on(table.userId, table.createdAt),
-    // #8662: makes refundTokens / refundTokenAmount idempotent under concurrency.
-    // A UNIQUE partial index over (user_id, operation, refundedUsageId) lets the
-    // refund INSERTs use ON CONFLICT DO NOTHING so two concurrent refunds for the
-    // same usageId credit at most once. Keyed per-operation so a 'refund' and a
-    // 'partial_refund' for one usageId remain independently idempotent (matching
-    // the prior NOT EXISTS guards). Partial predicate keeps the index tiny (refunds
-    // are a small subset of token_usage) and excludes the NULL refundedUsageId rows
-    // of no-usageId partial refunds, which are intentionally non-idempotent.
-    uniqueIndex('uq_token_usage_refund_idempotent')
-      .on(table.userId, table.operation, sql`(${table.metadata}->>'refundedUsageId')`)
-      .where(sql`${table.operation} IN ('refund','partial_refund')`),
+    // NOTE: The real DB constraint is a UNIQUE partial index over
+    // (user_id, operation, (metadata->>'refundedUsageId')) created CONCURRENTLY in
+    // migration 0005_token_usage_refund_idempotent_index_concurrent.sql (enforced
+    // only when operation IN ('refund','partial_refund')). It makes refundTokens /
+    // refundTokenAmount idempotent under concurrency via ON CONFLICT DO NOTHING.
+    // Drizzle can't model WHERE predicates or jsonb-expression columns on an index,
+    // so this schema-only placeholder uses a distinct name to avoid db:push diffs.
+    index('idx_token_usage_refund_idempotent_schema').on(table.userId, table.operation),
   ]
 );
 

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -16,6 +16,7 @@ import {
   index,
   pgEnum,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 import { DEFAULT_API_KEY_SCOPES } from '@/lib/config/scopes';
 
 // --- Enums ---
@@ -119,7 +120,20 @@ export const tokenUsage = pgTable(
     metadata: jsonb('metadata'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [index('idx_token_usage_user_date').on(table.userId, table.createdAt)]
+  (table) => [
+    index('idx_token_usage_user_date').on(table.userId, table.createdAt),
+    // #8662: makes refundTokens / refundTokenAmount idempotent under concurrency.
+    // A UNIQUE partial index over (user_id, operation, refundedUsageId) lets the
+    // refund INSERTs use ON CONFLICT DO NOTHING so two concurrent refunds for the
+    // same usageId credit at most once. Keyed per-operation so a 'refund' and a
+    // 'partial_refund' for one usageId remain independently idempotent (matching
+    // the prior NOT EXISTS guards). Partial predicate keeps the index tiny (refunds
+    // are a small subset of token_usage) and excludes the NULL refundedUsageId rows
+    // of no-usageId partial refunds, which are intentionally non-idempotent.
+    uniqueIndex('uq_token_usage_refund_idempotent')
+      .on(table.userId, table.operation, sql`(${table.metadata}->>'refundedUsageId')`)
+      .where(sql`${table.operation} IN ('refund','partial_refund')`),
+  ]
 );
 
 export const tokenPurchases = pgTable(

--- a/web/src/lib/tokens/__tests__/service.test.ts
+++ b/web/src/lib/tokens/__tests__/service.test.ts
@@ -545,6 +545,11 @@ describe('refundTokens', () => {
     expect(sql).toContain('ON CONFLICT');
     expect(sql).toContain('DO NOTHING');
     expect(sql).not.toContain('NOT EXISTS');
+    // Boundary (architect #8662): this function owns the 'refund' operation namespace,
+    // distinct from refundTokenAmount's 'partial_refund'. And userId is cast ::uuid so
+    // the ON CONFLICT arbiter resolves against the uuid-typed partial unique index.
+    expect(sql).toContain("'refund'");
+    expect(sql).toContain('::uuid');
   });
 
   it('AC1: two refunds for the same usageId credit exactly once (loser hits ON CONFLICT)', async () => {
@@ -704,6 +709,53 @@ describe('refundTokenAmount', () => {
     expect(sql).toContain('ON CONFLICT');
     expect(sql).toContain('DO NOTHING');
     expect(sql).not.toContain('NOT EXISTS');
+  });
+
+  // #8662: token_usage.user_id and users.id are uuid columns, but neon-http binds
+  // ${userId} as text. The idempotent CTE INSERT must cast ${userId}::uuid so its
+  // value matches the uuid-typed partial unique index — otherwise the ON CONFLICT
+  // arbiter inference fails at runtime ("no unique or exclusion constraint matching
+  // the ON CONFLICT specification"). This regression test pins the cast that
+  // refundTokens already carries; without it the security guard silently breaks in
+  // production while mock-based tests stay green.
+  it('idempotent path casts userId to uuid so the ON CONFLICT arbiter resolves', async () => {
+    const { refundTokenAmount } = await import('../service');
+
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([{ source: 'addon', tokens: 50, metadata: null }]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([]); // CTE statement
+
+    await refundTokenAmount('user-1', 50, 'partial failure', 'usage-cast');
+
+    const sql = (mockNeonSql.mock.calls[1][0] as TemplateStringsArray).join(' ');
+    // Both the INSERT value and the UPDATE predicate bind userId as uuid.
+    expect(sql).toContain('::uuid');
+    expect(sql).toContain('ON CONFLICT');
+  });
+
+  // #8662 boundary (architect finding): refundTokens writes operation='refund' and
+  // refundTokenAmount writes operation='partial_refund'. The idempotency key includes
+  // operation, so these two share a usageId but live in DIFFERENT key namespaces and
+  // each credits once. This is intentional (they restore different amounts/pools);
+  // callers must treat them as mutually exclusive per usageId. This test pins the
+  // operation literal so a refactor can't silently collapse the two namespaces (which
+  // would change refund semantics) without a failing test.
+  it('writes a distinct operation namespace (partial_refund) from refundTokens', async () => {
+    const { refundTokenAmount } = await import('../service');
+
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([{ source: 'addon', tokens: 50, metadata: null }]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([]); // CTE statement
+
+    await refundTokenAmount('user-1', 50, 'partial failure', 'usage-boundary');
+
+    const sql = (mockNeonSql.mock.calls[1][0] as TemplateStringsArray).join(' ');
+    // partial_refund is this function's operation; the conflict predicate spans both
+    // refund operations, but the inserted row is keyed to partial_refund specifically.
+    expect(sql).toContain("'partial_refund'");
+    expect(sql).toContain("operation IN ('refund','partial_refund')");
   });
 });
 

--- a/web/src/lib/tokens/__tests__/service.test.ts
+++ b/web/src/lib/tokens/__tests__/service.test.ts
@@ -521,6 +521,57 @@ describe('refundTokens', () => {
 
     await expect(refundTokens('user-1', 'usage-err')).rejects.toThrow('connection reset');
   });
+
+  // #8662: WHERE NOT EXISTS is a READ COMMITTED snapshot check, not a lock — two
+  // concurrent refunds for the same usageId can each miss the other's uncommitted
+  // INSERT and both credit. The fix mirrors creditAddonTokens: a UNIQUE partial
+  // index + ON CONFLICT DO NOTHING so the DB serialises the second insert to a
+  // no-op. The service-level guarantee is that it emits the conflict-based
+  // mechanism (the index, added in drizzle/0004, enforces the actual exactly-once).
+  it('uses ON CONFLICT DO NOTHING (not a snapshot NOT EXISTS) for idempotency', async () => {
+    const { refundTokens } = await import('../service');
+
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([{
+      id: 'usage-cc', userId: 'user-1', tokens: 30, source: 'addon', provider: 'anthropic',
+    }]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([{ id: 'user-1' }]); // CTE RETURNING
+
+    await refundTokens('user-1', 'usage-cc');
+
+    // calls[0] = setClause fragment, calls[1] = main CTE statement
+    const sql = (mockNeonSql.mock.calls[1][0] as TemplateStringsArray).join(' ');
+    expect(sql).toContain('ON CONFLICT');
+    expect(sql).toContain('DO NOTHING');
+    expect(sql).not.toContain('NOT EXISTS');
+  });
+
+  it('AC1: two refunds for the same usageId credit exactly once (loser hits ON CONFLICT)', async () => {
+    const { refundTokens } = await import('../service');
+    const record = {
+      id: 'usage-once', userId: 'user-1', tokens: 25, source: 'addon', provider: 'anthropic',
+    };
+
+    // First refund: INSERT wins → CTE RETURNING a row → credited.
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([record]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([{ id: 'user-1' }]); // CTE inserted + credited
+    const first = await refundTokens('user-1', 'usage-once');
+
+    // Second refund: same usageId. The unique index forces ON CONFLICT → INSERT is
+    // a no-op → EXISTS(ins) false → UPDATE skipped → CTE RETURNING empty.
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([record]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([]); // CTE conflict → no credit
+    const second = await refundTokens('user-1', 'usage-once');
+
+    expect(first.refunded).toBe(true);
+    expect(second.refunded).toBe(false);
+    expect([first, second].filter((r) => r.refunded)).toHaveLength(1);
+  });
 });
 
 describe('refundTokenAmount', () => {
@@ -632,6 +683,27 @@ describe('refundTokenAmount', () => {
     const setClauseCall = mockNeonSql.mock.calls[0];
     const setClauseValues = setClauseCall.slice(1);
     expect(setClauseValues).toContain(40); // full amount to addon
+  });
+
+  // #8662: the partial_refund idempotent path shares the same WHERE NOT EXISTS race
+  // as refundTokens. Its INSERT must also use ON CONFLICT DO NOTHING so concurrent
+  // partial refunds for one usageId credit at most once (backed by the same
+  // drizzle/0004 unique index, which covers operation IN ('refund','partial_refund')).
+  it('idempotent path uses ON CONFLICT DO NOTHING (not a snapshot NOT EXISTS)', async () => {
+    const { refundTokenAmount } = await import('../service');
+
+    mockWhere.mockReturnValueOnce(chainableWhere());
+    mockLimit.mockResolvedValueOnce([{ source: 'addon', tokens: 50, metadata: null }]);
+    mockNeonSqlResults.push([]); // setClause fragment
+    mockNeonSqlResults.push([]); // CTE statement
+
+    await refundTokenAmount('user-1', 50, 'partial failure', 'usage-partial-cc');
+
+    // calls[0] = setClause fragment, calls[1] = idempotent CTE statement
+    const sql = (mockNeonSql.mock.calls[1][0] as TemplateStringsArray).join(' ');
+    expect(sql).toContain('ON CONFLICT');
+    expect(sql).toContain('DO NOTHING');
+    expect(sql).not.toContain('NOT EXISTS');
   });
 });
 

--- a/web/src/lib/tokens/budget.ts
+++ b/web/src/lib/tokens/budget.ts
@@ -96,7 +96,9 @@ export async function reserveTokenBudget(
  * Release unused tokens after pipeline completes or cancels.
  *
  * Calculates (reserved - actualUsed) and refunds the difference.
- * Uses refundTokenAmount() which is idempotent via the CTE pattern.
+ * Uses refundTokenAmount() with a reservationId, so the refund is idempotent: its
+ * INSERT is guarded by ON CONFLICT DO NOTHING against the UNIQUE partial index
+ * uq_token_usage_refund_idempotent (#8662), crediting at most once even on retry.
  */
 export async function releaseUnusedBudget(
   userId: string,

--- a/web/src/lib/tokens/service.ts
+++ b/web/src/lib/tokens/service.ts
@@ -193,8 +193,8 @@ export interface RefundResult {
  * INTENTIONALLY scoped per-operation — a `'refund'` (this function) and a
  * `'partial_refund'` (`refundTokenAmount`) for the same `usageId` are independently
  * idempotent and would each credit once. Callers MUST treat full and partial refunds
- * for a given `usageId` as mutually exclusive (see `voice/batch/route.ts`, the only
- * caller of both, which dispatches them in an if/else). Calling both for the same
+ * for a given `usageId` as mutually exclusive (see `app/api/generate/voice/batch/route.ts`,
+ * the only caller of both, which dispatches them in an if/else). Calling both for the same
  * `usageId` would double-credit; the database does not prevent it by design, because
  * the two operations restore different amounts to potentially different pools.
  */

--- a/web/src/lib/tokens/service.ts
+++ b/web/src/lib/tokens/service.ts
@@ -185,6 +185,19 @@ export interface RefundResult {
   refunded: boolean;
 }
 
+/**
+ * Fully reverse the deduction recorded by a single usage record (all items failed).
+ *
+ * Idempotency boundary: the refund INSERT is keyed on
+ * `(user_id, operation, refundedUsageId)` with `operation = 'refund'`. This is
+ * INTENTIONALLY scoped per-operation — a `'refund'` (this function) and a
+ * `'partial_refund'` (`refundTokenAmount`) for the same `usageId` are independently
+ * idempotent and would each credit once. Callers MUST treat full and partial refunds
+ * for a given `usageId` as mutually exclusive (see `voice/batch/route.ts`, the only
+ * caller of both, which dispatches them in an if/else). Calling both for the same
+ * `usageId` would double-credit; the database does not prevent it by design, because
+ * the two operations restore different amounts to potentially different pools.
+ */
 export async function refundTokens(userId: string, usageId: string): Promise<RefundResult> {
   if (usageId === 'free') return { refunded: false };
 
@@ -201,7 +214,8 @@ export async function refundTokens(userId: string, usageId: string): Promise<Ref
 
   // 2. Atomic idempotent refund using a CTE (#8662).
   // The CTE INSERT is guarded by ON CONFLICT DO NOTHING against the UNIQUE partial
-  // index uq_token_usage_refund_idempotent (drizzle/0004), keyed on
+  // index uq_token_usage_refund_idempotent (built CONCURRENTLY in drizzle/0005;
+  // pre-existing duplicates removed first in drizzle/0004), keyed on
   // (user_id, operation, refundedUsageId). Unlike the previous WHERE NOT EXISTS —
   // a READ COMMITTED snapshot check, NOT a lock — the unique index serialises two
   // concurrent refunds for the same usageId: the first INSERT commits, the second
@@ -262,6 +276,13 @@ export async function refundTokens(userId: string, usageId: string): Promise<Ref
  *
  * For a complete operation failure (all items failed), prefer `refundTokens`
  * which reverses the exact deduction amount from the usage record.
+ *
+ * Idempotency boundary: when `usageId` is provided, the refund INSERT is keyed on
+ * `(user_id, operation, refundedUsageId)` with `operation = 'partial_refund'`. This
+ * is a DIFFERENT key namespace from `refundTokens` (`operation = 'refund'`), so the
+ * two are independently idempotent. A given `usageId` must be refunded by exactly one
+ * of the two functions, never both (see `refundTokens` for the rationale). Without a
+ * `usageId` the refund is NOT idempotent — the caller must guarantee at-most-once.
  */
 export async function refundTokenAmount(
   userId: string,
@@ -299,8 +320,8 @@ export async function refundTokenAmount(
 
   // Atomic idempotent refund using a CTE (#8662).
   // When usageId is provided, the CTE INSERT is guarded by ON CONFLICT DO NOTHING
-  // against uq_token_usage_refund_idempotent (drizzle/0004) — a lock-backed unique
-  // index, NOT the previous WHERE NOT EXISTS snapshot check, so two concurrent
+  // against uq_token_usage_refund_idempotent (built CONCURRENTLY in drizzle/0005) —
+  // a lock-backed unique index, NOT the previous WHERE NOT EXISTS snapshot check, so two concurrent
   // partial refunds for one usageId credit at most once. The UPDATE depends on the
   // CTE's RETURNING output so it only runs when the INSERT actually inserted.
   // When no usageId, the INSERT always succeeds (no idempotency needed).
@@ -324,12 +345,19 @@ export async function refundTokenAmount(
   }
 
   if (usageId) {
-    // Idempotent path: CTE INSERT + UPDATE in a single statement
+    // Idempotent path: CTE INSERT + UPDATE in a single statement.
+    // The ${userId}::uuid casts are load-bearing, not cosmetic: token_usage.user_id
+    // and users.id are uuid columns, but neon-http binds ${userId} as a text
+    // parameter. Without the cast the INSERT value is text, so Postgres cannot match
+    // it to the uuid-typed partial unique index uq_token_usage_refund_idempotent and
+    // the ON CONFLICT arbiter inference fails at runtime ("no unique or exclusion
+    // constraint matching the ON CONFLICT specification"). refundTokens casts the same
+    // way; keep the two in lockstep.
     await queryWithResilience(() =>
       neonSql`
         WITH ins AS (
           INSERT INTO token_usage (user_id, operation, tokens, source, metadata)
-          VALUES (${userId}, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb)
+          VALUES (${userId}::uuid, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb)
           ON CONFLICT (user_id, operation, (metadata->>'refundedUsageId'))
             WHERE operation IN ('refund','partial_refund')
             DO NOTHING
@@ -337,22 +365,23 @@ export async function refundTokenAmount(
         )
         UPDATE users
         SET ${setClause}, updated_at = NOW()
-        WHERE id = ${userId}
+        WHERE id = ${userId}::uuid
           AND EXISTS (SELECT 1 FROM ins)
       `
     );
   } else {
-    // No usageId: no idempotency guard needed, use transaction for atomicity
+    // No usageId: no idempotency guard needed, use transaction for atomicity.
+    // Cast ${userId}::uuid here too so both refund paths bind userId identically.
     await queryWithResilience(() =>
       neonSql.transaction([
         neonSql`
           INSERT INTO token_usage (user_id, operation, tokens, source, metadata)
-          VALUES (${userId}, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb)
+          VALUES (${userId}::uuid, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb)
         `,
         neonSql`
           UPDATE users
           SET ${setClause}, updated_at = NOW()
-          WHERE id = ${userId}
+          WHERE id = ${userId}::uuid
         `,
       ])
     );

--- a/web/src/lib/tokens/service.ts
+++ b/web/src/lib/tokens/service.ts
@@ -199,11 +199,15 @@ export async function refundTokens(userId: string, usageId: string): Promise<Ref
 
   if (!record) return { refunded: false };
 
-  // 2. Atomic idempotent refund using a CTE.
-  // The CTE INSERT uses WHERE NOT EXISTS to check-and-insert in one step.
-  // The UPDATE's WHERE depends on the CTE's RETURNING output (not a table scan),
-  // so it only runs when the INSERT actually inserted a row — preventing
-  // double-crediting when a pre-existing refund row matches.
+  // 2. Atomic idempotent refund using a CTE (#8662).
+  // The CTE INSERT is guarded by ON CONFLICT DO NOTHING against the UNIQUE partial
+  // index uq_token_usage_refund_idempotent (drizzle/0004), keyed on
+  // (user_id, operation, refundedUsageId). Unlike the previous WHERE NOT EXISTS —
+  // a READ COMMITTED snapshot check, NOT a lock — the unique index serialises two
+  // concurrent refunds for the same usageId: the first INSERT commits, the second
+  // hits the conflict and inserts nothing. The UPDATE's WHERE depends on the CTE's
+  // RETURNING output, so it only credits when the INSERT actually inserted a row —
+  // making the whole statement exactly-once even under concurrency.
   const neonSql = getNeonSql();
   const refundMetadata = JSON.stringify({ refundedUsageId: usageId });
 
@@ -227,13 +231,10 @@ export async function refundTokens(userId: string, usageId: string): Promise<Ref
     neonSql`
       WITH ins AS (
         INSERT INTO token_usage (user_id, operation, tokens, source, provider, metadata)
-        SELECT ${userId}::uuid, 'refund', ${-record.tokens}, ${record.source}, ${record.provider}, ${refundMetadata}::jsonb
-        WHERE NOT EXISTS (
-          SELECT 1 FROM token_usage
-          WHERE user_id = ${userId}::uuid
-            AND operation = 'refund'
-            AND metadata->>'refundedUsageId' = ${usageId}
-        )
+        VALUES (${userId}::uuid, 'refund', ${-record.tokens}, ${record.source}, ${record.provider}, ${refundMetadata}::jsonb)
+        ON CONFLICT (user_id, operation, (metadata->>'refundedUsageId'))
+          WHERE operation IN ('refund','partial_refund')
+          DO NOTHING
         RETURNING id
       )
       UPDATE users
@@ -296,10 +297,12 @@ export async function refundTokenAmount(
     }
   }
 
-  // Atomic idempotent refund using a CTE.
-  // When usageId is provided, the CTE INSERT uses WHERE NOT EXISTS to prevent
-  // duplicate partial refunds. The UPDATE depends on the CTE's RETURNING output
-  // so it only runs when the INSERT actually inserted — preventing double-credit.
+  // Atomic idempotent refund using a CTE (#8662).
+  // When usageId is provided, the CTE INSERT is guarded by ON CONFLICT DO NOTHING
+  // against uq_token_usage_refund_idempotent (drizzle/0004) — a lock-backed unique
+  // index, NOT the previous WHERE NOT EXISTS snapshot check, so two concurrent
+  // partial refunds for one usageId credit at most once. The UPDATE depends on the
+  // CTE's RETURNING output so it only runs when the INSERT actually inserted.
   // When no usageId, the INSERT always succeeds (no idempotency needed).
   const neonSql = getNeonSql();
   const metadata = JSON.stringify({
@@ -326,13 +329,10 @@ export async function refundTokenAmount(
       neonSql`
         WITH ins AS (
           INSERT INTO token_usage (user_id, operation, tokens, source, metadata)
-          SELECT ${userId}, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb
-          WHERE NOT EXISTS (
-            SELECT 1 FROM token_usage
-            WHERE user_id = ${userId}
-              AND operation = 'partial_refund'
-              AND metadata->>'refundedUsageId' = ${usageId}
-          )
+          VALUES (${userId}, 'partial_refund', ${-tokens}, ${source}, ${metadata}::jsonb)
+          ON CONFLICT (user_id, operation, (metadata->>'refundedUsageId'))
+            WHERE operation IN ('refund','partial_refund')
+            DO NOTHING
           RETURNING id
         )
         UPDATE users


### PR DESCRIPTION
## Summary

`refundTokens()` / `refundTokenAmount()` guarded against double-credit with a `WHERE NOT EXISTS (...)` subquery. Under READ COMMITTED that is a snapshot check, **not a lock** — two concurrent refund requests for the same `usageId` both see "no prior refund" and both credit the user. This is a real double-spend on the money path (bug-hunt 2026-05-31).

### Fix
- Add a **UNIQUE partial index** `uq_token_usage_refund_idempotent` on `token_usage (user_id, operation, (metadata->>'refundedUsageId')) WHERE operation IN ('refund','partial_refund')`.
- Replace the racy `WHERE NOT EXISTS` with `INSERT ... ON CONFLICT (...) DO NOTHING RETURNING id`, and only credit the user's balance when the INSERT actually inserted (CTE: `UPDATE users ... WHERE EXISTS (SELECT 1 FROM ins)`). Postgres now enforces at-most-once crediting at the storage layer under any concurrency.
- `${userId}::uuid` casts on the idempotent path are load-bearing: the arbiter on the uuid-typed partial index requires the INSERT value to be uuid-typed (neon-http binds params as text).

### Migration split (mirrors the production-proven `0002` pattern)
- `0004_token_usage_refund_idempotent_index.sql` — **transactional** dedup: deletes pre-existing duplicate refund rows (keeps earliest per key) so the unique index can be built. (Dedup removes duplicate *audit rows*; it does not reverse already-credited tokens — see follow-up below.)
- `0005_token_usage_refund_idempotent_index_concurrent.sql` — `CREATE UNIQUE INDEX CONCURRENTLY` (must run outside a transaction; `token_usage` is high-write, so we avoid the SHARE lock a plain `CREATE INDEX` would take).

`schema.ts` keeps a non-unique placeholder `index()` (Drizzle can't model partial/expression unique indexes); the real constraint lives in the migration, same as `credit_transactions` / `0002`.

### Idempotency boundary (documented + test-pinned)
`refundTokens` writes `operation='refund'`; `refundTokenAmount` writes `operation='partial_refund'`. These are intentionally **disjoint key namespaces** (they restore different amounts to potentially different pools). Mutual exclusivity is enforced structurally at the only dual-caller — the if/else in `app/api/generate/voice/batch/route.ts` — documented in JSDoc and pinned by tests.

## Test plan
- [x] `cd web && npx vitest run src/lib/tokens/` — 99/99 pass (added tests assert `ON CONFLICT DO NOTHING`, the `::uuid` cast on the arbiter path, and the distinct `partial_refund` namespace)
- [x] `npx eslint --max-warnings 0` (tokens + schema) — clean
- [x] `npx tsc --noEmit` — clean
- [x] Reviewed by architect / security / dx / infra / test — all PASS

## Follow-ups (tracked separately, not in this PR)
- **Balance reconciliation**: the `0004` dedup removes duplicate refund *audit rows* but does not claw back tokens already double-credited before this fix shipped. A one-off reconciliation pass should net out historical double-credits. (security + architect)
- **Postgres integration test**: the unit tests assert the emitted SQL shape against a mocked neon client; a real-Postgres concurrency test (two racing refunds → one credit) would close the loop. (test)

Closes #8662 (PF-838)