### PR TITLE
fix(tokens): make deductTokens atomic — single CTE for balance deduction + usage insert

### DIFF
--- a/.changeset/fix-deduct-tokens-atomic.md
+++ b/.changeset/fix-deduct-tokens-atomic.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+fix(tokens): deductTokens now performs the balance deduction and the usage-record insert in a single atomic CTE. Previously the two ran as separate statements, so a usage INSERT that failed after the balance UPDATE committed would charge a user with no token_usage row and no returned usageId — leaving the failed generation's refund path unable to run. The deduction, the usage row, and the returned usageId are now all-or-nothing (PF-839, #8663).

--- a/web/src/lib/auth/__tests__/edge-cases.test.ts
+++ b/web/src/lib/auth/__tests__/edge-cases.test.ts
@@ -219,10 +219,11 @@ describe('deductTokens — concurrent token deductions', () => {
 
   it('deducts from monthly tokens when sufficient', async () => {
     mockDbSelect.mockResolvedValue([makeUser({ monthlyTokens: 1000, monthlyTokensUsed: 0, addonTokens: 0 })]);
-    // neonSql tagged-template calls: first = UPDATE RETURNING, second = INSERT RETURNING
-    mockNeonSql
-      .mockResolvedValueOnce([{ id: 'user-1' }])      // UPDATE ... RETURNING id
-      .mockResolvedValueOnce([{ id: 'usage-uuid-1' }]); // INSERT ... RETURNING id
+    // Single atomic CTE (PF-839): WITH upd AS (UPDATE users ... RETURNING id)
+    // INSERT INTO token_usage ... WHERE EXISTS (SELECT 1 FROM upd) RETURNING id.
+    // One neonSql tagged-template call per attempt, returning the token_usage row
+    // whose id becomes the usageId the refund-on-failure path acts on.
+    mockNeonSql.mockResolvedValueOnce([{ id: 'usage-uuid-1' }]);
     // getTokenBalance after deduction reads via Drizzle select
     mockDbSelect.mockResolvedValueOnce([makeUser({ monthlyTokens: 1000, monthlyTokensUsed: 0, addonTokens: 0 })]);
     mockDbSelect.mockResolvedValueOnce([makeUser({ monthlyTokens: 1000, monthlyTokensUsed: 100, addonTokens: 0 })]);

--- a/web/src/lib/tokens/__tests__/service.test.ts
+++ b/web/src/lib/tokens/__tests__/service.test.ts
@@ -346,6 +346,12 @@ describe('deductTokens', () => {
     if (!result.success) {
       expect(result.error).toBe('INSUFFICIENT_TOKENS');
     }
+
+    // Each of the 4 attempts (initial + 3 retries) issues EXACTLY ONE atomic CTE
+    // statement — not a separate UPDATE + INSERT. This pins the single-statement
+    // contract per attempt: a regression back to two writes per attempt would make
+    // this 8, not 4 (PF-839).
+    expect(mockNeonSql).toHaveBeenCalledTimes(4);
   });
 
   it('handles negative tokenCost as free operation', async () => {
@@ -445,6 +451,35 @@ describe('deductTokens', () => {
     expect(metadataArg).toBeDefined();
     const parsed = JSON.parse(metadataArg as string);
     expect(parsed._split).toEqual({ monthly: 10, addon: 20 });
+  });
+
+  it('propagates a CTE failure to the caller without charging the user (PF-839)', async () => {
+    const { deductTokens } = await import('../service');
+
+    mockLimit.mockResolvedValueOnce([{
+      monthlyTokens: 100,
+      monthlyTokensUsed: 10,
+      addonTokens: 50,
+      billingCycleStart: null,
+    }]);
+
+    // The single atomic CTE throws mid-execution. Because the balance UPDATE and
+    // the usage INSERT are ONE statement, the failure rolls both back: the user is
+    // not charged, no usageId is fabricated, and the error surfaces to the caller
+    // (the pre-fix two-statement path could commit the UPDATE then crash on the
+    // INSERT, charging without a record).
+    mockNeonSql.mockRejectedValueOnce(new Error('connection reset'));
+
+    await expect(deductTokens('user-1', 'texture_generation', 30)).rejects.toThrow(
+      'connection reset'
+    );
+
+    // Exactly one statement was attempted — there is no separate write that could
+    // have partially committed.
+    expect(mockNeonSql).toHaveBeenCalledTimes(1);
+    // No post-deduction balance read happened: the function threw before returning
+    // success, so it never reached getTokenBalance.
+    expect(mockLimit).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/src/lib/tokens/__tests__/service.test.ts
+++ b/web/src/lib/tokens/__tests__/service.test.ts
@@ -230,9 +230,7 @@ describe('deductTokens', () => {
       billingCycleStart: null,
     }]);
 
-    // neonSql UPDATE RETURNING (atomic deduction)
-    mockNeonSqlResults.push([{ id: 'user-1' }]);
-    // neonSql INSERT RETURNING (usage log)
+    // Single atomic CTE: UPDATE users (gated) + INSERT token_usage RETURNING id (PF-839).
     mockNeonSqlResults.push([{ id: 'usage-123' }]);
 
     // getTokenBalance call after deduction
@@ -262,9 +260,7 @@ describe('deductTokens', () => {
       billingCycleStart: null,
     }]);
 
-    // neonSql UPDATE RETURNING (atomic deduction)
-    mockNeonSqlResults.push([{ id: 'user-1' }]);
-    // neonSql INSERT RETURNING (usage log)
+    // Single atomic CTE: UPDATE users (gated) + INSERT token_usage RETURNING id (PF-839).
     mockNeonSqlResults.push([{ id: 'usage-456' }]);
 
     // getTokenBalance after
@@ -294,9 +290,7 @@ describe('deductTokens', () => {
       billingCycleStart: null,
     }]);
 
-    // neonSql UPDATE RETURNING (atomic deduction)
-    mockNeonSqlResults.push([{ id: 'user-1' }]);
-    // neonSql INSERT RETURNING (usage log)
+    // Single atomic CTE: UPDATE users (gated) + INSERT token_usage RETURNING id (PF-839).
     mockNeonSqlResults.push([{ id: 'usage-789' }]);
 
     // getTokenBalance after
@@ -370,6 +364,87 @@ describe('deductTokens', () => {
     if (result.success) {
       expect(result.usageId).toBe('free');
     }
+  });
+
+  it('performs the balance deduction and usage insert in a single atomic CTE (PF-839)', async () => {
+    const { deductTokens } = await import('../service');
+
+    mockLimit.mockResolvedValueOnce([{
+      monthlyTokens: 100,
+      monthlyTokensUsed: 10,
+      addonTokens: 50,
+      billingCycleStart: null,
+    }]);
+
+    // ONE neonSql statement: the combined CTE returns the usage row id.
+    mockNeonSqlResults.push([{ id: 'usage-atomic' }]);
+
+    // getTokenBalance after
+    mockLimit.mockResolvedValueOnce([{
+      monthlyTokens: 100,
+      monthlyTokensUsed: 40,
+      addonTokens: 50,
+      billingCycleStart: null,
+    }]);
+
+    const result = await deductTokens('user-1', 'texture_generation', 30);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.usageId).toBe('usage-atomic');
+    }
+
+    // Exactly ONE statement — the balance UPDATE and the usage INSERT are a single
+    // atomic write (not two separate statements that can partially commit).
+    expect(mockNeonSql).toHaveBeenCalledTimes(1);
+
+    const sql = (mockNeonSql.mock.calls[0][0] as TemplateStringsArray).join(' ');
+    // Balance change + usage row gated together in one CTE.
+    expect(sql).toContain('UPDATE users');
+    expect(sql).toContain('INSERT INTO token_usage');
+    expect(sql).toContain('EXISTS (SELECT 1 FROM upd)');
+    // The race-protection WHERE guard is preserved inside the atomic statement.
+    expect(sql).toContain('(monthly_tokens - monthly_tokens_used) >=');
+
+    // The usage id is returned by the SAME statement that changed the balance.
+    const values = mockNeonSql.mock.calls[0].slice(1);
+    expect(values).toContain('texture_generation');
+  });
+
+  it('persists _split metadata in the same atomic statement for mixed source (PF-839)', async () => {
+    const { deductTokens } = await import('../service');
+
+    // 10 monthly remaining, need 30 → mixed (10 monthly + 20 addon)
+    mockLimit.mockResolvedValueOnce([{
+      monthlyTokens: 50,
+      monthlyTokensUsed: 40,
+      addonTokens: 100,
+      billingCycleStart: null,
+    }]);
+
+    mockNeonSqlResults.push([{ id: 'usage-mixed' }]);
+
+    mockLimit.mockResolvedValueOnce([{
+      monthlyTokens: 50,
+      monthlyTokensUsed: 50,
+      addonTokens: 80,
+      billingCycleStart: null,
+    }]);
+
+    const result = await deductTokens('user-1', 'texture_generation', 30);
+
+    expect(result.success).toBe(true);
+    expect(mockNeonSql).toHaveBeenCalledTimes(1);
+
+    // The metadata JSON interpolated into the single statement carries the pool
+    // split, so the audit metadata is written atomically with the balance change.
+    const values = mockNeonSql.mock.calls[0].slice(1) as unknown[];
+    const metadataArg = values.find(
+      (v): v is string => typeof v === 'string' && v.includes('_split')
+    );
+    expect(metadataArg).toBeDefined();
+    const parsed = JSON.parse(metadataArg as string);
+    expect(parsed._split).toEqual({ monthly: 10, addon: 20 });
   });
 });
 

--- a/web/src/lib/tokens/service.ts
+++ b/web/src/lib/tokens/service.ts
@@ -113,39 +113,51 @@ export async function deductTokens(
     source = 'addon';
   }
 
-  // Atomic deduction via UPDATE...WHERE...RETURNING (PF-996).
-  // The UPDATE's WHERE guards prevent the race condition (only succeeds if
-  // balance hasn't changed). We need the RETURNING result to check success,
-  // so this runs as a standalone statement (not in a transaction).
+  // Atomic deduction + usage record in a single CTE statement (PF-839).
   //
-  // The usage INSERT runs separately after. If it fails, the deduction still
-  // stands — worst case is a missing usage record (recoverable via admin
-  // tooling). This is acceptable because the UPDATE's WHERE guard is the
-  // critical atomicity point for financial correctness.
+  // The balance UPDATE and the usage INSERT are one statement, so they commit
+  // or roll back together: a user is never charged without a token_usage row,
+  // and deductTokens always returns the usageId that the refund-on-failure path
+  // (createGenerationHandler) acts on. The UPDATE's WHERE guards remain the
+  // race-protection point (only deduct if the balance is still sufficient); the
+  // INSERT is gated on EXISTS (SELECT 1 FROM upd) so it runs only when the
+  // guarded UPDATE actually matched a row. A single statement is atomic in
+  // Postgres, so an INSERT failure rolls back the UPDATE too — no charge without
+  // a record. This mirrors creditAddonTokens' atomic single-CTE pattern (PF-996
+  // moved the deduction into the WHERE-guarded UPDATE; PF-839 folds the usage
+  // INSERT into the same atomic statement).
   const neonSql = getNeonSql();
   const now = new Date().toISOString();
   // Always store the pool split so refundTokens/refundTokenAmount can
-  // proportionally credit back both pools for mixed-source deductions.
+  // proportionally credit back both pools for mixed-source deductions. Written
+  // atomically with the balance change via the CTE below.
   const enrichedMetadata = {
     ...(metadata ?? {}),
     _split: { monthly: monthlyDeduct, addon: addonDeduct },
   };
   const metadataJson = JSON.stringify(enrichedMetadata);
-  const updateRows = await queryWithResilience(() =>
+  const usageRows = await queryWithResilience(() =>
     neonSql`
-      UPDATE users
-      SET monthly_tokens_used = monthly_tokens_used + ${monthlyDeduct},
-          addon_tokens = addon_tokens - ${addonDeduct},
-          updated_at = ${now}
-      WHERE id = ${userId}
-        AND (monthly_tokens - monthly_tokens_used) >= ${monthlyDeduct}
-        AND addon_tokens >= ${addonDeduct}
+      WITH upd AS (
+        UPDATE users
+        SET monthly_tokens_used = monthly_tokens_used + ${monthlyDeduct},
+            addon_tokens = addon_tokens - ${addonDeduct},
+            updated_at = ${now}
+        WHERE id = ${userId}
+          AND (monthly_tokens - monthly_tokens_used) >= ${monthlyDeduct}
+          AND addon_tokens >= ${addonDeduct}
+        RETURNING id
+      )
+      INSERT INTO token_usage (user_id, operation, tokens, source, provider, metadata)
+      SELECT ${userId}, ${operation}, ${tokenCost}, ${source}, ${provider ?? null}, ${metadataJson}::jsonb
+      WHERE EXISTS (SELECT 1 FROM upd)
       RETURNING id
     `
   );
 
-  if (updateRows.length === 0) {
-    // Race condition: balance changed between read and update. Retry up to 3 times.
+  if (usageRows.length === 0) {
+    // The guarded UPDATE matched no row (balance changed between read and write),
+    // so the gated INSERT was skipped too — nothing was charged. Retry up to 3 times.
     if (_retryCount >= 3) {
       return {
         success: false,
@@ -157,19 +169,9 @@ export async function deductTokens(
     return deductTokens(userId, operation, tokenCost, provider, metadata, _retryCount + 1);
   }
 
-  // Log usage — if this fails, the deduction already committed (acceptable:
-  // user lost tokens without a usage record, but this is extremely rare and
-  // recoverable via admin tooling). We don't wrap in a transaction because
-  // the UPDATE's WHERE guard is the critical atomicity point.
-  const usageResult = await queryWithResilience(() =>
-    neonSql`
-      INSERT INTO token_usage (user_id, operation, tokens, source, provider, metadata)
-      VALUES (${userId}, ${operation}, ${tokenCost}, ${source}, ${provider ?? null}, ${metadataJson}::jsonb)
-      RETURNING id
-    `
-  );
-
-  const usageId = (usageResult[0] as { id: string }).id;
+  // The usageId comes from the SAME atomic statement that changed the balance,
+  // so a successful deduction always yields a refundable usage record.
+  const usageId = (usageRows[0] as { id: string }).id;
   const remaining = await getTokenBalance(userId);
 
   return {


### PR DESCRIPTION
## Summary

`deductTokens()` charged a user's token balance and recorded the matching `token_usage` row as **two separate `neon-http` statements**. If the `INSERT` failed after the balance `UPDATE` had already committed, the user was charged with **no usage record** — and the function then crashed dereferencing `usageResult[0].id` (TypeError). The refund-on-failure path in `createGenerationHandler` had no `usageId` to act on, so the user could lose tokens with no way to get them back.

This folds both writes into a **single atomic CTE**. A single Postgres statement is implicitly atomic, so the balance change and the usage insert now commit or roll back together:

```sql
WITH upd AS (
  UPDATE users
  SET monthly_tokens_used = monthly_tokens_used + $monthlyDeduct,
      addon_tokens = addon_tokens - $addonDeduct,
      updated_at = $now
  WHERE id = $userId
    AND (monthly_tokens - monthly_tokens_used) >= $monthlyDeduct
    AND addon_tokens >= $addonDeduct
  RETURNING id
)
INSERT INTO token_usage (user_id, operation, tokens, source, provider, metadata)
SELECT $userId, $operation, $tokenCost, $source, $provider, $metadataJson::jsonb
WHERE EXISTS (SELECT 1 FROM upd)
RETURNING id
```

- The `UPDATE`'s `WHERE` guard remains the race-protection point (deduct only if the balance is still sufficient).
- The `INSERT` is gated on `WHERE EXISTS (SELECT 1 FROM upd)`, so it runs **iff** the guarded `UPDATE` matched a row.
- A failed `INSERT` rolls the `UPDATE` back → **never a charge without a record**.
- A successful deduction always returns the `usageId` from the same statement, so the refund path is always actionable.

This mirrors the atomic single-CTE pattern already used by `creditAddonTokens` and `refundTokens` in the same file. No schema change, no new env var, and the external function contract (signature, return shape, retry-on-race up to 3) is unchanged.

## Changes
- `web/src/lib/tokens/service.ts` — `deductTokens` now uses one atomic CTE; corrected the misleading comments that previously accepted "a missing usage record" as acceptable.
- `web/src/lib/tokens/__tests__/service.test.ts` — updated the three success tests to the single-statement contract; added tests asserting (a) one combined CTE statement, (b) `_split` metadata persisted atomically for mixed-source, (c) exactly one CTE per retry attempt, (d) a CTE error propagates to the caller without charging.

## Test plan
- [x] `npx vitest run src/lib/tokens/` — 96 pass (service.test.ts 45 pass)
- [x] `npx eslint --max-warnings 0 .` — clean
- [x] `npx tsc --noEmit` — clean
- [x] Reviewed by specialized architect, security, dx, and test reviewers — all PASS

Closes #8663 (PF-839)