### PR TITLE
fix(hooks): stop SubagentStop reviewer-loop; harden both verdict gates + path-gate CI

### DIFF
--- a/.claude/hooks/__tests__/reject-incomplete-review.test.sh
+++ b/.claude/hooks/__tests__/reject-incomplete-review.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Tests for reject-incomplete-review.sh (SubagentStop verdict gate).
+#
+# Contract under test (hardened):
+#   exit 2  ONLY when a reviewer/guardian subagent emits a SUBSTANTIVE review
+#           body that genuinely lacks a PASS/FAIL verdict.
+#   exit 0  in every other case — including the loop-bug trigger where a
+#           background subagent returns only a short terse "tail" (e.g.
+#           "Hook validated. End.") that never contained the verdict.
+#
+# Run: bash .claude/hooks/__tests__/reject-incomplete-review.test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HERE/../reject-incomplete-review.sh"
+
+pass=0
+fail=0
+
+# run_hook <agent_type> <output> -> echoes the hook's exit code
+run_hook() {
+  local agent_type="$1" output="$2"
+  jq -nc --arg t "$agent_type" --arg o "$output" '{agent_type:$t, output:$o}' \
+    | bash "$HOOK" >/dev/null 2>&1
+  echo $?
+}
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %s (exit %s)\n' "$desc" "$actual"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s (expected exit %s, got %s)\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+# A genuine, substantive review body that omits a verdict (>200 chars, no
+# PASS/FAIL). Deliberately avoids the words pass/fail to keep intent unambiguous.
+SUBSTANTIVE_NO_VERDICT="The in-flight dedup block in web/src/lib/api/responseCache.ts reuses a single \
+shared promise across joiners. On rejection the joiners re-check the cache and otherwise run their own \
+attempt, which looks correct. The identity-guarded cleanup at the end of the function only removes the \
+entry it registered, so a sibling joiner's live entry is preserved across concurrent settles."
+
+# A long error dump (>200 chars) that is not a review at all.
+TRACEBACK_DUMP="Traceback (most recent call last):
+  File \"agent_runtime.py\", line 412, in dispatch
+    result = await self._run_review(ctx)
+  File \"agent_runtime.py\", line 388, in _run_review
+    raise RuntimeError('model stream closed before completion')
+RuntimeError: model stream closed before completion — the review never produced any findings."
+
+echo "reject-incomplete-review.sh"
+
+# --- Preserved behavior ---
+assert_exit "non-reviewer agent is ignored"                 0 "$(run_hook "builder" "anything at all here")"
+assert_exit "reviewer with PASS verdict accepted"           0 "$(run_hook "security-reviewer" "VERDICT: PASS — all checks clean.")"
+assert_exit "reviewer with FAIL verdict accepted"           0 "$(run_hook "code-architect-reviewer" "VERDICT: FAIL — see issue in foo.ts")"
+assert_exit "guardian with PASS verdict accepted"           0 "$(run_hook "dx-guardian" "Looks good. PASS.")"
+
+# --- The genuine loop-block case (must still fire) ---
+assert_exit "substantive review missing a verdict blocks"   2 "$(run_hook "security-reviewer" "$SUBSTANTIVE_NO_VERDICT")"
+
+# --- Hardening: unverifiable output must NOT loop-block ---
+assert_exit "empty output is unverifiable"                  0 "$(run_hook "security-reviewer" "")"
+assert_exit "whitespace-only output is unverifiable"        0 "$(run_hook "security-reviewer" "   $(printf '\n\t')  ")"
+assert_exit "terse subagent tail is unverifiable"           0 "$(run_hook "security-reviewer" "Hook validated. End.")"
+assert_exit "short acknowledgement is unverifiable"         0 "$(run_hook "test-writer-reviewer" "Acknowledged.")"
+assert_exit "long error dump is not a review"               0 "$(run_hook "security-reviewer" "$TRACEBACK_DUMP")"
+
+echo ""
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/__tests__/reject-incomplete-review.test.sh
+++ b/.claude/hooks/__tests__/reject-incomplete-review.test.sh
@@ -3,13 +3,19 @@
 #
 # Contract under test (hardened):
 #   exit 2  ONLY when a reviewer/guardian subagent emits a SUBSTANTIVE review
-#           body that genuinely lacks a PASS/FAIL verdict.
-#   exit 0  in every other case — including the loop-bug trigger where a
-#           background subagent returns only a short terse "tail" (e.g.
-#           "Hook validated. End.") that never contained the verdict.
+#           body (>= 200 trimmed chars) that genuinely lacks a PASS/FAIL verdict.
+#   exit 0  in every other case — a clear verdict, a non-reviewer agent, empty /
+#           whitespace-only output, a JSON error object, a short terse "tail"
+#           (e.g. "Hook validated. End."), or unparseable input.
+#
+# The exit-0 cases are the loop-bug fix: a background subagent's SubagentStop
+# `.output` is only a short tail, never the full review it already returned to
+# the orchestrator, so treating its missing verdict as a failure looped forever.
 #
 # Run: bash .claude/hooks/__tests__/reject-incomplete-review.test.sh
 set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required to run these tests"; exit 1; }
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK="$HERE/../reject-incomplete-review.sh"
@@ -17,12 +23,25 @@ HOOK="$HERE/../reject-incomplete-review.sh"
 pass=0
 fail=0
 
-# run_hook <agent_type> <output> -> echoes the hook's exit code
+# run_hook <agent_type> <output> -> echoes the hook's exit code.
+# Builds a well-formed JSON payload via jq so arbitrary content is safe.
 run_hook() {
   local agent_type="$1" output="$2"
   jq -nc --arg t "$agent_type" --arg o "$output" '{agent_type:$t, output:$o}' \
     | bash "$HOOK" >/dev/null 2>&1
   echo $?
+}
+
+# run_hook_raw <raw_stdin> -> echoes the hook's exit code, piping bytes verbatim
+# (used to feed malformed / non-JSON input).
+run_hook_raw() {
+  printf '%s' "$1" | bash "$HOOK" >/dev/null 2>&1
+  echo $?
+}
+
+# repeat_char <char> <count> -> a string of <count> copies of <char>.
+repeat_char() {
+  printf '%*s' "$2" '' | tr ' ' "$1"
 }
 
 assert_exit() {
@@ -43,31 +62,53 @@ shared promise across joiners. On rejection the joiners re-check the cache and o
 attempt, which looks correct. The identity-guarded cleanup at the end of the function only removes the \
 entry it registered, so a sibling joiner's live entry is preserved across concurrent settles."
 
-# A long error dump (>200 chars) that is not a review at all.
-TRACEBACK_DUMP="Traceback (most recent call last):
-  File \"agent_runtime.py\", line 412, in dispatch
-    result = await self._run_review(ctx)
-  File \"agent_runtime.py\", line 388, in _run_review
-    raise RuntimeError('model stream closed before completion')
-RuntimeError: model stream closed before completion — the review never produced any findings."
+# A JSON error object the platform might place in `.output` (>200 chars, no
+# verdict). Starts with '{' — never the shape of a real review body.
+JSON_ERROR_OBJECT='{"error":"model_stream_closed","detail":"the subagent stream closed before the \
+security review of web/src/lib/auth/api-auth.ts produced any findings or a verdict, so nothing \
+meaningful was returned by the run and the orchestrator should treat the output as unverifiable here"}'
+
+# A >200-char body that mentions PASSED / FAILED (past tense) but issues no bare
+# PASS/FAIL verdict. Word boundaries must keep this from satisfying the gate.
+PASSED_FAILED_NO_VERDICT="The migration PASSED through three of its stages and exactly one integration \
+check FAILED to run on the first attempt, but the reviewer never recorded a formal determination about \
+the change to web/src/lib/api/responseCache.ts and left no overall conclusion of any kind here today."
+
+# A >200-char body whose only verdict token is lowercase 'pass' (case-insensitive
+# match must accept it).
+LOWERCASE_VERDICT="After reviewing the change to web/src/lib/api/responseCache.ts and walking every \
+branch of the in-flight dedup path together with the identity-guarded cleanup at the tail of the \
+function, my overall determination for this particular submission is pass and there is nothing more."
 
 echo "reject-incomplete-review.sh"
 
-# --- Preserved behavior ---
-assert_exit "non-reviewer agent is ignored"                 0 "$(run_hook "builder" "anything at all here")"
+# --- Preserved behavior: verdict present / non-reviewer ---
+assert_exit "non-reviewer agent is ignored"                 0 "$(run_hook "builder" "$SUBSTANTIVE_NO_VERDICT")"
 assert_exit "reviewer with PASS verdict accepted"           0 "$(run_hook "security-reviewer" "VERDICT: PASS — all checks clean.")"
 assert_exit "reviewer with FAIL verdict accepted"           0 "$(run_hook "code-architect-reviewer" "VERDICT: FAIL — see issue in foo.ts")"
 assert_exit "guardian with PASS verdict accepted"           0 "$(run_hook "dx-guardian" "Looks good. PASS.")"
+assert_exit "guardian with FAIL verdict accepted"           0 "$(run_hook "docs-guardian" "VERDICT: FAIL — fix the table in x.md")"
+assert_exit "lowercase 'pass' verdict accepted"             0 "$(run_hook "security-reviewer" "$LOWERCASE_VERDICT")"
 
 # --- The genuine loop-block case (must still fire) ---
 assert_exit "substantive review missing a verdict blocks"   2 "$(run_hook "security-reviewer" "$SUBSTANTIVE_NO_VERDICT")"
+assert_exit "PASSED/FAILED prose is not a verdict (blocks)" 2 "$(run_hook "security-reviewer" "$PASSED_FAILED_NO_VERDICT")"
+
+# --- Threshold boundary (MIN_REVIEW_CHARS = 200) ---
+assert_exit "199 chars no verdict is unverifiable"          0 "$(run_hook "security-reviewer" "$(repeat_char x 199)")"
+assert_exit "200 chars no verdict is substantive (blocks)"  2 "$(run_hook "security-reviewer" "$(repeat_char x 200)")"
+assert_exit "201 chars no verdict is substantive (blocks)"  2 "$(run_hook "security-reviewer" "$(repeat_char x 201)")"
 
 # --- Hardening: unverifiable output must NOT loop-block ---
 assert_exit "empty output is unverifiable"                  0 "$(run_hook "security-reviewer" "")"
 assert_exit "whitespace-only output is unverifiable"        0 "$(run_hook "security-reviewer" "   $(printf '\n\t')  ")"
 assert_exit "terse subagent tail is unverifiable"           0 "$(run_hook "security-reviewer" "Hook validated. End.")"
 assert_exit "short acknowledgement is unverifiable"         0 "$(run_hook "test-writer-reviewer" "Acknowledged.")"
-assert_exit "long error dump is not a review"               0 "$(run_hook "security-reviewer" "$TRACEBACK_DUMP")"
+assert_exit "JSON error object is not a review"             0 "$(run_hook "security-reviewer" "$JSON_ERROR_OBJECT")"
+
+# --- Fail-safe on malformed / non-JSON input (never exit 2, never undefined) ---
+assert_exit "non-JSON stdin fails safe"                     0 "$(run_hook_raw 'not valid json {{{')"
+assert_exit "empty stdin fails safe"                        0 "$(run_hook_raw '')"
 
 echo ""
 echo "passed: $pass  failed: $fail"

--- a/.claude/hooks/__tests__/reject-incomplete-review.test.sh
+++ b/.claude/hooks/__tests__/reject-incomplete-review.test.sh
@@ -93,6 +93,9 @@ assert_exit "lowercase 'pass' verdict accepted"             0 "$(run_hook "secur
 # --- The genuine loop-block case (must still fire) ---
 assert_exit "substantive review missing a verdict blocks"   2 "$(run_hook "security-reviewer" "$SUBSTANTIVE_NO_VERDICT")"
 assert_exit "PASSED/FAILED prose is not a verdict (blocks)" 2 "$(run_hook "security-reviewer" "$PASSED_FAILED_NO_VERDICT")"
+# The gate matches reviewer|guardian — pin the block path for a *guardian* type too,
+# so a regression narrowing the match to only '-reviewer' is caught.
+assert_exit "guardian substantive review missing verdict blocks" 2 "$(run_hook "docs-guardian" "$SUBSTANTIVE_NO_VERDICT")"
 
 # --- Threshold boundary (MIN_REVIEW_CHARS = 200) ---
 assert_exit "199 chars no verdict is unverifiable"          0 "$(run_hook "security-reviewer" "$(repeat_char x 199)")"

--- a/.claude/hooks/__tests__/review-quality-gate.test.sh
+++ b/.claude/hooks/__tests__/review-quality-gate.test.sh
@@ -61,6 +61,9 @@ assert_exit "guardian PASS verdict accepted"              0 "$(run_hook "dx-guar
 
 # --- Missing verdict blocks ---
 assert_exit "reviewer with no verdict blocks"             2 "$(run_hook "security-reviewer" "I looked at the diff and it seems mostly fine overall.")"
+# The gate matches reviewer|guardian — pin the no-verdict block path for a
+# *guardian* type too, so a regression narrowing the match is caught.
+assert_exit "guardian with no verdict blocks"             2 "$(run_hook "dx-guardian" "I looked at the docs and they seem mostly fine overall.")"
 
 # --- FAIL must be actionable (file ref + verb) ---
 assert_exit "FAIL with file ref and verb accepted"        0 "$(run_hook "code-architect-reviewer" "$FAIL_COMPLETE")"
@@ -74,6 +77,12 @@ assert_exit "guardian FAIL with file ref and verb ok"     0 "$(run_hook "docs-gu
 assert_exit "FAIL citing only a .yml file accepted"       0 "$(run_hook "security-reviewer" "VERDICT: FAIL — fix the download-artifact version in .github/workflows/ci.yml to match the upload step.")"
 assert_exit "FAIL citing only a .yaml file accepted"      0 "$(run_hook "security-reviewer" "VERDICT: FAIL — update the cache key in .github/actions/setup/action.yaml so it invalidates correctly.")"
 assert_exit "FAIL citing only a .toml file accepted"      0 "$(run_hook "docs-guardian" "VERDICT: FAIL — fix the wasm-bindgen pin in engine/Cargo.toml to restore the lockfile match.")"
+
+# --- 'tail -1' selects the LAST verdict token when output contains both ---
+# The gate resolves the verdict via `grep -oiE '\bPASS\b|\bFAIL\b' | tail -1`, so
+# a reviewer who corrects themselves mid-output is judged on their final word.
+assert_exit "FAIL then PASS: last verdict PASS, no file ref required" 0 "$(run_hook "security-reviewer" "VERDICT: FAIL — problem here. Actually: VERDICT: PASS")"
+assert_exit "PASS then FAIL: last verdict FAIL, requires file ref"    2 "$(run_hook "security-reviewer" "VERDICT: PASS — oops, wait. VERDICT: FAIL — no file here.")"
 
 # --- Fail-safe on malformed / non-JSON input (never propagate a jq error code) ---
 assert_exit "non-JSON stdin fails safe"                   0 "$(run_hook_raw 'not valid json {{{')"

--- a/.claude/hooks/__tests__/review-quality-gate.test.sh
+++ b/.claude/hooks/__tests__/review-quality-gate.test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Tests for review-quality-gate.sh (Stop-event verdict gate).
+#
+# Contract under test:
+#   exit 0  — non-reviewer agent, OR a reviewer whose output has a PASS verdict,
+#             OR a FAIL verdict that carries both a file reference and an
+#             actionable verb. Malformed/non-JSON stdin fails safe to exit 0.
+#   exit 2  — a reviewer whose output lacks any verdict, OR a FAIL verdict
+#             missing a file reference, OR a FAIL verdict missing an actionable
+#             verb.
+#
+# Unlike the SubagentStop sibling (reject-incomplete-review.test.sh), this gate
+# sees the reviewer's COMPLETE output, so it enforces the stricter shape.
+#
+# Run: bash .claude/hooks/__tests__/review-quality-gate.test.sh
+set -uo pipefail
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required to run these tests"; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$HERE/../review-quality-gate.sh"
+
+pass=0
+fail=0
+
+# run_hook <agent_type> <output> -> echoes the hook's exit code.
+run_hook() {
+  local agent_type="$1" output="$2"
+  jq -nc --arg t "$agent_type" --arg o "$output" '{agent_type:$t, output:$o}' \
+    | bash "$HOOK" >/dev/null 2>&1
+  echo $?
+}
+
+# run_hook_raw <raw_stdin> -> echoes the hook's exit code (malformed-input path).
+run_hook_raw() {
+  printf '%s' "$1" | bash "$HOOK" >/dev/null 2>&1
+  echo $?
+}
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass=$((pass + 1))
+    printf '  ok   %s (exit %s)\n' "$desc" "$actual"
+  else
+    fail=$((fail + 1))
+    printf '  FAIL %s (expected exit %s, got %s)\n' "$desc" "$expected" "$actual"
+  fi
+}
+
+FAIL_COMPLETE="VERDICT: FAIL — fix the missing await on the rateLimitPublicRoute() call in web/src/lib/api/foo.ts line 12."
+FAIL_NO_FILEREF="VERDICT: FAIL — add the missing guard before the deduction, it is required for correctness here."
+FAIL_NO_VERB="VERDICT: FAIL — the regression lives in web/src/lib/api/foo.ts and remains entirely unresolved as written."
+
+echo "review-quality-gate.sh"
+
+# --- Verdict present / non-reviewer ---
+assert_exit "non-reviewer agent is ignored"               0 "$(run_hook "builder" "no verdict at all here")"
+assert_exit "reviewer PASS verdict accepted"              0 "$(run_hook "security-reviewer" "Everything checks out. VERDICT: PASS")"
+assert_exit "guardian PASS verdict accepted"              0 "$(run_hook "dx-guardian" "Docs are accurate. VERDICT: PASS")"
+
+# --- Missing verdict blocks ---
+assert_exit "reviewer with no verdict blocks"             2 "$(run_hook "security-reviewer" "I looked at the diff and it seems mostly fine overall.")"
+
+# --- FAIL must be actionable (file ref + verb) ---
+assert_exit "FAIL with file ref and verb accepted"        0 "$(run_hook "code-architect-reviewer" "$FAIL_COMPLETE")"
+assert_exit "FAIL missing a file reference blocks"        2 "$(run_hook "security-reviewer" "$FAIL_NO_FILEREF")"
+assert_exit "FAIL missing an actionable verb blocks"      2 "$(run_hook "security-reviewer" "$FAIL_NO_VERB")"
+assert_exit "guardian FAIL with file ref and verb ok"     0 "$(run_hook "docs-guardian" "VERDICT: FAIL — update the table in .claude/rules/agent-operations.md")"
+
+# --- Fail-safe on malformed / non-JSON input (never propagate a jq error code) ---
+assert_exit "non-JSON stdin fails safe"                   0 "$(run_hook_raw 'not valid json {{{')"
+assert_exit "empty stdin fails safe"                      0 "$(run_hook_raw '')"
+
+echo ""
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/__tests__/review-quality-gate.test.sh
+++ b/.claude/hooks/__tests__/review-quality-gate.test.sh
@@ -68,6 +68,13 @@ assert_exit "FAIL missing a file reference blocks"        2 "$(run_hook "securit
 assert_exit "FAIL missing an actionable verb blocks"      2 "$(run_hook "security-reviewer" "$FAIL_NO_VERB")"
 assert_exit "guardian FAIL with file ref and verb ok"     0 "$(run_hook "docs-guardian" "VERDICT: FAIL — update the table in .claude/rules/agent-operations.md")"
 
+# --- FAIL citing only a config/workflow file is actionable (CI/infra/Rust reviews).
+# Use a *gated* agent type (matches reviewer|guardian) so the file-ref branch runs;
+# infra-devops/test-writer/architect are not matched by this gate and exit early. ---
+assert_exit "FAIL citing only a .yml file accepted"       0 "$(run_hook "security-reviewer" "VERDICT: FAIL — fix the download-artifact version in .github/workflows/ci.yml to match the upload step.")"
+assert_exit "FAIL citing only a .yaml file accepted"      0 "$(run_hook "security-reviewer" "VERDICT: FAIL — update the cache key in .github/actions/setup/action.yaml so it invalidates correctly.")"
+assert_exit "FAIL citing only a .toml file accepted"      0 "$(run_hook "docs-guardian" "VERDICT: FAIL — fix the wasm-bindgen pin in engine/Cargo.toml to restore the lockfile match.")"
+
 # --- Fail-safe on malformed / non-JSON input (never propagate a jq error code) ---
 assert_exit "non-JSON stdin fails safe"                   0 "$(run_hook_raw 'not valid json {{{')"
 assert_exit "empty stdin fails safe"                      0 "$(run_hook_raw '')"

--- a/.claude/hooks/reject-incomplete-review.sh
+++ b/.claude/hooks/reject-incomplete-review.sh
@@ -1,17 +1,27 @@
 #!/usr/bin/env bash
-# SubagentStop hook: if a reviewer subagent stops without posting a PASS/FAIL
-# verdict, exit 2 to send it back to finish the review.
+# SubagentStop hook: if a reviewer/guardian subagent stops without posting a
+# PASS/FAIL verdict, exit 2 to send it back to finish the review.
 #
-# HARDENING: a background subagent's SubagentStop `.output` is only a short
-# terse "tail" of its run (e.g. "Acknowledged.", "Hook validated. End."), not
-# the full review body it already returned to the orchestrator. Treating that
-# absence-of-verdict as a failure made this hook re-activate the agent forever
-# (exit 2 -> agent stops with the same terse tail -> exit 2 -> ...). We now only
-# loop-block when the output is SUBSTANTIVE — long enough to be a real review
-# body — and still lacks a verdict. Empty, whitespace-only, terse-tail, or
-# visibly errored output exits 0: there is no review body to send back to.
+# WHY THIS IS HARDENED (loop-bug fix):
+# A background subagent's SubagentStop `.output` is only a short terse "tail" of
+# its run (e.g. "Acknowledged.", "Hook validated. End."), NOT the full review
+# body it already returned to the orchestrator. Treating that absence-of-verdict
+# as a failure made this hook re-activate the agent forever:
+#   exit 2 -> agent stops with the same terse tail -> exit 2 -> ...
+# We now only loop-block when the output is SUBSTANTIVE — long enough to be a
+# real review body (>= MIN_REVIEW_CHARS) — and still lacks a verdict. Anything
+# unverifiable (empty, whitespace-only, a JSON error object, or a short tail)
+# exits 0: there is no review body to send back to, so blocking would only loop.
 #
-# Exit code 2 = block (Claude Code re-activates the agent with the message).
+# The MIN_REVIEW_CHARS heuristic is deliberately a LENGTH check on an inherently
+# truncated payload, not a content classifier: keyword/error-sniffing was removed
+# because case-insensitive prose openers (e.g. "fatal: ...") let real reviews slip
+# the gate. The authoritative full-output verdict gate is review-quality-gate.sh,
+# which runs on the Stop event where the complete review IS present. Here, when in
+# doubt we err toward exit 0 (allow) — the safe, non-looping direction for a tail.
+#
+# Exit code 2 = block (Claude Code re-activates the agent with the message below).
+# Any other path exits 0 (allow). Malformed input fails safe to allow.
 
 set -euo pipefail
 
@@ -21,10 +31,14 @@ set -euo pipefail
 MIN_REVIEW_CHARS=200
 
 INPUT=$(cat)
-AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null)
-OUTPUT=$(echo "$INPUT" | jq -r '.output // ""' 2>/dev/null)
 
-# Only enforce on reviewer/guardian agents
+# Fail safe: malformed / non-JSON input must never propagate a jq error through
+# `set -e` (an undefined hook exit code) — default to a non-reviewer/empty payload
+# so the hook allows the stop rather than blocking on garbage it cannot parse.
+AGENT_TYPE=$(printf '%s' "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null || echo "unknown")
+OUTPUT=$(printf '%s' "$INPUT" | jq -r '.output // ""' 2>/dev/null || echo "")
+
+# Only enforce on reviewer/guardian agents.
 if ! echo "$AGENT_TYPE" | grep -qiE "reviewer|guardian"; then
   exit 0
 fi
@@ -41,20 +55,21 @@ TRIMMED=$(printf '%s' "$OUTPUT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$
 
 # Empty / whitespace-only -> nothing to send back to.
 if [ -z "$TRIMMED" ]; then
+  echo "[reject-incomplete-review] empty output — allowing stop (no review body)" >&2
   exit 0
 fi
 
-# Errored/interrupted run that dumped a stack trace instead of a review. The
-# markers are anchored to the start and use formats (colon/paren-delimited) that
-# do not occur at the head of normal review prose, so review content that merely
-# discusses errors, timeouts, or rate limits is NOT matched here.
-if printf '%s' "$TRIMMED" | grep -qiE \
-  '^(Traceback \(most recent call last\)|Error: |Uncaught |Unhandled |panic:|fatal:|Aborted|Killed|Segmentation fault)'; then
+# A JSON object (platform/runtime error blob, not review prose). Review bodies
+# never begin with '{'; this is the one structural shape we treat as non-review
+# regardless of length, so a long error object cannot loop the agent.
+if [ "${TRIMMED:0:1}" = "{" ]; then
+  echo "[reject-incomplete-review] output is a JSON object, not a review — allowing stop" >&2
   exit 0
 fi
 
 # Terse subagent completion tail (not the full review body) -> unverifiable.
 if [ "${#TRIMMED}" -lt "$MIN_REVIEW_CHARS" ]; then
+  echo "[reject-incomplete-review] output is ${#TRIMMED} chars (< $MIN_REVIEW_CHARS) — terse tail, allowing stop" >&2
   exit 0
 fi
 

--- a/.claude/hooks/reject-incomplete-review.sh
+++ b/.claude/hooks/reject-incomplete-review.sh
@@ -1,26 +1,64 @@
 #!/usr/bin/env bash
-# TeammateIdle hook: if a reviewer goes idle without posting a PASS/FAIL verdict,
-# exit code 2 to send them back to work.
+# SubagentStop hook: if a reviewer subagent stops without posting a PASS/FAIL
+# verdict, exit 2 to send it back to finish the review.
 #
-# Exit code 2 = block (Claude Code re-activates the agent with the rejection message).
+# HARDENING: a background subagent's SubagentStop `.output` is only a short
+# terse "tail" of its run (e.g. "Acknowledged.", "Hook validated. End."), not
+# the full review body it already returned to the orchestrator. Treating that
+# absence-of-verdict as a failure made this hook re-activate the agent forever
+# (exit 2 -> agent stops with the same terse tail -> exit 2 -> ...). We now only
+# loop-block when the output is SUBSTANTIVE — long enough to be a real review
+# body — and still lacks a verdict. Empty, whitespace-only, terse-tail, or
+# visibly errored output exits 0: there is no review body to send back to.
+#
+# Exit code 2 = block (Claude Code re-activates the agent with the message).
 
 set -euo pipefail
+
+# Minimum trimmed length for output to count as a real, verifiable review body.
+# Terse subagent completion tails are far shorter than this; a genuine review
+# that omits only its verdict is well above it.
+MIN_REVIEW_CHARS=200
 
 INPUT=$(cat)
 AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null)
 OUTPUT=$(echo "$INPUT" | jq -r '.output // ""' 2>/dev/null)
 
-# Only enforce on reviewer agents
+# Only enforce on reviewer/guardian agents
 if ! echo "$AGENT_TYPE" | grep -qiE "reviewer|guardian"; then
   exit 0
 fi
 
-# Check for a clear PASS or FAIL verdict
+# A clear PASS or FAIL verdict is all we require — accept and move on.
 if echo "$OUTPUT" | grep -qiE '\bPASS\b|\bFAIL\b'; then
   exit 0
 fi
 
-# No verdict found — send reviewer back to work
+# --- Hardening: never loop-block on unverifiable output ---
+
+# Trim surrounding whitespace so we measure real content.
+TRIMMED=$(printf '%s' "$OUTPUT" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+
+# Empty / whitespace-only -> nothing to send back to.
+if [ -z "$TRIMMED" ]; then
+  exit 0
+fi
+
+# Errored/interrupted run that dumped a stack trace instead of a review. The
+# markers are anchored to the start and use formats (colon/paren-delimited) that
+# do not occur at the head of normal review prose, so review content that merely
+# discusses errors, timeouts, or rate limits is NOT matched here.
+if printf '%s' "$TRIMMED" | grep -qiE \
+  '^(Traceback \(most recent call last\)|Error: |Uncaught |Unhandled |panic:|fatal:|Aborted|Killed|Segmentation fault)'; then
+  exit 0
+fi
+
+# Terse subagent completion tail (not the full review body) -> unverifiable.
+if [ "${#TRIMMED}" -lt "$MIN_REVIEW_CHARS" ]; then
+  exit 0
+fi
+
+# Substantive review body that genuinely omits a verdict — send it back.
 echo "REVIEW INCOMPLETE: You have not posted a clear PASS or FAIL verdict."
 echo ""
 echo "You MUST end your review with one of:"

--- a/.claude/hooks/review-quality-gate.sh
+++ b/.claude/hooks/review-quality-gate.sh
@@ -6,6 +6,17 @@
 #   3. Actionable findings (not just a summary)
 #
 # Exit code 2 = block (sends the reviewer back to complete the review).
+#
+# DIVERGENCE FROM reject-incomplete-review.sh (intentional — do not "unify"):
+# This runs on the *Stop* event, where `.output` is the reviewer's COMPLETE
+# output, so it can safely demand a verdict + file ref + actionable verb and
+# block hard when any is missing. Its SubagentStop sibling
+# (reject-incomplete-review.sh) sees only a short terse "tail" of the run, not
+# the full review, so it deliberately does the opposite — it errs toward
+# allowing the stop and only blocks on a substantive-but-verdict-less body, to
+# avoid an infinite re-activation loop. The terse-tail hardening lives there,
+# NOT here; this gate needs no length/JSON heuristics because its payload is
+# always the real thing.
 
 set -euo pipefail
 

--- a/.claude/hooks/review-quality-gate.sh
+++ b/.claude/hooks/review-quality-gate.sh
@@ -48,8 +48,10 @@ VERDICT=$(echo "$OUTPUT" | grep -oiE '\bPASS\b|\bFAIL\b' | tail -1 | tr '[:lower
 
 # On FAIL, verify there are actionable findings
 if [ "$VERDICT" = "FAIL" ]; then
-  # Check for file references (e.g. src/lib/foo.ts, engine/src/bridge.rs)
-  if ! echo "$OUTPUT" | grep -qE '[a-zA-Z0-9_/-]+\.(ts|tsx|rs|sh|json|md|py|js|jsx)'; then
+  # Check for file references (e.g. src/lib/foo.ts, engine/src/bridge.rs,
+  # .github/workflows/ci.yml, engine/Cargo.toml — CI/infra/Rust reviews cite
+  # config files, so yml/yaml/toml count as actionable references too).
+  if ! echo "$OUTPUT" | grep -qE '[a-zA-Z0-9_/-]+\.(ts|tsx|rs|sh|json|md|py|js|jsx|yml|yaml|toml)'; then
     echo "REVIEW INCOMPLETE: FAIL verdict requires at least one file reference."
     echo ""
     echo "Specify the exact file(s) affected by each finding."

--- a/.claude/hooks/review-quality-gate.sh
+++ b/.claude/hooks/review-quality-gate.sh
@@ -21,8 +21,11 @@
 set -euo pipefail
 
 INPUT=$(cat)
-AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null)
-OUTPUT=$(echo "$INPUT" | jq -r '.output // ""' 2>/dev/null)
+# Fail safe on malformed / non-JSON input: a jq parse error must not propagate
+# an undefined exit code through `set -e` — default to a non-reviewer/empty
+# payload so the gate allows the stop rather than aborting on unparseable input.
+AGENT_TYPE=$(printf '%s' "$INPUT" | jq -r '.agent_type // "unknown"' 2>/dev/null || echo "unknown")
+OUTPUT=$(printf '%s' "$INPUT" | jq -r '.output // ""' 2>/dev/null || echo "")
 
 # Only enforce on reviewer/guardian agents — non-reviewers don't produce verdicts
 if ! echo "$AGENT_TYPE" | grep -qiE "reviewer|guardian"; then

--- a/.claude/rules/agent-operations.md
+++ b/.claude/rules/agent-operations.md
@@ -289,14 +289,27 @@ bash .claude/hooks/__tests__/reject-incomplete-review.test.sh
 # All hook test suites
 for t in .claude/hooks/__tests__/*.test.sh; do echo "== $t =="; bash "$t" || break; done
 
-# Lint every hook + test (zero findings required, same bar as web lint)
-shellcheck .claude/hooks/*.sh .claude/hooks/__tests__/*.test.sh
+# Lint the review-loop hooks this gate owns — zero findings required, and the CI
+# `hook-tests` job (.github/workflows/ci.yml) runs exactly this. Newly added or
+# edited hooks MUST be shellcheck-clean.
+shellcheck \
+  .claude/hooks/reject-incomplete-review.sh \
+  .claude/hooks/review-quality-gate.sh \
+  .claude/hooks/__tests__/reject-incomplete-review.test.sh \
+  .claude/hooks/__tests__/review-quality-gate.test.sh
+
+# Linting the WHOLE tree still surfaces ~10 pre-existing findings across 8 older
+# hooks (tracked in #8676). Scope shellcheck to the files you touched until that
+# cleanup lands rather than treating the legacy debt as a regression:
+#   shellcheck .claude/hooks/*.sh .claude/hooks/__tests__/*.test.sh
 ```
 
 Each suite is a self-contained bash script that exits non-zero if any case fails
 (no bats dependency — bats is not installed). See
 `.claude/hooks/__tests__/reject-incomplete-review.test.sh` as the canonical
-pattern.
+pattern. CI runs every `*.test.sh` under `.claude/hooks/__tests__/` via the
+path-gated `hook-tests` job whenever `.claude/hooks/**` changes, so a regression
+in a hook's exit-code contract fails the PR instead of silently shipping.
 
 ### Writing a hook test
 

--- a/.claude/rules/agent-operations.md
+++ b/.claude/rules/agent-operations.md
@@ -271,3 +271,43 @@ Claude Code only loads `CLAUDE.md` and `.claude/CLAUDE.md` on `SessionStart`. Af
 To test the hook manually: `bash .claude/hooks/inject-post-compact.sh`. To see the wall-clock cost: `time bash .claude/hooks/inject-post-compact.sh > /dev/null`. To verify the size budget: `bash .claude/hooks/inject-post-compact.sh | wc -c` (should be well under 10000).
 
 When you add a new file under `.claude/rules/`, the glob picks it up automatically — but the pointer-table summary in the hook is a hardcoded `case` block. Add a one-line summary for the new file there so the agent knows what topic the file covers.
+
+## 12. Testing Hooks (`.claude/hooks/__tests__/`)
+
+Hooks with non-trivial logic (verdict gates, deferred-fix detection, metadata
+checks) get a co-located bash test next to the hook under `.claude/hooks/__tests__/`.
+A hook silently exiting the wrong code is a hard-to-spot failure — a SubagentStop
+gate that loops, or a PreToolUse gate that blocks valid work — so these are tested
+like any other code, TEST-FIRST.
+
+### Running hook tests
+
+```bash
+# A single hook's suite
+bash .claude/hooks/__tests__/reject-incomplete-review.test.sh
+
+# All hook test suites
+for t in .claude/hooks/__tests__/*.test.sh; do echo "== $t =="; bash "$t" || break; done
+
+# Lint every hook + test (zero findings required, same bar as web lint)
+shellcheck .claude/hooks/*.sh .claude/hooks/__tests__/*.test.sh
+```
+
+Each suite is a self-contained bash script that exits non-zero if any case fails
+(no bats dependency — bats is not installed). See
+`.claude/hooks/__tests__/reject-incomplete-review.test.sh` as the canonical
+pattern.
+
+### Writing a hook test
+
+- Drive the hook through its real contract: build the JSON payload (Edit/Write
+  hooks read `TOOL_INPUT_*` env vars; Stop/SubagentStop/Bash hooks read stdin
+  JSON) with `jq -nc --arg ...`, pipe it to `bash "$HOOK"`, and assert on `$?`.
+  Exit 0 = allow/continue, exit 2 = block — those two codes ARE the behavior, so
+  assert on them directly.
+- Cover the boundary, the fail-safe, and the "looks-like-but-isn't" cases, not
+  just the happy path — e.g. exact length thresholds, malformed/non-JSON stdin
+  (must fail safe, never propagate a `jq` error code through `set -e`), and
+  word-boundary near-misses (`PASSED` is not the `PASS` verdict).
+- Guard host assumptions at the top (`command -v jq` etc.) so a missing tool
+  reports clearly instead of every case failing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,9 @@ jobs:
       - run: npm ci
 
       - name: Download blob reports
-        uses: actions/download-artifact@v8
+        # Must match the upload-artifact major version used for blob-report-*
+        # above (@v4) — mixing artifact action majors is a documented gotcha.
+        uses: actions/download-artifact@v4
         with:
           path: web/all-blob-reports
           pattern: blob-report-*
@@ -522,7 +524,9 @@ jobs:
           failed=$(jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key' needs.json)
           if [ -n "$failed" ]; then
             echo "::error::Required CI gate(s) failed or were cancelled:"
-            echo "$failed" | sed 's/^/  - /'
+            while IFS= read -r line; do
+              echo "  - $line"
+            done <<< "$failed"
             exit 1
           fi
           echo "All required gates passed (or were correctly skipped via path filter)."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       needs-ci: ${{ steps.changes.outputs.ci }}
       needs-docs: ${{ steps.changes.outputs.docs }}
       needs-design: ${{ steps.changes.outputs.design }}
+      needs-hooks: ${{ steps.changes.outputs.hooks }}
       needs-any-code: ${{ steps.changes.outputs.any-code }}
     steps:
       - uses: actions/checkout@v6
@@ -45,7 +46,7 @@ jobs:
         run: |
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
 
-          web=false; engine=false; mcp=false; ci=false; docs=false; design=false
+          web=false; engine=false; mcp=false; ci=false; docs=false; design=false; hooks=false
 
           echo "$CHANGED" | grep -q '^web/' && web=true
           echo "$CHANGED" | grep -q '^engine/' && engine=true
@@ -53,24 +54,32 @@ jobs:
           echo "$CHANGED" | grep -qE '^\.github/workflows/|^scripts/|^package\.json|^package-lock\.json|^\.claude/skills/.*/scripts/' && ci=true
           echo "$CHANGED" | grep -qE '^apps/docs/|^mcp-server/manifest/' && docs=true
           echo "$CHANGED" | grep -qE '^apps/design/|^packages/ui/' && design=true
+          # Claude Code hook scripts + their self-contained bash test suites.
+          # Kept OUT of `ci` and any-code on purpose: a hook change must trigger
+          # ONLY the lightweight hook-tests job, never the heavy quality-gates
+          # fan-out (lint/typecheck/test-web/test-mcp/build-wasm).
+          echo "$CHANGED" | grep -qE '^\.claude/hooks/' && hooks=true
 
           any_code=false
           if [ "$web" = "true" ] || [ "$engine" = "true" ] || [ "$mcp" = "true" ] || [ "$ci" = "true" ] || [ "$docs" = "true" ] || [ "$design" = "true" ]; then
             any_code=true
           fi
 
-          echo "web=$web" >> "$GITHUB_OUTPUT"
-          echo "engine=$engine" >> "$GITHUB_OUTPUT"
-          echo "mcp=$mcp" >> "$GITHUB_OUTPUT"
-          echo "ci=$ci" >> "$GITHUB_OUTPUT"
-          echo "docs=$docs" >> "$GITHUB_OUTPUT"
-          echo "design=$design" >> "$GITHUB_OUTPUT"
-          echo "any-code=$any_code" >> "$GITHUB_OUTPUT"
+          {
+            echo "web=$web"
+            echo "engine=$engine"
+            echo "mcp=$mcp"
+            echo "ci=$ci"
+            echo "docs=$docs"
+            echo "design=$design"
+            echo "hooks=$hooks"
+            echo "any-code=$any_code"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Changed paths detected:"
-          echo "  web=$web engine=$engine mcp=$mcp ci=$ci docs=$docs design=$design any-code=$any_code"
-          if [ "$any_code" = "false" ]; then
-            echo "No code changes — downstream jobs will be skipped"
+          echo "  web=$web engine=$engine mcp=$mcp ci=$ci docs=$docs design=$design hooks=$hooks any-code=$any_code"
+          if [ "$any_code" = "false" ] && [ "$hooks" = "false" ]; then
+            echo "No relevant changes — downstream jobs will be skipped"
           fi
 
   # ---- Quality Gates (reusable workflow shared with CD) ----
@@ -209,6 +218,53 @@ jobs:
 
       - name: Build Storybook
         run: cd apps/design && npx storybook build -o storybook-static
+
+  # ---- Hook Tests ----
+  # Runs when .claude/hooks/** changed. Executes the self-contained bash test
+  # suites that guard the reviewer-loop hooks (reject-incomplete-review.sh and
+  # review-quality-gate.sh), so a regression in their exit-code contract is
+  # caught in CI instead of silently looping or letting incomplete reviews
+  # through. Gated on its own `hooks` path output (NOT any-code) so hook-only
+  # PRs pay only this ~30s gate, never the full quality-gates fan-out.
+  hook-tests:
+    name: Hook Tests
+    needs: [ci-gate]
+    if: ${{ needs.ci-gate.outputs.needs-hooks == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run hook test suites
+        run: |
+          # jq + shellcheck are preinstalled on ubuntu-latest runners.
+          shopt -s nullglob
+          suites=(.claude/hooks/__tests__/*.test.sh)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "::error::No hook test suites found under .claude/hooks/__tests__/"
+            exit 1
+          fi
+          rc=0
+          for suite in "${suites[@]}"; do
+            echo "::group::$suite"
+            bash "$suite" || rc=1
+            echo "::endgroup::"
+          done
+          exit "$rc"
+
+      - name: Shellcheck the hooks owned by this change
+        run: |
+          # Scope shellcheck to the hardened review hooks + their tests only.
+          # The wider .claude/hooks/ tree carries pre-existing findings tracked
+          # separately (see .claude/rules/agent-operations.md §12) — linting all
+          # of it here would fail this gate on unrelated, untouched debt.
+          shellcheck \
+            .claude/hooks/reject-incomplete-review.sh \
+            .claude/hooks/review-quality-gate.sh \
+            .claude/hooks/__tests__/reject-incomplete-review.test.sh \
+            .claude/hooks/__tests__/review-quality-gate.test.sh
 
   # ---- Preview Deployment (PR only) ----
   # Deploys a Vercel preview for every PR so reviewers can test changes without
@@ -451,6 +507,7 @@ jobs:
       - build-nextjs
       - docs-internal-gate
       - design-internal-gate
+      - hook-tests
       - test-e2e-ui
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

Hardens the two sibling reviewer-loop hooks and adds a path-gated CI suite for them.

- **`reject-incomplete-review.sh` (SubagentStop)** no longer infinitely re-activates a reviewer subagent on a terse completion tail. It now blocks (`exit 2`) only on a *substantive-but-verdict-less* body and otherwise fails safe (`exit 0`) on empty/whitespace/JSON-object/short-tail/malformed output. The previous case-insensitive keyword error-heuristic (a security-relevant bypass) is removed in favour of a pure `MIN_REVIEW_CHARS` threshold + a `{`-prefix JSON-object structural guard + a jq fail-safe.
- **`review-quality-gate.sh` (Stop)** is made fail-safe on non-JSON/empty stdin (a jq parse error can no longer propagate an undefined exit code through `set -e`), and its FAIL file-reference check now accepts `yml`/`yaml`/`toml` so a CI/infra/Rust reviewer citing only a workflow or `Cargo.toml` is no longer spuriously blocked.
- The two hooks **diverge intentionally by event** (Stop sees the full output -> strict; SubagentStop sees only a terse tail -> lenient). The divergence is cross-documented in both files so they are not naively "unified".
- **CI:** a new path-gated `hook-tests` job runs every `.claude/hooks/__tests__/*.test.sh` and shellchecks the files this branch owns. It is keyed on a dedicated `hooks` ci-gate output kept **out** of `any-code`, so a hook-only PR triggers **only** this lightweight job — never the heavy quality-gates fan-out. A ci.yml edit still correctly triggers the full gates.
- **Boy Scout:** aligned `merge-e2e-reports` `download-artifact@v8` -> `@v4` (the blob-report pair is now v4<->v4), and replaced an SC2001 `sed` in the `ci-success` gate with a shellcheck-clean `while read` loop. `actionlint .github/workflows/ci.yml` now reports zero findings.

Closes #8675

Pre-existing static-analysis debt in the 8 untouched hook scripts is tracked separately in #8676 (the SC2001 item there is resolved by this PR).

## Test plan

- [x] `bash .claude/hooks/__tests__/review-quality-gate.test.sh` — 16/16 (covers FAIL reviews citing only `.yml`/`.yaml`/`.toml`, a guardian no-verdict block, and the `tail -1` last-verdict-wins rule — all via a gated reviewer/guardian agent_type)
- [x] `bash .claude/hooks/__tests__/reject-incomplete-review.test.sh` — 19/19 (covers a guardian-type substantive no-verdict body blocking, alongside the terse-tail / threshold / fail-safe cases)
- [x] `shellcheck` clean on the 4 owned hook/test files
- [x] `actionlint .github/workflows/ci.yml` — zero findings
- [x] Blast radius verified both directions: hook-only PR -> only `hook-tests`; ci.yml edit -> full gates
- [x] 6 specialized reviewers (architect, security, dx, test, infra-devops, docs-guardian) — PASS