### PR TITLE
ci(changeset): skip changeset gate for non-npm Dependabot PRs

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -13,11 +13,13 @@ jobs:
     name: Require Changeset
     runs-on: ubuntu-latest
     steps:
-      - name: Skip if label present or Version Packages PR
+      - name: Skip for label, Version Packages, or non-npm Dependabot PR
         id: skip
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          ACTOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # Bypass for "skip changeset" label
           if echo "$LABELS" | grep -q '"skip changeset"'; then
@@ -30,6 +32,24 @@ jobs:
           if [[ "$PR_TITLE" == "chore: version packages"* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Changeset check bypassed — Version Packages PR."
+            exit 0
+          fi
+          # Bypass for Dependabot PRs in ecosystems that are NOT npm-versioned:
+          # cargo crates (compiled into the WASM engine) and pinned GitHub
+          # Actions. A changeset is structurally inapplicable to these —
+          # .changeset/config.json only version-manages the npm workspace
+          # packages (web, @spawnforge/ui, mcp-server, root). npm bumps
+          # (dependabot/npm_and_yarn/*) are deliberately NOT matched, so a
+          # user-facing web / @spawnforge/ui / mcp-server runtime bump still
+          # needs a changeset or the explicit 'skip changeset' label. Uses the
+          # same actor-gating idiom as pr-workitem-check.yml's Dependabot
+          # exemption, but narrower in scope: that job skips ALL Dependabot PRs
+          # (actor-only), whereas this skips only the non-npm ecosystems (by
+          # branch prefix), so npm bumps still reach the gate.
+          if [[ "$ACTOR" == "dependabot[bot]" ]] && \
+             [[ "$HEAD_REF" == dependabot/cargo/* || "$HEAD_REF" == dependabot/github_actions/* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Changeset check bypassed — Dependabot non-npm ecosystem (cargo/github-actions); no npm package to version."
             exit 0
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/changeset-gate-tests.yml
+++ b/.github/workflows/changeset-gate-tests.yml
@@ -1,0 +1,30 @@
+name: Changeset Gate Tests
+
+# Exercises the inline "skip" decision of changeset-check.yml via its co-located
+# bash suite. The decision logic must stay inline in the gate workflow (it runs
+# before checkout), so the test extracts the real `run:` block and runs it — this
+# job guards that contract against silent drift. Standalone (like the gate it
+# tests), path-gated so it only runs when the gate or its test changes; it is not
+# part of ci.yml's ci-success aggregate.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/changeset-check.yml'
+      - '.github/workflows/changeset-gate-tests.yml'
+      - 'scripts/__tests__/changeset-skip-decision.test.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  skip-decision:
+    name: Changeset Skip Decision
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Shellcheck the suite
+        run: shellcheck scripts/__tests__/changeset-skip-decision.test.sh
+      - name: Run skip-decision suite
+        run: bash scripts/__tests__/changeset-skip-decision.test.sh

--- a/scripts/__tests__/changeset-skip-decision.test.sh
+++ b/scripts/__tests__/changeset-skip-decision.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Unit tests for the "skip" decision in .github/workflows/changeset-check.yml.
+#
+# The skip decision runs BEFORE checkout (so the gate is cheap for PRs it does
+# not apply to), which means the logic MUST live inline in the workflow YAML —
+# it cannot be factored into a repo-file script the workflow sources. To test it
+# without a drifting copy, this suite extracts the real `run:` block of the step
+# with `id: skip` straight from the workflow and exercises it under mocked PR
+# contexts, in the same `bash -eo pipefail` shell GitHub Actions uses for `run:`.
+set -uo pipefail
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 required"; exit 1; }
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="$HERE/../../.github/workflows/changeset-check.yml"
+FAILURES=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+[ -f "$WORKFLOW" ] || { echo "workflow not found: $WORKFLOW"; exit 1; }
+
+# Extract the bash body of the step whose id is `skip` — the single source of
+# truth. No PyYAML dependency: walk indentation from `id: skip` to the next
+# `run: |`, capture the block scalar, and dedent it.
+SKIP_SCRIPT="$(python3 - "$WORKFLOW" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+try:
+    i = next(idx for idx, l in enumerate(lines) if l.strip() == "id: skip")
+    j = next(idx for idx in range(i, len(lines)) if lines[idx].strip().startswith("run: |"))
+except StopIteration:
+    sys.exit("could not locate the `id: skip` step's run block")
+run_indent = len(lines[j]) - len(lines[j].lstrip())
+body = []
+for l in lines[j + 1:]:
+    if l.strip() == "":
+        body.append("")
+        continue
+    if (len(l) - len(l.lstrip())) <= run_indent:
+        break
+    body.append(l)
+nonempty = [l for l in body if l.strip()]
+common = min((len(l) - len(l.lstrip()) for l in nonempty), default=0)
+print("\n".join(l[common:] if l.strip() else "" for l in body))
+PY
+)"
+
+if [ -z "${SKIP_SCRIPT// /}" ]; then
+  echo "FAILED to extract the skip step's run block"
+  exit 1
+fi
+
+# Run the extracted decision under the same shell flags GitHub Actions uses for
+# `run:` blocks (bash -e -o pipefail), with a throwaway GITHUB_OUTPUT, and echo
+# the resulting skip value.
+run_decision() {
+  local labels="$1" title="$2" actor="$3" head="$4"
+  local out
+  out="$(mktemp)"
+  LABELS="$labels" PR_TITLE="$title" ACTOR="$actor" HEAD_REF="$head" GITHUB_OUTPUT="$out" \
+    bash -eo pipefail -c "$SKIP_SCRIPT" >/dev/null 2>&1
+  grep -oE 'skip=(true|false)' "$out" | tail -1 | cut -d= -f2
+  rm -f "$out"
+}
+
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$desc (skip=$actual)"
+  else
+    fail "$desc — expected skip=$expected, got '$actual'"
+  fi
+}
+
+echo "=== changeset-check.yml skip-decision tests ==="
+
+# --- Preserved behavior (label + Version Packages title) -----------------------
+check "skip changeset label bypasses" true \
+  "$(run_decision '["skip changeset"]' 'fix: a thing' 'human' 'feature/x')"
+check "Version Packages PR bypasses" true \
+  "$(run_decision '[]' 'chore: version packages' 'github-actions[bot]' 'changeset-release/main')"
+
+# --- New behavior: Dependabot non-npm ecosystems bypass ------------------------
+check "dependabot cargo bump bypasses" true \
+  "$(run_decision '["dependencies"]' 'chore(deps): bump emath' 'dependabot[bot]' 'dependabot/cargo/engine/emath-0.34.3')"
+check "dependabot github_actions bump bypasses" true \
+  "$(run_decision '["dependencies"]' 'chore(deps): bump gh-aw' 'dependabot[bot]' 'dependabot/github_actions/github/gh-aw-abc123')"
+
+# --- npm Dependabot is deliberately NOT bypassed (a user-facing runtime bump
+#     still needs a changeset decision, or the explicit label) -----------------
+check "dependabot npm bump is NOT bypassed" false \
+  "$(run_decision '["dependencies"]' 'chore(deps): bump portless' 'dependabot[bot]' 'dependabot/npm_and_yarn/web/minor-and-patch-x')"
+check "dependabot npm bump WITH skip label still bypasses (label path intact)" true \
+  "$(run_decision '["skip changeset"]' 'chore(deps): bump portless' 'dependabot[bot]' 'dependabot/npm_and_yarn/web/x')"
+
+# --- Actor-gated: a human pushing a dependabot-looking branch is NOT bypassed --
+check "non-dependabot actor on a cargo-prefixed branch is NOT bypassed" false \
+  "$(run_decision '[]' 'feat: x' 'human' 'dependabot/cargo/engine/x')"
+
+# --- Ordinary PR is not bypassed ----------------------------------------------
+check "ordinary feature PR is not bypassed" false \
+  "$(run_decision '[]' 'feat: add a feature' 'human' 'feature/add-a-feature')"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "$FAILURES test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The **Require Changeset** gate (`.github/workflows/changeset-check.yml`) FAILs on every Dependabot PR for an ecosystem that `.changeset/config.json` does not version-manage — **cargo crates** (compiled into the WASM engine) and **GitHub Actions**. A changeset is structurally inapplicable to those bumps (there is no npm package to version), so the only unstick today is a manual `skip changeset` label on each PR (which is exactly what had to be done for #8656–#8660).

This adds a third inline early-pass branch to the gate's pre-checkout `skip` step: when the actor is `dependabot[bot]` **and** the head ref is `dependabot/cargo/*` or `dependabot/github_actions/*`, the changeset requirement is skipped.

`dependabot/npm_and_yarn/*` is **deliberately NOT matched** — a user-facing `web` / `@spawnforge/ui` / `mcp-server` runtime bump still needs a changeset (or the explicit `skip changeset` label) so a human decides on release notes.

## Why the logic stays inline

The `skip` step runs **before** checkout (so the gate is cheap for PRs it does not apply to), which means the decision cannot be factored into a repo-file script the workflow sources. To guard the inline logic against silent drift, `scripts/__tests__/changeset-skip-decision.test.sh` extracts the real `run:` block straight from the workflow and exercises it under the same `bash -eo pipefail` shell GitHub Actions uses for `run:`, across 8 cases (label, Version Packages, cargo-skip, actions-skip, npm-NOT-skip, npm+label, actor-gating, ordinary PR).

A standalone, path-gated workflow (`changeset-gate-tests.yml`) runs the suite + shellcheck whenever the gate or its test changes. It is standalone (like the gate it tests) — **not** a job in `ci.yml` — to avoid colliding with the open `ci.yml` change in #8677.

## Safety

`HEAD_REF` (`github.event.pull_request.head.ref`, an attacker-controllable field) is bound via `env:` and only ever compared as a glob inside `[[ ]]` — never interpolated into the `run:` string. Uses the same actor-gating idiom as `pr-workitem-check.yml`'s Dependabot exemption, but narrower in scope (that job skips ALL Dependabot PRs by actor; this skips only the non-npm ecosystems by branch prefix).

Closes #8678

## Test plan

- [x] `actionlint` clean on both workflows
- [x] `shellcheck` clean on the test suite
- [x] `bash scripts/__tests__/changeset-skip-decision.test.sh` — all 8 cases pass
- [x] npm Dependabot bump proven NOT bypassed (still reaches the gate)
- [ ] CI: `Changeset Gate Tests` runs green on this PR