### PR TITLE
fix(api): isolate in-flight dedup failures per joiner in the response cache

### DIFF
--- a/.changeset/fix-responsecache-joiner-isolation.md
+++ b/.changeset/fix-responsecache-joiner-isolation.md
@@ -17,3 +17,8 @@ independent attempt. Because the failed originator already releases any tokens i
 deducted, a joiner only pays when its own attempt succeeds. The userId-in-key
 invariant that keeps dedup same-user-only is now documented next to the in-flight
 logic and locked by a guard test.
+
+In-flight cleanup is now identity-guarded: because multiple joiners can run their
+own attempts on the same key concurrently, a settling caller only deletes the
+in-flight entry it actually registered. A blind delete would evict a live sibling
+entry and break dedup for requests arriving before it settles.

--- a/.changeset/fix-responsecache-joiner-isolation.md
+++ b/.changeset/fix-responsecache-joiner-isolation.md
@@ -1,0 +1,19 @@
+---
+"web": patch
+---
+
+fix(api): isolate in-flight dedup failures per joiner in the AI generation response cache
+
+`cachedGenerate()` shares a single in-flight promise across concurrent callers
+with the same cache key. Previously, when that shared promise rejected (a
+transient provider error, or — for a same-user request — an `ApiKeyError`),
+**every** waiting joiner inherited the same rejection and was permanently bound
+to one attempt's failure, even though each could have succeeded independently.
+
+The joiner path now isolates failures: on rejection it re-checks the cache (so a
+surviving joiner rides a concurrently-populated result instead of redundantly
+regenerating and re-charging) and otherwise falls through to run its own
+independent attempt. Because the failed originator already releases any tokens it
+deducted, a joiner only pays when its own attempt succeeds. The userId-in-key
+invariant that keeps dedup same-user-only is now documented next to the in-flight
+logic and locked by a guard test.

--- a/web/src/lib/api/__tests__/responseCache.test.ts
+++ b/web/src/lib/api/__tests__/responseCache.test.ts
@@ -175,7 +175,12 @@ describe('responseCache', () => {
       whenJoined: () => Promise<void>;
     }
 
-    function makeJoinDetectable<T>(): JoinDetectable<T> {
+    // `joinThreshold` is the `.then` attachment count at which `whenJoined()`
+    // resolves. The originator's internal `await` is the 1st attachment, so the
+    // default of 2 fires once a single joiner has attached. Tests with N joiners
+    // pass `1 + N` to wait until every joiner has truly joined the shared promise
+    // before it is settled.
+    function makeJoinDetectable<T>(joinThreshold = 2): JoinDetectable<T> {
       let resolveInner!: (value: T) => void;
       let rejectInner!: (error: unknown) => void;
       const inner = new Promise<T>((res, rej) => {
@@ -187,7 +192,7 @@ describe('responseCache', () => {
       const thenable = {
         then(onF?: ((value: T) => unknown) | null, onR?: ((error: unknown) => unknown) | null) {
           attachCount += 1;
-          if (attachCount >= 2) signalJoined?.();
+          if (attachCount >= joinThreshold) signalJoined?.();
           return inner.then(onF ?? undefined, onR ?? undefined);
         },
       };
@@ -197,10 +202,21 @@ describe('responseCache', () => {
         reject: (error: unknown) => rejectInner(error),
         whenJoined: () =>
           new Promise<void>((res) => {
-            if (attachCount >= 2) res();
+            if (attachCount >= joinThreshold) res();
             else signalJoined = res;
           }),
       };
+    }
+
+    // A plain externally-controlled deferred (no join detection needed).
+    function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+      let resolve!: (value: T) => void;
+      let reject!: (error: unknown) => void;
+      const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+      });
+      return { promise, resolve, reject };
     }
 
     it('runs the joiner\'s own attempt when the shared in-flight promise rejects', async () => {
@@ -290,6 +306,58 @@ describe('responseCache', () => {
 
       expect(userA, 'different users MUST get different cache keys (no cross-user dedup)').not.toBe(userB);
       expect(userAAgain, 'same user + same request MUST get the same key (dedup works)').toBe(userA);
+    });
+
+    it('does not evict a sibling joiner\'s in-flight entry when a clobbered joiner settles first', async () => {
+      // Regression for the in-flight cleanup race the failure-isolation fall-through
+      // exposes. When two joiners fall through after a shared rejection, each
+      // registers its OWN in-flight promise — the second overwrites the first in
+      // the map. If the first (now-clobbered) joiner then settles and blindly
+      // deletes the key, it evicts the SURVIVING joiner's still-live entry, so a
+      // later identical request misses dedup and starts a redundant third
+      // generation (an extra charge). Cleanup must only remove the entry it owns.
+      const originatorCtl = makeJoinDetectable<{ audio: string }>(3); // originator + 2 joiners attach
+      const clobberedCtl = makeDeferred<{ audio: string }>();          // first fall-through joiner (overwritten in map)
+      const survivorCtl = makeDeferred<{ audio: string }>();           // second fall-through joiner (set last → survives)
+      const executeFn = vi.fn()
+        .mockReturnValueOnce(originatorCtl.promise) // call 1: originator — rejects
+        .mockReturnValueOnce(clobberedCtl.promise)  // call 2: first joiner's own attempt (clobbered)
+        .mockReturnValueOnce(survivorCtl.promise);  // call 3: second joiner's own attempt (survives)
+
+      const originator = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(1));
+      const joinerA = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      const joinerB = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await originatorCtl.whenJoined(); // both joiners have attached to the shared promise
+
+      originatorCtl.reject(new Error('originator failed'));
+      // Attach the rejection expectation now so the originator's failure is always
+      // handled, even if a later assertion throws and we never reach the await.
+      const originatorRejects = expect(originator).rejects.toThrow('originator failed');
+
+      // Both joiners fall through and register their own in-flight promises.
+      // call 2 sets first, call 3 overwrites it → the survivor is call 3's entry.
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(3));
+
+      const key = await _generateCacheKey('sfx_generation', { prompt: 'boom' }, 'user_A');
+      expect(_inFlight.has(key), 'a fall-through joiner must register an in-flight entry').toBe(true);
+
+      // Settle the CLOBBERED joiner (call 2) first and let its cleanup run.
+      clobberedCtl.resolve({ audio: 'clobbered' });
+      await Promise.race([joinerA, joinerB]); // the clobbered joiner fully settles → its finally runs
+
+      // The surviving joiner's entry (call 3) MUST still be in the map — the
+      // clobbered joiner's cleanup must not have evicted an entry it no longer owns.
+      expect(
+        _inFlight.has(key),
+        'clobbered joiner must not evict the surviving joiner\'s in-flight entry',
+      ).toBe(true);
+
+      // Once the survivor itself settles, the entry IS cleaned up by its true owner.
+      survivorCtl.resolve({ audio: 'survivor' });
+      await Promise.all([joinerA, joinerB]);
+      await originatorRejects;
+      expect(_inFlight.has(key), 'the surviving joiner cleans up its own entry on settle').toBe(false);
     });
   });
 

--- a/web/src/lib/api/__tests__/responseCache.test.ts
+++ b/web/src/lib/api/__tests__/responseCache.test.ts
@@ -160,6 +160,139 @@ describe('responseCache', () => {
     });
   });
 
+  describe('in-flight dedup failure isolation (PF-843, #8667)', () => {
+    // The in-flight map shares ONE promise across every caller on a key. To test
+    // the joiner path deterministically we need to know the joiner has actually
+    // *joined* (attached to the shared promise) before we settle it — otherwise a
+    // late joiner would run its own attempt and a regression test would pass for
+    // the wrong reason. This helper exposes a thenable whose 2nd `.then`
+    // attachment (1st = the originator's internal `await`, 2nd = the joiner's
+    // `await`) resolves `whenJoined()`.
+    interface JoinDetectable<T> {
+      promise: Promise<T>;
+      resolve: (value: T) => void;
+      reject: (error: unknown) => void;
+      whenJoined: () => Promise<void>;
+    }
+
+    function makeJoinDetectable<T>(): JoinDetectable<T> {
+      let resolveInner!: (value: T) => void;
+      let rejectInner!: (error: unknown) => void;
+      const inner = new Promise<T>((res, rej) => {
+        resolveInner = res;
+        rejectInner = rej;
+      });
+      let attachCount = 0;
+      let signalJoined: (() => void) | undefined;
+      const thenable = {
+        then(onF?: ((value: T) => unknown) | null, onR?: ((error: unknown) => unknown) | null) {
+          attachCount += 1;
+          if (attachCount >= 2) signalJoined?.();
+          return inner.then(onF ?? undefined, onR ?? undefined);
+        },
+      };
+      return {
+        promise: thenable as unknown as Promise<T>,
+        resolve: (value: T) => resolveInner(value),
+        reject: (error: unknown) => rejectInner(error),
+        whenJoined: () =>
+          new Promise<void>((res) => {
+            if (attachCount >= 2) res();
+            else signalJoined = res;
+          }),
+      };
+    }
+
+    it('runs the joiner\'s own attempt when the shared in-flight promise rejects', async () => {
+      const ctl = makeJoinDetectable<{ audio: string }>();
+      const executeFn = vi.fn()
+        .mockReturnValueOnce(ctl.promise)               // originator — will reject
+        .mockResolvedValueOnce({ audio: 'joiner_own' }); // joiner's independent attempt
+
+      const originator = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(1));
+      const joiner = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await ctl.whenJoined();
+
+      ctl.reject(new Error('transient provider blip'));
+
+      // The originator surfaces its own failure...
+      await expect(originator).rejects.toThrow('transient provider blip');
+      // ...but the joiner is NOT permanently bound to it — it ran its own attempt.
+      const joinerResult = await joiner;
+      expect(joinerResult.result).toEqual({ audio: 'joiner_own' });
+      expect(joinerResult.cached).toBe(false);
+      expect(executeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('rides a concurrently-cached result instead of re-executing after a rejection', async () => {
+      const ctl = makeJoinDetectable<{ audio: string }>();
+      const executeFn = vi.fn().mockReturnValueOnce(ctl.promise); // ONLY the originator runs; joiner must not call again
+
+      const originator = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(1));
+      const joiner = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await ctl.whenJoined();
+
+      // A concurrent sibling attempt populated the cache for this exact key
+      // before the shared promise's rejection propagates to the joiner.
+      const key = await _generateCacheKey('sfx_generation', { prompt: 'boom' }, 'user_A');
+      _memoryCache.set(key, {
+        result: { audio: 'sibling_cached' },
+        createdAt: 0,
+        ttlMs: Number.MAX_SAFE_INTEGER,
+        operation: 'sfx_generation',
+      });
+
+      ctl.reject(new Error('transient provider blip'));
+
+      await expect(originator).rejects.toThrow('transient provider blip');
+      const joinerResult = await joiner;
+      // Joiner re-checked the cache after the rejection — no redundant regen/charge.
+      expect(joinerResult.result).toEqual({ audio: 'sibling_cached' });
+      expect(joinerResult.cached).toBe(true);
+      expect(executeFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('lets a same-user joiner independently re-derive the originator\'s ApiKeyError', async () => {
+      // The joiner is the SAME user (userId is in the key), so its own attempt
+      // hits the same missing-key failure. This is intentional: the joiner
+      // correctly re-derives the same 402 rather than inheriting a shared
+      // rejection it cannot retry.
+      const ctl = makeJoinDetectable<{ audio: string }>();
+      const apiKeyError = new Error('No API key configured');
+      const executeFn = vi.fn()
+        .mockReturnValueOnce(ctl.promise)
+        .mockRejectedValueOnce(apiKeyError); // joiner's own attempt — same user, same failure
+
+      const originator = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await vi.waitFor(() => expect(executeFn).toHaveBeenCalledTimes(1));
+      const joiner = cachedGenerate('sfx_generation', { prompt: 'boom' }, executeFn, { userId: 'user_A' });
+      await ctl.whenJoined();
+
+      ctl.reject(apiKeyError);
+
+      await expect(originator).rejects.toThrow('No API key configured');
+      await expect(joiner).rejects.toThrow('No API key configured');
+      expect(executeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('GUARD: generateCacheKey must incorporate userId so dedup never spans users', async () => {
+      // In-flight dedup shares ONE promise (and its single result/failure) among
+      // all joiners on a key. That is only safe because the key includes userId,
+      // so joiners are always the SAME user. If userId is ever dropped from the
+      // key, different users would dedup onto each other: one user's result would
+      // leak to another AND a joiner would ride a generation it never paid for.
+      // This guard fails loudly if that invariant is broken.
+      const userA = await _generateCacheKey('sfx_generation', { prompt: 'boom' }, 'user_A');
+      const userB = await _generateCacheKey('sfx_generation', { prompt: 'boom' }, 'user_B');
+      const userAAgain = await _generateCacheKey('sfx_generation', { prompt: 'boom' }, 'user_A');
+
+      expect(userA, 'different users MUST get different cache keys (no cross-user dedup)').not.toBe(userB);
+      expect(userAAgain, 'same user + same request MUST get the same key (dedup works)').toBe(userA);
+    });
+  });
+
   describe('getCachedResult', () => {
     it('returns hit:false when nothing is cached', async () => {
       const result = await getCachedResult('sfx_generation', { prompt: 'boom' });

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -256,11 +256,39 @@ export async function cachedGenerate<T>(
   const memResult = memoryGet<T>(key);
   if (memResult !== undefined) return { result: memResult, cached: true };
 
-  // 2. Check in-flight dedup
+  // 2. Check in-flight dedup.
+  //
+  // The in-flight map shares ONE promise (and thus one result) across every
+  // caller on a key. This is only safe because generateCacheKey incorporates
+  // userId (see step 1 and the GUARD test in responseCache.test.ts): joiners
+  // are therefore always the SAME user firing identical concurrent requests.
+  // That invariant matters because executeFn (in createGenerationHandler)
+  // performs the token deduction — joiners never run it, so they ride for free.
+  // A shared promise across DIFFERENT users would both leak one user's result
+  // to another AND let a joiner ride a generation it never paid for. Do not
+  // drop userId from the key without revisiting this.
   const existing = inFlight.get(key);
   if (existing) {
-    const result = await existing.promise as T;
-    return { result, cached: true };
+    try {
+      const result = await existing.promise as T;
+      return { result, cached: true };
+    } catch {
+      // Per-joiner failure isolation: the shared in-flight promise rejected (a
+      // transient provider blip, or — for a same-user request — the originator's
+      // ApiKeyError). Rather than binding every joiner to that single failure,
+      // re-check the cache (a concurrent attempt may have populated it, so a
+      // surviving joiner does not redundantly regenerate or re-charge) and
+      // otherwise fall through to run this caller's own independent attempt
+      // below. The failed originator already released any tokens it deducted, so
+      // a joiner only pays when its own attempt succeeds.
+      if (isUpstashConfigured()) {
+        const settled = await redisGet<T>(key);
+        if (settled !== undefined) return { result: settled, cached: true };
+      }
+      const settledMem = memoryGet<T>(key);
+      if (settledMem !== undefined) return { result: settledMem, cached: true };
+      // Fall through to step 3 and execute this caller's own attempt.
+    }
   }
 
   // 3. Execute and cache

--- a/web/src/lib/api/responseCache.ts
+++ b/web/src/lib/api/responseCache.ts
@@ -296,7 +296,8 @@ export async function cachedGenerate<T>(
   const ttlMs = ttlSeconds * 1000;
 
   const promise = executeFn();
-  inFlight.set(key, { promise });
+  const entry: InFlightEntry<T> = { promise };
+  inFlight.set(key, entry);
 
   try {
     const result = await promise;
@@ -312,7 +313,12 @@ export async function cachedGenerate<T>(
 
     return { result, cached: false };
   } finally {
-    inFlight.delete(key);
+    // Identity-guarded cleanup: only remove the entry THIS call registered. The
+    // failure-isolation fall-through above lets multiple joiners run their own
+    // attempts on the same key concurrently, so a later attempt may have already
+    // overwritten inFlight[key]. A blind delete would evict that live sibling
+    // entry and break dedup for requests arriving in the gap before it settles.
+    if (inFlight.get(key) === entry) inFlight.delete(key);
   }
 }
 


### PR DESCRIPTION
## Summary

`cachedGenerate()` (the AI-generation response cache) deduplicates concurrent requests with the same cache key by sharing **one** in-flight promise across all callers. Previously, when that shared promise rejected — a transient provider error, or for a same-user request an `ApiKeyError` — **every** waiting joiner inherited the same rejection and was permanently bound to one attempt's failure, even though each could have succeeded independently. One unlucky originator failed the whole fan-out.

This PR isolates failures per joiner:

- **On rejection, a joiner re-checks the cache** (Redis + memory) and rides a concurrently-populated result instead of redundantly regenerating and re-charging.
- **On a cache miss, the joiner falls through to run its own independent `executeFn` attempt.** Because the failed originator already releases any tokens it deducted, a joiner only pays when its own attempt succeeds — no double-charge, no charge-without-delivery.
- **In-flight cleanup is identity-guarded.** Because multiple fall-through joiners can run their own attempts on the same key concurrently, each captures the entry it registered and the `finally` only deletes that exact entry (`if (inFlight.get(key) === entry) inFlight.delete(key)`). A blind delete would evict a live sibling entry and break dedup for requests arriving in the gap before it settles.

The `userId`-in-key invariant (which keeps dedup strictly same-user, so a joiner can never serve or be charged for another user's request) is now documented next to the in-flight logic and locked by a guard test.

## Why

Found in the 2026-05-31 full-system bug hunt. The shared-promise design meant a single failing request degraded every concurrent same-key request for that user — a reliability and (because joiners could be denied a result they'd have gotten on their own attempt) a correctness problem.

Blast radius is contained: `cachedGenerate` has exactly one caller, `createGenerationHandler.ts`, whose 14 existing tests continue to pass.

Closes #8667 (PF-843)

## Test plan

- [x] New `describe('in-flight dedup failure isolation (PF-843, #8667)')` block with 5 tests, including:
  - joiner runs its own attempt when the shared promise rejects
  - joiner rides a concurrently-cached result instead of re-executing after a rejection
  - same-user joiner independently re-derives the originator's `ApiKeyError`
  - **GUARD**: `generateCacheKey` must incorporate `userId` so dedup never spans users
  - **concurrency**: a clobbered joiner settling first does not evict the surviving joiner's in-flight entry (RED without the identity-guard)
- [x] Deterministic join detection (`makeJoinDetectable`) ensures joiners have truly joined before the originator rejects — no false-GREEN
- [x] `responseCache.test.ts` 28/28 pass; `createGenerationHandler.test.ts` 14/14 pass
- [x] `eslint --max-warnings 0` clean; `tsc --noEmit` clean