### PR TITLE
fix(deps): regenerate root lockfile for portless 0.13.1 (unbreak npm ci on main)

### DIFF
--- a/.changeset/fix-lockfile-sync-anthropic-portless.md
+++ b/.changeset/fix-lockfile-sync-anthropic-portless.md
@@ -2,9 +2,9 @@
 "web": patch
 ---
 
-fix(deps): resolve `package-lock.json` drift that broke `npm ci` (used by the Vercel preview-deploy job) repo-wide with EUSAGE.
+fix(deps): resolve a root `package-lock.json` drift that broke frozen `npm ci` repo-wide with EUSAGE (the Vercel preview-deploy job and every Quality Gates job that runs `npm ci` as setup).
 
-- `@anthropic-ai/sdk`: lockfile still resolved `0.93.0` while `web/package.json` declared `^0.100.1` — synced the lockfile to `0.100.1` (no `engines` constraint; no runtime code imports it directly, the Anthropic path goes through `@ai-sdk/anthropic`).
-- `portless`: a Dependabot bump set `web/package.json` to `^0.13.1`, but `portless@0.13.1` requires Node `>=24` while this repo targets Node 20 (`.nvmrc`, `engines ">=20 <25"`, all CI `node-version: 20`). The lockfile had never moved off the Node-20-compatible `0.12.0`. Reverted the declaration to `^0.12.0` to match, and added a `dependabot.yml` ignore for `portless >=0.13.1` so it can still advance to `0.13.0` (Node `>=20`) but won't re-grab the Node-24-only line until the repo adopts Node 24.
+- `@anthropic-ai/sdk`: the lockfile still resolved `0.93.0` while `web/package.json` declared `^0.100.1` — synced the lockfile to `0.100.1` (no `engines` constraint; no runtime code imports it directly, the Anthropic path goes through `@ai-sdk/anthropic`).
+- `portless`: `web/package.json` declares `^0.13.0`, but the root lockfile had drifted — it still pinned the Node-20-era `0.12.0`, which does **not** satisfy `^0.13.0`, so frozen `npm ci` failed with `EUSAGE Missing: portless@0.13.x from lock file`. Regenerated the root lockfile to `portless@0.13.1`, the newest line satisfying `^0.13.0`, which requires Node `>=24`. That is correct for this repo — it targets Node 24 (`.node-version` = `24`, `engines.node` `">=24 <25"`). This is a **forward-fix to match the manifest, not a revert**, and no `dependabot.yml` ignore is involved.
 
 No source change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18222,6 +18222,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/portless": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/portless/-/portless-0.13.1.tgz",
+      "integrity": "sha512-1B+8Xd4tB1gOIkRHOUEi/LCOp8PIxUsL3ACBX5G2UkKw25TSRNUqAlQcBGxweJgdXb9DPQFX5utKLRUzPFhMnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "portless": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -21941,7 +21959,7 @@
         "eslint": "^9",
         "eslint-config-next": "^16.2.3",
         "jsdom": "^29.0.1",
-        "portless": "^0.12.0",
+        "portless": "^0.13.0",
         "tailwindcss": "^4",
         "typescript": "^6",
         "vitest": "^4.1.7"
@@ -22128,24 +22146,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "web/node_modules/portless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/portless/-/portless-0.12.0.tgz",
-      "integrity": "sha512-zE8EYJ5xIEtKEBu1wnD+FavOE90/GNxRixF4Mu2hxMvDuVx1ftUbA6VbjbxI9sP9LUt0L26l6OiENGo4EFtLfw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "os": [
-        "darwin",
-        "linux",
-        "win32"
-      ],
-      "bin": {
-        "portless": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20"
       }
     }
   }


### PR DESCRIPTION
## Summary

`origin/main` is currently broken for `npm ci` — **every** open PR fails at `Run npm ci`:

```
npm error code EUSAGE
npm error Missing: portless@0.13.1 from lock file
```

This regenerates the root `package-lock.json` so portless resolves to `0.13.1`, matching the `^0.13.0` already declared in `web/package.json`.

## Root cause

- #8658 bumped `web/package.json` portless `^0.12.0` → `^0.13.0` (caret) but touched **only the manifest**. This is a single-root-lockfile monorepo, so Dependabot's `directory: /web` could not regenerate the root lockfile.
- `^0.13.0` resolves to latest `0.13.1`; lockfile still pinned `0.12.0` → drift → `EUSAGE`.
- #8658's green CI reflected an intermediate Dependabot force-push state, not the final manifest-only squash.

## Why forward (0.13.1), not revert to 0.12.0

`0.13.1` requires Node ≥24. The repo is now on Node 24 (#8672: `.node-version`=24, `engines ">=24 <25"`), so the original pin rationale ("0.13.1 needs Node 24") is resolved. Reverting would contradict two already-merged PRs (#8658, #8672) and re-trigger Dependabot. portless is **dev-only** (local Portless routing — never shipped), so blast radius is the dev/CI toolchain only.

## Diff scope

Lockfile-only, portless-only: removes `web/node_modules/portless@0.12.0` (engines ≥20), adds `node_modules/portless@0.13.1` (engines ≥24, no transitive deps, re-hoisted to root), and syncs the `web` node's recorded range to `^0.13.0`.

## Changeset scope vs. diff scope

This PR's **diff** is portless-only (above). The **changeset** is deliberately broader — it is the single accurate release-notes artifact for the whole unreleased lockfile-sync remediation, so it also lists the `@anthropic-ai/sdk` `0.93.0`→`0.100.1` sync. That `@anthropic-ai/sdk` sync **already landed on `main`** (main's lockfile is already at `0.100.1`), so this PR's lockfile diff touches **no** `@anthropic-ai/sdk` node — only portless. The changeset rewrite here also **corrects the now-misleading changeset currently on `main`**, which falsely claims the repo "targets Node 20" and "reverted to `^0.12.0`" (the repo is on Node 24 and keeps `^0.13.0`).

## Verification

- `npm ci` (frozen) → passes (added 1328 packages, no EUSAGE).
- `git diff package-lock.json` confirmed portless-only (no other package nodes touched).

## Follow-ups (separate)

- Durable pre-merge lockfile-drift gate so this class of drift can never reach main again (#8686).
- Unblocks #8680 / #8681 / #8682 — they need `@dependabot rebase` once this merges (also picks up #8679's changeset auto-skip).

Closes #8683
