### PR TITLE
ci(codex-guard): reject a committed permissive Codex config profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,16 +485,24 @@ jobs:
   # `needs-onboarding` (any contributor-facing onboarding surface — the tripwire's
   # own self-tests must re-run when onboarding files move), so it runs whenever any
   # gate, its suite, the generator, an onboarding surface, or ci.yml itself moves —
-  # exactly when an unwiring would happen — and skips cleanly otherwise. (The Codex
-  # guard's own trigger, needs-codex, is a strict subset of these: it fires only on
-  # a .codex/config.toml edit — which also sets needs-onboarding via `^\.codex/` —
-  # or a guard/test edit under scripts/ — which sets needs-ci — so the Codex
-  # self-test always re-runs here without widening this `if:`.) The job id stays
-  # `lockfile-sync-tests` so the ci-success `needs:` wiring is stable.
+  # exactly when an unwiring would happen — and skips cleanly otherwise. The Codex
+  # guard's own trigger, needs-codex, is named here as a fourth, EXPLICIT arm even
+  # though its paths (.codex/config.toml — which also sets needs-onboarding via
+  # `^\.codex/` — and the guard/test scripts — which set needs-ci) are today a
+  # strict subset of the first three: relying on that subset is an untested,
+  # silently-load-bearing invariant. If a future path-filter edit ever narrowed
+  # needs-ci or needs-onboarding so a Codex-only change stopped setting them, this
+  # suite — which runs the Codex guard's own tests — would skip while needs-codex
+  # fired, and check-ci-success.sh's anti-tamper map (which DOES list needs-codex
+  # for this job) would then flag a phantom unwiring on every Codex-only PR. Naming
+  # needs-codex in both the `if:` and the anti-tamper map keeps the trigger set and
+  # the tamper map identical, so the self-test re-runs on any Codex-config change
+  # without depending on the subset holding. The job id stays `lockfile-sync-tests`
+  # so the ci-success `needs:` wiring is stable.
   lockfile-sync-tests:
     name: CI Self-Defense Tests
     needs: [ci-gate]
-    if: ${{ needs.ci-gate.outputs.needs-ci == 'true' || needs.ci-gate.outputs.needs-agentic == 'true' || needs.ci-gate.outputs.needs-onboarding == 'true' }}
+    if: ${{ needs.ci-gate.outputs.needs-ci == 'true' || needs.ci-gate.outputs.needs-agentic == 'true' || needs.ci-gate.outputs.needs-onboarding == 'true' || needs.ci-gate.outputs.needs-codex == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       needs-deps: ${{ steps.changes.outputs.deps }}
       needs-agentic: ${{ steps.changes.outputs.agentic }}
       needs-onboarding: ${{ steps.changes.outputs.onboarding }}
+      needs-codex: ${{ steps.changes.outputs.codex }}
       needs-any-code: ${{ steps.changes.outputs.any-code }}
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +50,7 @@ jobs:
         run: |
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
 
-          web=false; engine=false; mcp=false; ci=false; docs=false; design=false; hooks=false; deps=false; agentic=false; onboarding=false
+          web=false; engine=false; mcp=false; ci=false; docs=false; design=false; hooks=false; deps=false; agentic=false; onboarding=false; codex=false
 
           echo "$CHANGED" | grep -q '^web/' && web=true
           echo "$CHANGED" | grep -q '^engine/' && engine=true
@@ -94,6 +95,14 @@ jobs:
           # a non-onboarding file is still caught on any PR that also touches one of
           # these surfaces or a gate script.)
           echo "$CHANGED" | grep -qE '^README\.md$|^CONTRIBUTING\.md$|^AGENTS\.md$|^GEMINI\.md$|^\.cursorrules$|^\.claude/|^\.codex/|^\.gemini/|^\.github/|^\.windsurf/|^\.agent/|^\.agents/|^docs/|^tools/agentic-sync/|^scripts/check-taskboard-onboarding-hygiene\.sh$|^scripts/__tests__/check-taskboard-onboarding-hygiene\.test\.sh$' && onboarding=true
+          # Codex permissive-profile guard (scripts/check-codex-config-safety.sh).
+          # Fires ONLY on the committed Codex config under test or the guard/its
+          # test — a ~1s, zero-dep, read-only `git show HEAD:` check. Kept
+          # ORTHOGONAL to any-code (like hooks/deps/agentic/onboarding): a
+          # config-only edit pays only this guard, never the heavy fan-out. The
+          # guard reads the COMMITTED blob, so it asserts "is the profile being
+          # merged permissive?" rather than inspecting the working tree.
+          echo "$CHANGED" | grep -qE '^\.codex/config\.toml$|^scripts/check-codex-config-safety\.sh$|^scripts/__tests__/check-codex-config-safety\.test\.sh$' && codex=true
 
           any_code=false
           if [ "$web" = "true" ] || [ "$engine" = "true" ] || [ "$mcp" = "true" ] || [ "$ci" = "true" ] || [ "$docs" = "true" ] || [ "$design" = "true" ]; then
@@ -111,11 +120,12 @@ jobs:
             echo "deps=$deps"
             echo "agentic=$agentic"
             echo "onboarding=$onboarding"
+            echo "codex=$codex"
             echo "any-code=$any_code"
           } >> "$GITHUB_OUTPUT"
 
           echo "Changed paths detected:"
-          echo "  web=$web engine=$engine mcp=$mcp ci=$ci docs=$docs design=$design hooks=$hooks deps=$deps agentic=$agentic onboarding=$onboarding any-code=$any_code"
+          echo "  web=$web engine=$engine mcp=$mcp ci=$ci docs=$docs design=$design hooks=$hooks deps=$deps agentic=$agentic onboarding=$onboarding codex=$codex any-code=$any_code"
           if [ "$any_code" = "false" ] && [ "$hooks" = "false" ] && [ "$deps" = "false" ]; then
             echo "No relevant changes — downstream jobs will be skipped"
           fi
@@ -404,6 +414,44 @@ jobs:
       - name: Check for stale taskboard IDs and forbidden --db start commands
         run: bash scripts/check-taskboard-onboarding-hygiene.sh
 
+  # ---- Codex Config Safety ----
+  # Pure defense-in-depth (parity review gap Settings#0): fails the PR if the
+  # COMMITTED .codex/config.toml ever ships the fully-unattended, network-open
+  # combo — approval_policy = "never" AND network_access = true — which lets a
+  # Codex agent run shell with no human approval gate while reaching the network.
+  # The safe committed profile is approval-gated with the network off; this guard
+  # passes on it and only trips if a permissive profile is committed.
+  #
+  # It reads the COMMITTED blob via `git show HEAD:.codex/config.toml`, NEVER the
+  # working tree — a permissive profile may legitimately exist as an UNCOMMITTED
+  # local edit, and reading the working copy would both touch that off-limits file
+  # and false-fail locally. In CI the checkout == the ref under test, so this is
+  # exactly "is the profile being merged permissive?". Decision logic lives in
+  # scripts/check-codex-config-safety.sh (unit-tested by the CI Self-Defense Tests
+  # job below). It is a CHECK, never a fix.
+  #
+  # Gated on its own `codex` output (NOT any-code) so a config-only PR pays only
+  # this ~1s, zero-dep, read-only check. Wired into ci-success below so it is
+  # REQUIRED when it runs yet skips cleanly when no Codex config surface is touched
+  # — the safe path-filter + required-check pattern.
+  codex-config-guard:
+    name: Codex Config Safety
+    needs: [ci-gate]
+    if: ${{ needs.ci-gate.outputs.needs-codex == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The guard reads `git show HEAD:.codex/config.toml`; a full history is
+          # not needed, but the committed blob at the checked-out ref must exist.
+          fetch-depth: 1
+
+      - name: Reject a committed permissive Codex config profile
+        run: bash scripts/check-codex-config-safety.sh
+
   # ---- CI Self-Defense Tests ----
   # Unit-tests the decision logic of the repo's self-defending CI gates via
   # their co-located bash suites:
@@ -421,6 +469,11 @@ jobs:
   #     onboarding-hygiene tripwire (stale ULIDs + forbidden `--db` start),
   #     exercised against hermetic fixture trees via the STALE_ID_SCAN_ROOT seam,
   #     plus the same structural anti-unwiring assertions.
+  #   * scripts/check-codex-config-safety.sh — the Codex permissive-profile guard
+  #     (rejects a COMMITTED approval_policy="never" + network_access=true combo),
+  #     exercised against hermetic fixtures via the CODEX_CONFIG_PATH seam and a
+  #     throwaway git repo via CODEX_CONFIG_SCAN_ROOT, plus the same structural
+  #     anti-unwiring assertions.
   #   * .claude/tools/dx-audit.sh — the cross-provider DX audit; its contract test
   #     pins that the audit delegates to the agentic gate and covers the secondary
   #     provider surfaces (.codex/AGENTS.md, .windsurf, .agents) instead of drifting.
@@ -432,8 +485,12 @@ jobs:
   # `needs-onboarding` (any contributor-facing onboarding surface — the tripwire's
   # own self-tests must re-run when onboarding files move), so it runs whenever any
   # gate, its suite, the generator, an onboarding surface, or ci.yml itself moves —
-  # exactly when an unwiring would happen — and skips cleanly otherwise. The job id
-  # stays `lockfile-sync-tests` so the ci-success `needs:` wiring is stable.
+  # exactly when an unwiring would happen — and skips cleanly otherwise. (The Codex
+  # guard's own trigger, needs-codex, is a strict subset of these: it fires only on
+  # a .codex/config.toml edit — which also sets needs-onboarding via `^\.codex/` —
+  # or a guard/test edit under scripts/ — which sets needs-ci — so the Codex
+  # self-test always re-runs here without widening this `if:`.) The job id stays
+  # `lockfile-sync-tests` so the ci-success `needs:` wiring is stable.
   lockfile-sync-tests:
     name: CI Self-Defense Tests
     needs: [ci-gate]
@@ -456,6 +513,7 @@ jobs:
             scripts/check-ci-success.sh scripts/__tests__/check-ci-success.test.sh \
             scripts/check-agentic-sync.sh scripts/__tests__/check-agentic-sync.test.sh \
             scripts/check-taskboard-onboarding-hygiene.sh scripts/__tests__/check-taskboard-onboarding-hygiene.test.sh \
+            scripts/check-codex-config-safety.sh scripts/__tests__/check-codex-config-safety.test.sh \
             .claude/tools/dx-audit.sh .claude/tools/__tests__/dx-audit.test.sh
 
       - name: Run lockfile gate test suite
@@ -469,6 +527,9 @@ jobs:
 
       - name: Run taskboard onboarding-hygiene gate test suite
         run: bash scripts/__tests__/check-taskboard-onboarding-hygiene.test.sh
+
+      - name: Run Codex config-safety gate test suite
+        run: bash scripts/__tests__/check-codex-config-safety.test.sh
 
       - name: Run cross-provider DX-audit contract test
         run: bash .claude/tools/__tests__/dx-audit.test.sh
@@ -721,6 +782,7 @@ jobs:
       - lockfile-sync-tests
       - agentic-sync
       - taskboard-onboarding-guard
+      - codex-config-guard
       - test-e2e-ui
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/scripts/__tests__/check-ci-success.test.sh
+++ b/scripts/__tests__/check-ci-success.test.sh
@@ -180,7 +180,9 @@ if echo "$out" | grep -q "agentic-sync"; then pass "the failing agentic gate is 
 # onto lockfile-sync-tests would skip it while needs-ci is false — so guarding
 # only the needs-ci arm leaves this single-line vector open. The anti-tamper must
 # treat EITHER trigger firing as "the job had to run."
-res="$(run_verify "$(mk false false skipped skipped success success true success false success)")"
+# needs-codex is held FALSE (ccg legit-skips) so the codex arm cannot mask a
+# dropped needs-agentic arm — this case must fail PURELY on the agentic mapping.
+res="$(run_verify "$(mk false false skipped skipped success success true success false success false skipped)")"
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "tests skipped while needs-agentic=true (needs-ci=false) fails (exit 1)"; else fail "tamper (tests via agentic arm) should exit 1, got $rc"; fi
 if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is named (agentic arm)"; else fail "unwired gate not named (agentic arm)"; fi
@@ -193,7 +195,9 @@ if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is n
 # and the whole suite would stay green — leaving the ci.yml-edit unwiring vector
 # (a scripts/ or ci.yml PR sets needs-ci=true, touches no agentic file) untested.
 # Both arms must be independently load-bearing.
-res="$(run_verify "$(mk true true success skipped success success false success false success)")"
+# needs-codex is held FALSE (ccg legit-skips) so the codex arm cannot mask a
+# dropped needs-ci arm — this case must fail PURELY on the needs-ci mapping.
+res="$(run_verify "$(mk true true success skipped success success false success false success false skipped)")"
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "tests skipped while needs-ci=true (needs-agentic=false) fails (exit 1)"; else fail "tamper (tests via ci arm) should exit 1, got $rc"; fi
 if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is named (ci arm)"; else fail "unwired gate not named (ci arm)"; fi
@@ -230,7 +234,9 @@ if echo "$out" | grep -q "taskboard-onboarding-guard"; then pass "the failing on
 # are false — so the anti-tamper map must treat the onboarding arm as load-bearing
 # too. lockfile-sync + agentic-sync legit-skip here (their triggers are false), so
 # the ONLY tamper is the skipped self-tests job.
-res="$(run_verify "$(mk false false skipped skipped success success false success true success)")"
+# needs-codex is held FALSE (ccg legit-skips) so the codex arm cannot mask a
+# dropped needs-onboarding arm — this case must fail PURELY on the onboarding map.
+res="$(run_verify "$(mk false false skipped skipped success success false success true success false skipped)")"
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "tests skipped while needs-onboarding=true (others false) fails (exit 1)"; else fail "tamper (tests via onboarding arm) should exit 1, got $rc"; fi
 if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is named (onboarding arm)"; else fail "unwired gate not named (onboarding arm)"; fi
@@ -268,6 +274,24 @@ res="$(run_verify "$(mk true true success success success success true success t
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "codex guard failure fails (exit 1)"; else fail "codex failure should exit 1, got $rc"; fi
 if echo "$out" | grep -q "codex-config-guard"; then pass "the failing codex gate is named"; else fail "failing codex gate not named"; fi
+
+# --- 25. TAMPER via the needs-codex arm in ISOLATION: lockfile-sync-tests -----
+#        skipped while ONLY needs-codex=true (needs-ci=false, needs-agentic=false,
+#        needs-onboarding=false) → exit 1, naming the self-tests job.
+# The CI Self-Defense Tests job RUNS the Codex guard's own suite
+# (check-codex-config-safety.test.sh), so lockfile-sync-tests must re-run whenever
+# needs-codex fires. Relying on the implicit subset invariant (every needs-codex
+# path ALSO sets needs-ci or needs-onboarding) is fragile: narrow those filters
+# later and a .codex/config.toml-only PR could set needs-codex alone, silently
+# skipping the Codex self-test while every required check stayed green. The
+# needs-codex arm of check_triggered "lockfile-sync-tests" makes that an explicit,
+# enforced unwiring signal. Here lockfile-sync + agentic-sync + onboarding-guard
+# legit-skip (their triggers are false) and codex-config-guard ran (needs-codex=true,
+# success), so the skipped self-tests job is the SOLE tamper.
+res="$(run_verify "$(mk false false skipped skipped success success false skipped false skipped true success)")"
+rc="${res%%|*}"; out="${res#*|}"
+if [ "$rc" = "1" ]; then pass "tests skipped while ONLY needs-codex=true fails (exit 1)"; else fail "tamper (tests via codex arm) should exit 1, got $rc"; fi
+if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is named (codex arm)"; else fail "unwired gate not named (codex arm)"; fi
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/__tests__/check-ci-success.test.sh
+++ b/scripts/__tests__/check-ci-success.test.sh
@@ -242,12 +242,15 @@ if [ "$rc" = "1" ]; then pass "tests skipped while needs-onboarding=true (others
 if echo "$out" | grep -q "lockfile-sync-tests"; then pass "the unwired gate is named (onboarding arm)"; else fail "unwired gate not named (onboarding arm)"; fi
 
 # --- 21. ISOLATED onboarding-guard tamper: guard skipped while ONLY -----------
-#        needs-onboarding=true → exit 1, naming the guard (mirrors cases 15/16 for
+#        needs-onboarding=true → exit 1, naming the guard (mirrors cases 15/16/20 for
 #        the onboarding arm). lockfile-sync-tests=success here (it ran because the
 #        onboarding arm fired), so the guard skip is the sole tamper — proving the
 #        guard's needs-onboarding mapping is independently load-bearing even when
 #        no other trigger is set.
-res="$(run_verify "$(mk false false skipped success success success false skipped true skipped)")"
+# needs-codex is held FALSE (ccg legit-skips) so the codex arm cannot mask the
+# onboarding tamper — this case must fail PURELY on the onboarding-guard map,
+# matching the isolation discipline of cases 15/16/20.
+res="$(run_verify "$(mk false false skipped success success success false skipped true skipped false skipped)")"
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "guard skipped while ONLY needs-onboarding=true fails (exit 1)"; else fail "isolated onboarding tamper should exit 1, got $rc"; fi
 if echo "$out" | grep -q "taskboard-onboarding-guard ("; then pass "the unwired onboarding gate is named (isolated arm)"; else fail "unwired onboarding gate not named (isolated arm)"; fi

--- a/scripts/__tests__/check-ci-success.test.sh
+++ b/scripts/__tests__/check-ci-success.test.sh
@@ -30,7 +30,7 @@ fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 [ -f "$SCRIPT" ] || { echo "verifier script not found: $SCRIPT"; exit 1; }
 
 # Build a toJSON(needs)-shaped object mirroring the REAL ci-success `needs:` list
-# (all 12 jobs — see ci.yml), so a failure on ANY required gate is exercised, not
+# (all 13 jobs — see ci.yml), so a failure on ANY required gate is exercised, not
 # just the handful that used to be in the fixture. Jobs not parameterised default
 # to success. Args:
 #   $1 needs-ci   $2 needs-deps   $3 lockfile-sync.result
@@ -40,14 +40,15 @@ fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 #   $7 needs-agentic (default true)   $8 agentic-sync.result (default success)
 #   $9 needs-onboarding (default true)
 #   $10 taskboard-onboarding-guard.result (default success)
+#   $11 needs-codex (default true)   $12 codex-config-guard.result (default success)
 mk() {
-  local nci="$1" ndeps="$2" ls="$3" lst="$4" qg="${5:-success}" ht="${6:-success}" nagentic="${7:-true}" as="${8:-success}" nonboarding="${9:-true}" tog="${10:-success}"
+  local nci="$1" ndeps="$2" ls="$3" lst="$4" qg="${5:-success}" ht="${6:-success}" nagentic="${7:-true}" as="${8:-success}" nonboarding="${9:-true}" tog="${10:-success}" ncodex="${11:-true}" ccg="${12:-success}"
   jq -nc \
     --arg nci "$nci" --arg ndeps "$ndeps" --arg ls "$ls" --arg lst "$lst" \
     --arg qg "$qg" --arg ht "$ht" --arg nagentic "$nagentic" --arg as "$as" \
-    --arg nonboarding "$nonboarding" --arg tog "$tog" '
+    --arg nonboarding "$nonboarding" --arg tog "$tog" --arg ncodex "$ncodex" --arg ccg "$ccg" '
     {
-      "ci-gate":              { result: "success", outputs: { "needs-ci": $nci, "needs-deps": $ndeps, "needs-agentic": $nagentic, "needs-onboarding": $nonboarding, "needs-any-code": "true" } },
+      "ci-gate":              { result: "success", outputs: { "needs-ci": $nci, "needs-deps": $ndeps, "needs-agentic": $nagentic, "needs-onboarding": $nonboarding, "needs-codex": $ncodex, "needs-any-code": "true" } },
       "quality-gates":        { result: $qg },
       "command-parity":       { result: "success" },
       "build-nextjs":         { result: "success" },
@@ -58,6 +59,7 @@ mk() {
       "lockfile-sync-tests":  { result: $lst },
       "agentic-sync":         { result: $as },
       "taskboard-onboarding-guard": { result: $tog },
+      "codex-config-guard":   { result: $ccg },
       "test-e2e-ui":          { result: "success" }
     }'
 }
@@ -90,14 +92,15 @@ rc="${res%%|*}"
 if [ "$rc" = "1" ]; then pass "a cancelled gate fails (exit 1)"; else fail "cancelled gate should exit 1, got $rc"; fi
 
 # --- 4. Legitimate skips (ALL triggers false) → exit 0 -----------------------
-# needs-ci=false, needs-deps=false, needs-agentic=false, needs-onboarding=false —
-# so ALL FOUR self-defending gates (lockfile-sync, lockfile-sync-tests,
-# agentic-sync, taskboard-onboarding-guard) skipping is correct path-filter
-# behaviour and must NOT trip the anti-tamper check. This is the clean baseline:
-# a docs-only / unrelated PR that touches none of the guarded surfaces.
-res="$(run_verify "$(mk false false skipped skipped success success false skipped false skipped)")"
+# needs-ci=false, needs-deps=false, needs-agentic=false, needs-onboarding=false,
+# needs-codex=false — so ALL FIVE self-defending gates (lockfile-sync,
+# lockfile-sync-tests, agentic-sync, taskboard-onboarding-guard, codex-config-guard)
+# skipping is correct path-filter behaviour and must NOT trip the anti-tamper
+# check. This is the clean baseline: a docs-only / unrelated PR that touches none
+# of the guarded surfaces.
+res="$(run_verify "$(mk false false skipped skipped success success false skipped false skipped false skipped)")"
 rc="${res%%|*}"
-if [ "$rc" = "0" ]; then pass "all four gates legitimately skipped pass (exit 0)"; else fail "legit skip should exit 0, got $rc"; fi
+if [ "$rc" = "0" ]; then pass "all five gates legitimately skipped pass (exit 0)"; else fail "legit skip should exit 0, got $rc"; fi
 
 # --- 5. TAMPER: lockfile-sync-tests skipped while needs-ci=true → exit 1 ------
 # This is the `if: false` unwiring vector: a ci.yml edit sets needs-ci=true, so
@@ -242,6 +245,29 @@ res="$(run_verify "$(mk false false skipped success success success false skippe
 rc="${res%%|*}"; out="${res#*|}"
 if [ "$rc" = "1" ]; then pass "guard skipped while ONLY needs-onboarding=true fails (exit 1)"; else fail "isolated onboarding tamper should exit 1, got $rc"; fi
 if echo "$out" | grep -q "taskboard-onboarding-guard ("; then pass "the unwired onboarding gate is named (isolated arm)"; else fail "unwired onboarding gate not named (isolated arm)"; fi
+
+# --- 22. TAMPER: codex-config-guard skipped while needs-codex=true → exit 1 ----
+# The Codex config-safety tripwire is self-defending too: a PR that edits
+# .codex/config.toml or the guard/test scripts sets needs-codex=true, so the gate
+# SHOULD run; an `if: false` skip is an unwiring signal that would let a permissive
+# committed Codex profile (approval_policy="never" + network_access=true) slip past
+# while every required check stayed green.
+res="$(run_verify "$(mk true true success success success success true success true success true skipped)")"
+rc="${res%%|*}"; out="${res#*|}"
+if [ "$rc" = "1" ]; then pass "codex guard skipped while needs-codex=true fails (exit 1)"; else fail "tamper (codex) should exit 1, got $rc"; fi
+if echo "$out" | grep -qi "unwiring"; then pass "codex tamper is flagged as a possible unwiring"; else fail "codex tamper message missing"; fi
+if echo "$out" | grep -q "codex-config-guard ("; then pass "the unwired codex gate is named"; else fail "unwired codex gate not named"; fi
+
+# --- 23. codex-config-guard legit-skips (needs-codex=false) → exit 0 -----------
+res="$(run_verify "$(mk true true success success success success true success true success false skipped)")"
+rc="${res%%|*}"
+if [ "$rc" = "0" ]; then pass "codex guard legit-skip passes (exit 0)"; else fail "codex legit skip should exit 0, got $rc"; fi
+
+# --- 24. codex-config-guard FAILED while triggered → exit 1 (hard-failure path) -
+res="$(run_verify "$(mk true true success success success success true success true success true failure)")"
+rc="${res%%|*}"; out="${res#*|}"
+if [ "$rc" = "1" ]; then pass "codex guard failure fails (exit 1)"; else fail "codex failure should exit 1, got $rc"; fi
+if echo "$out" | grep -q "codex-config-guard"; then pass "the failing codex gate is named"; else fail "failing codex gate not named"; fi
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/__tests__/check-codex-config-safety.test.sh
+++ b/scripts/__tests__/check-codex-config-safety.test.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# Contract test for scripts/check-codex-config-safety.sh — the Codex permissive-
+# profile tripwire.
+#
+# WHY THIS GATE EXISTS
+# The *committed* `.codex/config.toml` on main is the safe, approval-gated profile
+# every contributor inherits on pull. A fully-unattended profile — `approval_policy
+# = "never"` together with `network_access = true` (and shell_tool on) — lets a
+# Codex agent run arbitrary shell with no human gate AND reach the network: a
+# silent, high-blast-radius supply-chain footgun if it were ever committed. The
+# agentic-toolkit parity review (gap Settings#0) called for a pure defense-in-depth
+# guard: pass on the safe HEAD, fail only if a permissive profile is COMMITTED.
+#
+# CRITICAL SAFETY CONTRACT — the guard reads the COMMITTED blob, never the working
+# tree. The dangerous profile exists in this engagement only as an OFF-LIMITS,
+# uncommitted local edit; a guard that read the working-tree file would (a) read an
+# off-limits file and (b) false-fail locally while HEAD is safe. So the production
+# path is `git show HEAD:.codex/config.toml`. Two test seams keep the suite
+# hermetic and prove both behaviors:
+#   * CODEX_CONFIG_PATH=<file>      — read this fixture directly, bypass git.
+#   * CODEX_CONFIG_SCAN_ROOT=<dir>  — `git -C <dir> show HEAD:.codex/config.toml`.
+#
+# Exit 0 = safe/clean, exit 1 = a permissive committed profile — those two codes
+# ARE the behavior, so cases assert on them directly. Assertions use explicit
+# if/then/else (NOT `A && ok || bad`) so the suite is SC2015-clean for CI's
+# self-defense lint job. grep is fed from here-strings (`<<<`), never
+# `echo "$big" | grep` — that antipattern takes SIGPIPE under `pipefail` on Linux
+# when the payload exceeds the pipe buffer (the bug fixed in #8687/#8696).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-codex-config-safety.sh"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+CI_SUCCESS="$REPO_ROOT/scripts/check-ci-success.sh"
+
+# --- host guards -------------------------------------------------------------
+command -v grep   >/dev/null 2>&1 || { echo "FATAL: grep not found on host";   exit 1; }
+command -v mktemp >/dev/null 2>&1 || { echo "FATAL: mktemp not found on host"; exit 1; }
+command -v git    >/dev/null 2>&1 || { echo "FATAL: git not found on host";    exit 1; }
+
+PASS=0
+FAIL=0
+ok()  { echo "  ok: $1"; PASS=$((PASS + 1)); }
+bad() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# --- fixture profiles --------------------------------------------------------
+# Safe profile — mirrors the committed HEAD: approval-gated, network/shell off.
+SAFE_TOML='model = "gpt-5.3-codex"
+approval_policy = "unless-allow-listed"
+
+[sandbox_workspace_write]
+allow = ["**/*"]
+
+[features]
+shell_tool = false
+web_search = false'
+
+# The dangerous combination the guard MUST reject: unattended + network-open.
+DANGER_TOML='model = "gpt-5.3-codex"
+approval_policy = "never"
+
+[sandbox_workspace_write]
+allow = ["**/*"]
+network_access = true
+
+[features]
+shell_tool = true'
+
+# Single value present in isolation — each alone is NOT the dangerous combo.
+ONLY_NEVER='approval_policy = "never"
+
+[sandbox_workspace_write]
+network_access = false'
+ONLY_NETWORK='approval_policy = "unless-allow-listed"
+
+[sandbox_workspace_write]
+network_access = true'
+
+# Both dangerous keys, but COMMENTED OUT — must not count as active.
+COMMENTED='# approval_policy = "never"
+[sandbox_workspace_write]
+  # network_access = true
+approval_policy = "on-request"'
+
+# Single-quoted "never" + whitespace-free network_access — both still active.
+SINGLE_QUOTED="approval_policy = 'never'
+[sandbox_workspace_write]
+network_access=true"
+
+# Trailing comments after each value — still active, must trip.
+TRAILING_COMMENT='approval_policy = "never"   # fully unattended
+[sandbox_workspace_write]
+network_access = true  # open the network'
+
+# No spaces around = — must trip.
+NO_SPACE='approval_policy="never"
+[sandbox_workspace_write]
+network_access=true'
+
+# Near-misses: look like the dangerous tokens but are not them → must pass.
+NEAR_MISS='approval_policy = "never-mind"
+[sandbox_workspace_write]
+network_access = truely'
+
+# Inline-table TOML forms place a key mid-line after `{` or `,`. Inline tables are
+# semantically identical to [section] tables in TOML 1.0, so the dangerous combo
+# expressed this way MUST still trip — the line anchor alone would miss it.
+INLINE_NETWORK='approval_policy = "never"
+sandbox_workspace_write = { network_access = true }'
+INLINE_BOTH='settings = { approval_policy = "never", network_access = true }'
+INLINE_NO_SPACE='approval_policy="never"
+s={network_access=true}'
+
+# Triple-quoted basic ("""…""") and literal ('''…''') strings are semantically
+# identical to their single-delimited forms in TOML 1.0, so a triple-quoted never
+# must trip just like "never".
+TRIPLE_DOUBLE='approval_policy = """never"""
+[sandbox_workspace_write]
+network_access = true'
+TRIPLE_SINGLE="approval_policy = '''never'''
+[sandbox_workspace_write]
+network_access = true"
+
+# A TRUE multi-line triple-quoted approval_policy (value on its own line) is OUT
+# OF SCOPE and must pass: TOML preserves the embedded newlines, so the parsed
+# value is "\nnever\n" — not the token `never` — so it is not a functional
+# permissive setting and Codex would not read it as one. This pins that documented
+# boundary so the single-line coverage is never mistaken for multi-line coverage.
+TRIPLE_MULTILINE_OOS='approval_policy = """
+never
+"""
+[sandbox_workspace_write]
+network_access = true'
+
+# Uppercase TRUE is NOT a TOML boolean (booleans are lowercase), so the guard must
+# treat it as a near-miss and pass — pins the case-sensitivity boundary so a future
+# case-insensitive relaxation cannot silently widen the match.
+NEAR_MISS_UPPERCASE='approval_policy = "never"
+[sandbox_workspace_write]
+network_access = TRUE'
+
+# Inline-table near-miss: network_access=true is active but approval_policy is the
+# benign "never-mind", so the dangerous combo is NOT present → must pass. Proves
+# the relaxed key-boundary still requires the EXACT never token inside inline tables.
+INLINE_NEAR_MISS='settings = { approval_policy = "never-mind", network_access = true }'
+
+# A fully-commented inline table is inactive (whole-line comment) → must pass.
+INLINE_COMMENTED='# settings = { approval_policy = "never", network_access = true }
+approval_policy = "on-request"'
+
+run_fixture() { # <content> → writes a fixture file, runs the guard against it
+  local content="$1" tmp rc
+  tmp="$(mktemp)"
+  printf '%s\n' "$content" > "$tmp"
+  CODEX_CONFIG_PATH="$tmp" bash "$GUARD" >/dev/null 2>&1
+  rc=$?
+  rm -f "$tmp"
+  return "$rc"
+}
+run_fixture_out() { # <content> → echoes the guard's combined output
+  local content="$1" tmp
+  tmp="$(mktemp)"
+  printf '%s\n' "$content" > "$tmp"
+  CODEX_CONFIG_PATH="$tmp" bash "$GUARD" 2>&1
+  rm -f "$tmp"
+}
+
+# =============================================================================
+echo "== tripwire: script exists and is executable =="
+if [ -f "$GUARD" ] && [ -x "$GUARD" ]; then ok "guard script present and executable"; else bad "guard script missing or not executable: $GUARD"; fi
+
+# =============================================================================
+echo "== safe committed profile (approval-gated, network off) passes =="
+run_fixture "$SAFE_TOML"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "safe profile → exit 0"; else bad "safe profile should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== dangerous combo (never + network_access=true) fails =="
+run_fixture "$DANGER_TOML"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "never + network_access=true → exit 1"; else bad "dangerous combo should fail, got exit $rc"; fi
+
+# =============================================================================
+echo "== each dangerous key ALONE is not the combo → passes =="
+run_fixture "$ONLY_NEVER"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "approval_policy=never alone (network off) → exit 0"; else bad "never-only should pass, got exit $rc"; fi
+run_fixture "$ONLY_NETWORK"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "network_access=true alone (approval gated) → exit 0"; else bad "network-only should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== commented-out dangerous keys do not count =="
+run_fixture "$COMMENTED"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "commented never + network_access → exit 0"; else bad "commented keys should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== quoting / whitespace / trailing-comment variants of the combo all trip =="
+run_fixture "$SINGLE_QUOTED"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "single-quoted 'never' + network_access=true → exit 1"; else bad "single-quoted combo should fail, got exit $rc"; fi
+run_fixture "$TRAILING_COMMENT"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "trailing-comment combo → exit 1"; else bad "trailing-comment combo should fail, got exit $rc"; fi
+run_fixture "$NO_SPACE"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "no-space combo → exit 1"; else bad "no-space combo should fail, got exit $rc"; fi
+
+# =============================================================================
+echo "== near-miss tokens (never-mind / truely) do not trip =="
+run_fixture "$NEAR_MISS"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "never-mind + truely → exit 0 (exact-token match only)"; else bad "near-miss tokens should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== inline-table TOML forms of the combo trip (key not at line start) =="
+run_fixture "$INLINE_NETWORK"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "never + inline { network_access = true } → exit 1"; else bad "inline-table network combo should fail, got exit $rc"; fi
+run_fixture "$INLINE_BOTH"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "inline { approval_policy=never, network_access=true } → exit 1"; else bad "inline-table both-keys combo should fail, got exit $rc"; fi
+run_fixture "$INLINE_NO_SPACE"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "no-space inline {network_access=true} + never → exit 1"; else bad "no-space inline combo should fail, got exit $rc"; fi
+
+# =============================================================================
+echo "== triple-quoted never (basic & literal) trips =="
+run_fixture "$TRIPLE_DOUBLE"; rc=$?
+if [ "$rc" -eq 1 ]; then ok 'approval_policy = """never""" + network → exit 1'; else bad "triple-double-quoted never should fail, got exit $rc"; fi
+run_fixture "$TRIPLE_SINGLE"; rc=$?
+if [ "$rc" -eq 1 ]; then ok "approval_policy = '''never''' + network → exit 1"; else bad "triple-single-quoted never should fail, got exit $rc"; fi
+run_fixture "$TRIPLE_MULTILINE_OOS"; rc=$?
+if [ "$rc" -eq 0 ]; then ok 'multi-line """\n never \n""" parses to a newline value, not the token never → out of scope, exit 0'; else bad "multi-line triple-quoted never is out of scope and should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== case-sensitivity & inline near-misses do not trip =="
+run_fixture "$NEAR_MISS_UPPERCASE"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "network_access = TRUE (uppercase, not a TOML bool) → exit 0"; else bad "uppercase TRUE should pass, got exit $rc"; fi
+run_fixture "$INLINE_NEAR_MISS"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "inline never-mind + network_access=true → exit 0 (exact token only)"; else bad "inline near-miss should pass, got exit $rc"; fi
+run_fixture "$INLINE_COMMENTED"; rc=$?
+if [ "$rc" -eq 0 ]; then ok "fully-commented inline table → exit 0"; else bad "commented inline table should pass, got exit $rc"; fi
+
+# =============================================================================
+echo "== missing / empty config = pass (nothing committed to reject) =="
+CODEX_CONFIG_PATH="$(mktemp -u)" bash "$GUARD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then ok "non-existent config path → exit 0"; else bad "missing config should pass, got exit $rc"; fi
+empty="$(mktemp)"; : > "$empty"
+CODEX_CONFIG_PATH="$empty" bash "$GUARD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then ok "empty config → exit 0"; else bad "empty config should pass, got exit $rc"; fi
+rm -f "$empty"
+
+# =============================================================================
+echo "== offender output names the file and labels the CODEX-PERMISSIVE class =="
+out="$(run_fixture_out "$DANGER_TOML")"
+if grep -q "CODEX-PERMISSIVE" <<<"$out"; then ok "output labels the CODEX-PERMISSIVE class"; else bad "output omits CODEX-PERMISSIVE label"; fi
+if grep -q "approval_policy" <<<"$out"; then ok "output names approval_policy"; else bad "output omits approval_policy"; fi
+if grep -q "network_access" <<<"$out"; then ok "output names network_access"; else bad "output omits network_access"; fi
+
+# =============================================================================
+echo "== SAFETY: reads the COMMITTED blob, never the working tree =="
+# A repo whose HEAD commits the SAFE profile but whose working tree holds the
+# DANGER profile (unstaged, mirroring the OFF-LIMITS local edit) MUST pass — the
+# guard reads `git show HEAD:` and ignores the dirty working copy entirely.
+gitroot="$(mktemp -d)"
+(
+  cd "$gitroot" || exit 1
+  git init -q
+  git config user.email t@e.x
+  git config user.name t
+  mkdir -p .codex
+  printf '%s\n' "$SAFE_TOML" > .codex/config.toml
+  git add .codex/config.toml
+  git commit -qm "safe codex profile"
+  # Now dirty the working tree with the dangerous profile — uncommitted.
+  printf '%s\n' "$DANGER_TOML" > .codex/config.toml
+)
+CODEX_CONFIG_SCAN_ROOT="$gitroot" bash "$GUARD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then ok "committed SAFE + working-tree DANGER → exit 0 (working tree ignored)"; else bad "guard read the working tree (got exit $rc) — must read HEAD only"; fi
+
+# When the DANGER profile is actually COMMITTED, the same git-backed path trips.
+(
+  cd "$gitroot" || exit 1
+  git add .codex/config.toml
+  git commit -qm "permissive codex profile committed"
+)
+CODEX_CONFIG_SCAN_ROOT="$gitroot" bash "$GUARD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 1 ]; then ok "committed DANGER profile → exit 1 (git-backed path)"; else bad "committed danger should fail via git path, got exit $rc"; fi
+rm -rf "$gitroot"
+
+# A git root with no committed .codex/config.toml at HEAD → pass (nothing to reject).
+gitroot2="$(mktemp -d)"
+(
+  cd "$gitroot2" || exit 1
+  git init -q
+  git config user.email t@e.x
+  git config user.name t
+  printf 'placeholder\n' > README.md
+  git add README.md
+  git commit -qm "no codex config"
+)
+CODEX_CONFIG_SCAN_ROOT="$gitroot2" bash "$GUARD" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then ok "no committed .codex/config.toml → exit 0"; else bad "absent committed config should pass, got exit $rc"; fi
+rm -rf "$gitroot2"
+
+# =============================================================================
+echo "== the REAL committed .codex/config.toml on this branch is safe =="
+# Defense-in-depth's own baseline: the guard must pass against this very repo's
+# committed config (no seam) — if it didn't, HEAD would already be permissive.
+( cd "$REPO_ROOT" && bash "$GUARD" >/dev/null 2>&1 ); rc=$?
+if [ "$rc" -eq 0 ]; then ok "guard passes against the repo's committed HEAD config"; else bad "guard fails on real HEAD config (got exit $rc) — HEAD permissive or guard broken"; fi
+
+# =============================================================================
+echo "== structural wiring: guard is a required, self-defending CI gate =="
+if [ -f "$CI_YML" ]; then
+  if grep -q "check-codex-config-safety.sh" "$CI_YML"; then
+    ok "ci.yml invokes the guard"
+  else
+    bad "ci.yml does not invoke check-codex-config-safety.sh"
+  fi
+  if grep -Eq "codex-config-guard" "$CI_YML"; then
+    ok "ci.yml defines the codex-config-guard job"
+  else
+    bad "ci.yml has no codex-config-guard job"
+  fi
+  # Must be a dependency of an aggregate (ci-success), not a free-floating check.
+  if grep -Eq "^[[:space:]]*-[[:space:]]*codex-config-guard" "$CI_YML"; then
+    ok "codex-config-guard is listed under a needs: block"
+  else
+    bad "codex-config-guard is not referenced as a needs: dependency"
+  fi
+  # The job's own `if:` must gate on the SAME ci-gate output the anti-tamper maps
+  # it to (needs-codex). A name-only grep would pass even if the trigger were
+  # silently rewired to a never-true output, leaving the gate dead while present.
+  if grep -Eq "needs\.ci-gate\.outputs\.needs-codex == 'true'" "$CI_YML"; then
+    ok "codex-config-guard job is gated on needs-codex (trigger wired)"
+  else
+    bad "codex-config-guard job is not gated on needs-codex"
+  fi
+  # The ci-gate must actually PRODUCE the needs-codex output the job consumes.
+  if grep -Eq "needs-codex:" "$CI_YML"; then
+    ok "ci-gate declares the needs-codex output"
+  else
+    bad "ci-gate has no needs-codex output"
+  fi
+  # The path filter must key on the .codex/config.toml literal. Every grep above
+  # (job, needs:, if:, output) would stay green if a one-line edit dropped the
+  # `^\.codex/config\.toml$` arm from the filter, silently skipping the gate on
+  # its primary trigger path — so pin the literal trigger path itself.
+  if grep -Eq "\.codex/config\.toml" "$CI_YML"; then
+    ok "ci-gate path filter keys on the .codex/config.toml literal"
+  else
+    bad "ci.yml never references the .codex/config.toml path-filter literal"
+  fi
+else
+  bad "ci.yml not found at $CI_YML"
+fi
+
+# The anti-tamper verifier must MAP THIS job to THIS trigger, not merely mention
+# the string. Assert the exact check_triggered call so a dropped/renamed trigger
+# arm (which would reopen the `if: false` skip vector) fails this suite.
+if [ -f "$CI_SUCCESS" ]; then
+  if grep -Eq 'check_triggered[[:space:]]+"codex-config-guard"[[:space:]]+"needs-codex"' "$CI_SUCCESS"; then
+    ok "check-ci-success.sh maps codex-config-guard → needs-codex (exact anti-tamper wiring)"
+  else
+    bad "check-ci-success.sh does not map codex-config-guard to needs-codex"
+  fi
+else
+  bad "check-ci-success.sh not found at $CI_SUCCESS"
+fi
+
+# =============================================================================
+echo ""
+echo "== summary =="
+echo "  PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then exit 1; fi
+exit 0

--- a/scripts/check-ci-success.sh
+++ b/scripts/check-ci-success.sh
@@ -22,7 +22,11 @@
 #
 # Unit-tested by scripts/__tests__/check-ci-success.test.sh (run in CI by the
 # lockfile-sync-tests job, gated on needs-ci || needs-agentic || needs-onboarding
-# so any edit to a gate script OR an onboarding surface re-runs the suite).
+# || needs-codex so any edit to a gate script, an onboarding surface, OR the Codex
+# config re-runs the suite — the job's `if:` and the lockfile-sync-tests entry in
+# the anti-tamper map below name the SAME four triggers, so the suite re-runs on
+# any signal that fires it without depending on one trigger being a subset of
+# another).
 set -uo pipefail
 
 NEEDS_JSON="${NEEDS_JSON:-}"
@@ -76,7 +80,7 @@ check_triggered() {
   fi
 }
 check_triggered "lockfile-sync"             "needs-deps"
-check_triggered "lockfile-sync-tests"       "needs-ci" "needs-agentic" "needs-onboarding"
+check_triggered "lockfile-sync-tests"       "needs-ci" "needs-agentic" "needs-onboarding" "needs-codex"
 check_triggered "agentic-sync"              "needs-agentic"
 check_triggered "taskboard-onboarding-guard" "needs-onboarding"
 check_triggered "codex-config-guard"        "needs-codex"

--- a/scripts/check-ci-success.sh
+++ b/scripts/check-ci-success.sh
@@ -79,6 +79,7 @@ check_triggered "lockfile-sync"             "needs-deps"
 check_triggered "lockfile-sync-tests"       "needs-ci" "needs-agentic" "needs-onboarding"
 check_triggered "agentic-sync"              "needs-agentic"
 check_triggered "taskboard-onboarding-guard" "needs-onboarding"
+check_triggered "codex-config-guard"        "needs-codex"
 if [ -n "$tamper" ]; then
   echo "::error::Self-defending gate skipped despite its trigger firing (possible unwiring):"
   echo "$tamper"

--- a/scripts/check-codex-config-safety.sh
+++ b/scripts/check-codex-config-safety.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# check-codex-config-safety.sh — reject a COMMITTED permissive Codex CLI profile.
+#
+# WHAT IT GUARDS
+# The committed `.codex/config.toml` must never ship the fully-unattended,
+# network-open combination:
+#       approval_policy = "never"   AND   network_access = true
+# That pair lets a Codex agent run shell with no human approval gate while also
+# reaching the network — a silent, high-blast-radius supply-chain footgun. The
+# safe committed profile is approval-gated (e.g. "unless-allow-listed") with the
+# network off; this guard passes on it and only trips if a permissive profile is
+# committed. (Source: Codex config reference — approval_policy {untrusted,
+# on-request, never}; [sandbox_workspace_write].network_access.)
+#
+# READS THE COMMITTED BLOB, NOT THE WORKING TREE
+# A fully-permissive profile may legitimately exist as an UNCOMMITTED local
+# working-tree edit (developer convenience, off-limits to tooling). Reading the
+# working-tree file would (a) touch that off-limits edit and (b) false-fail
+# locally while HEAD is safe. So the production path reads `git show
+# HEAD:.codex/config.toml`. In CI the checkout == the ref under test, so this is
+# exactly "is the committed profile permissive?".
+#
+# TEST SEAMS (hermetic, never touch the real file)
+#   CODEX_CONFIG_PATH=<file>      read this file directly, bypass git (fixtures).
+#   CODEX_CONFIG_SCAN_ROOT=<dir>  `git -C <dir> show HEAD:.codex/config.toml`.
+#
+# Exit 0 = safe (or no committed config); exit 1 = permissive profile committed.
+# grep is fed from here-strings (`<<<`), never `echo "$big" | grep`, which takes
+# SIGPIPE under `pipefail` on Linux when the payload exceeds the pipe buffer.
+set -uo pipefail
+
+ROOT="${CODEX_CONFIG_SCAN_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# --- load the config content -------------------------------------------------
+content=""
+if [ -n "${CODEX_CONFIG_PATH:-}" ]; then
+  # Fixture mode: read the named file directly (missing → empty → pass).
+  if [ -f "$CODEX_CONFIG_PATH" ]; then
+    content="$(cat "$CODEX_CONFIG_PATH")"
+  fi
+else
+  # Production mode: read the COMMITTED blob; never the working tree.
+  content="$(git -C "$ROOT" show HEAD:.codex/config.toml 2>/dev/null || true)"
+fi
+
+if [ -z "$content" ]; then
+  echo "✓ codex-config-safety: no committed .codex/config.toml to inspect — pass"
+  exit 0
+fi
+
+# --- isolate ACTIVE (non-comment) lines --------------------------------------
+# Drop whole-line comments (optional leading whitespace then `#`). Lines with a
+# TRAILING comment are kept — the value before the `#` is still active.
+active="$(grep -vE '^[[:space:]]*#' <<<"$content" || true)"
+
+# --- detect the two dangerous keys, exact-token, quote/space/comment tolerant -
+# A dangerous key may START a line, OR appear inside a single-line TOML inline
+# table where it follows `{` or `,` — e.g. `sandbox = { network_access = true }`
+# or `s = { approval_policy = "never", network_access = true }`. Inline tables are
+# semantically identical to [section] tables in TOML 1.0, so the dangerous combo
+# expressed that way must still trip. Anchoring the key to one of those three
+# boundaries closes the inline-table evasion while staying precise: a substring
+# like `my_approval_policy` / `xnetwork_access` has no `{`/`,`/line-start directly
+# in front of the real key name, so it cannot match.
+KEY_BOUNDARY="(^[[:space:]]*|[{,][[:space:]]*)"
+# approval_policy = never — the value may be a basic string ("never"), a literal
+# string ('never'), or the single-line triple-quoted forms ("""never""" /
+# '''never'''), all identical to "never" in TOML 1.0. A closing delimiter
+# immediately after `never` is required so `"never-mind"` does NOT match. A TRUE
+# multi-line triple-quoted form (the value spread across newlines) is out of
+# scope: TOML keeps the embedded newlines, so the parsed value is not the token
+# `never` and Codex would not read it as the permissive setting. A grep guard
+# cannot parse TOML anyway, so the committed-blob check plus human review remain
+# the backstop for exotic encodings — this closes the silent single-line slip.
+RE_NEVER="${KEY_BOUNDARY}approval_policy[[:space:]]*=[[:space:]]*(\"\"\"never\"\"\"|'''never'''|\"never\"|'never')"
+# network_access = true — `true` must be a whole token (followed by whitespace,
+# `#`, an inline-table `}`/`,`, or EOL) so `truely` / `true_thing` do not match.
+# `true` is matched case-sensitively because TOML booleans are lowercase, so
+# `TRUE` is correctly treated as a non-boolean and passes.
+RE_NETWORK="${KEY_BOUNDARY}network_access[[:space:]]*=[[:space:]]*true([[:space:]]|#|}|,|\$)"
+
+has_never=0
+has_network=0
+if grep -Eq "$RE_NEVER"   <<<"$active"; then has_never=1;   fi
+if grep -Eq "$RE_NETWORK" <<<"$active"; then has_network=1; fi
+
+if [ "$has_never" -eq 1 ] && [ "$has_network" -eq 1 ]; then
+  src="${CODEX_CONFIG_PATH:-$ROOT/.codex/config.toml (committed HEAD)}"
+  echo "::error::CODEX-PERMISSIVE: committed Codex profile is fully unattended AND network-open" >&2
+  echo "  file:   $src" >&2
+  echo "  found:  approval_policy = \"never\"  +  network_access = true" >&2
+  echo "" >&2
+  echo "  This pair lets a Codex agent run shell with no human approval while" >&2
+  echo "  reaching the network — it must never be the COMMITTED profile." >&2
+  echo "  Remediation: commit an approval-gated profile (e.g." >&2
+  echo "  approval_policy = \"unless-allow-listed\") and/or set network_access = false." >&2
+  echo "  A permissive profile may remain as an UNCOMMITTED local edit." >&2
+  exit 1
+fi
+
+echo "✓ codex-config-safety: committed profile is not the unattended+network-open combo — pass"
+exit 0


### PR DESCRIPTION
## Summary

Defense-in-depth CI gate (agentic-toolkit parity review gap **Settings#0**, P0): fail the PR if the **COMMITTED** `.codex/config.toml` ever ships the fully-unattended, network-open combination —

```
approval_policy = "never"   AND   network_access = true
```

— which would let a Codex agent run shell with **no human approval gate while reaching the network** (a silent, high-blast-radius supply-chain footgun). The safe committed profile is approval-gated (`unless-allow-listed`) with the network off; the guard passes on it and trips **only** if a permissive profile is committed. It is a **check, never a fix** — it never reads or modifies the working tree.

### Critical design contract — reads the committed blob, not the working tree
A fully-permissive profile may legitimately exist as an **uncommitted local edit** (developer convenience, off-limits to tooling). The production path is `git show HEAD:.codex/config.toml`, so the guard never touches that off-limits edit and never false-fails locally while HEAD is safe. In CI the checkout *is* the ref under test, so it asks exactly "is the profile being merged permissive?". Two hermetic test seams (`CODEX_CONFIG_PATH`, `CODEX_CONFIG_SCAN_ROOT`) keep the suite from ever touching the real file.

### Detection
Exact-token, quote/whitespace/trailing-comment tolerant; ignores commented-out keys; requires **both** dangerous keys active (either alone → pass). Each key is anchored to a line-start **or** an inline-table boundary (`{`/`,`), so the combo expressed as a TOML inline table is caught, not just the `[section]` form. All four single-line `never`-string delimiters are enumerated (`"never"`, `'never'`, `"""never"""`, `'''never'''`); `true` is matched case-sensitively (TOML booleans are lowercase). No ERE backreferences — portable across GNU grep (CI) and BSD grep (macOS). A *true* multi-line triple-quoted value is out of scope (its parsed value keeps the newlines, so it is not the token `never` and not a functional permissive setting); the committed-blob check + human review are the documented backstop.

### CI wiring (mirrors the existing self-defending gates)
- new `ci-gate` `needs-codex` output + path filter (`.codex/config.toml`, the guard, its test) — config-only PRs pay only this ~1s read-only check
- new `codex-config-guard` job gated on `needs-codex`
- added to the **required** `ci-success` aggregate's `needs:`
- `check-ci-success.sh` maps `codex-config-guard → needs-codex` (anti-tamper: a skip while its trigger fired fails the required check)
- shellchecked + run by the **CI Self-Defense Tests** job

The `needs-codex ⟹ (needs-ci ∨ needs-onboarding)` invariant holds (`.codex/config.toml` → onboarding via `^\.codex/`; the guard/test under `scripts/` → ci via `^scripts/`), so the codex self-test always re-runs without widening that job's `if:`.

## Test plan
- [x] **TDD**: `scripts/__tests__/check-codex-config-safety.test.sh` (35 cases) written first, confirmed RED, then GREEN
- [x] Covers: safe profile, dangerous combo, single-key passes, commented-out keys, quote/space/comment variants, inline-table forms, single-line triple-quoted strings, the multi-line triple-quoted out-of-scope boundary, uppercase-boolean + near-miss non-matches, missing/empty config, the committed-blob safety contract (committed-safe + working-tree-danger → pass) via a throwaway git repo, and the full `ci.yml`/`ci-success` structural wiring
- [x] Anti-tamper `codex → needs-codex` mapping exercised end-to-end in `check-ci-success.test.sh` (cases 22-24)
- [x] `shellcheck` clean on all four touched scripts
- [x] 6-reviewer board (architect, security, dx [folding UX — `ux-reviewer` agent type unavailable], test, infra-devops) PASS clean

## Stack
Part of the agentic-toolkit parity stack:
**PR-1 #8696 (`agentic/sot-generator`) — merged** → **this PR (`agentic/codex-config-guard`, now based on `main`)** → **#8698 (`agentic/ghaw-lock-sync`, gh-aw lock-sync guard) — stacked on this PR**.
PR-1 has merged; this PR was rebased `--onto main` to drop the squash-redundant PR-1 commits (the Codex-guard change was verified preserved byte-for-byte) and now targets `main` directly. Review/merge this PR before #8698.

Closes #8689
