### PR TITLE
ci: fail npm-audit gate on high advisories, not just critical

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -452,11 +452,11 @@ jobs:
 
       - name: npm audit (web)
         working-directory: web
-        run: npm audit --audit-level=critical
+        run: npm audit --audit-level=high
 
       - name: npm audit (mcp-server)
         working-directory: mcp-server
-        run: npm audit --audit-level=critical
+        run: npm audit --audit-level=high
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -446,14 +446,14 @@ jobs:
 
       - name: npm audit (web)
         working-directory: web
-        run: npm audit --audit-level=critical
+        run: npm audit --audit-level=high
 
       - run: npm ci
         working-directory: mcp-server
 
       - name: npm audit (mcp-server)
         working-directory: mcp-server
-        run: npm audit --audit-level=critical
+        run: npm audit --audit-level=high
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary
- The CD (`cd.yml`) and Quality Gates (`quality-gates.yml`) `npm audit` steps for both `web` and `mcp-server` ran at `--audit-level=critical`, so every current high/moderate advisory passed the gate unnoticed.
- Tightened all four steps to `--audit-level=high` so high-severity advisories fail the build.

CI-only change (no runtime/user-facing code) → `skip changeset` label.

Closes #8600

## Test plan
- [x] `npm audit --audit-level=high` is currently clean for `web` and `mcp-server` (gate passes on this branch)
- [x] CI: CD + Quality Gates npm-audit steps run at `high`