### PR TITLE
fix: allow Vercel Cron routes through Clerk proxy (health-monitor 401)

### DIFF
--- a/.changeset/fix-cron-clerk-proxy-401.md
+++ b/.changeset/fix-cron-clerk-proxy-401.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Allow Vercel Cron routes (`/api/cron/*`) through the Clerk proxy so the scheduled health-monitor isn't 401'd before its own `CRON_SECRET` check runs (#8605). The cron routes remain self-protected by their bearer secret.

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -1,78 +1,179 @@
+// @vitest-environment node
 /**
- * Tests for proxy.ts — public route configuration.
+ * Behavioural tests for proxy.ts.
  *
- * Verifies that unauthenticated routes (health, status, webhooks, etc.)
- * are included in the public routes list so Clerk auth doesn't block them.
+ * Previously this suite read proxy.ts as a *string* and asserted
+ * `source.toContain('/api/cron')`. That is a fake test: it passes off the
+ * explanatory comment that merely mentions `/api/cron`, and it cannot tell a
+ * working pattern (`/api/cron(.*)`) from a broken one (`/api/cron`, which would
+ * NOT match the `/api/cron/health-monitor` subpath under Clerk's matcher). So
+ * the "fix" for #8605 could regress to 401-ing the cron job and the green test
+ * would never notice.
  *
- * proxy.ts uses dynamic require() for Clerk at module scope, making it
- * difficult to mock. We validate the route configuration by reading the
- * source file and checking for the expected route patterns.
+ * These tests exercise real behaviour instead:
+ *  - the public-route list run through the REAL Clerk `createRouteMatcher`;
+ *  - the proxy's real auth decision (`applyAuthDecision`): public passes,
+ *    protected API → 401, protected page → redirect, authed landing → dashboard.
+ *    It is driven directly with a fake `auth()` result and the real matcher —
+ *    proxy.ts pulls clerkMiddleware in via a runtime `require()` that the test
+ *    runner can't intercept, so the decision logic is exported and tested as a
+ *    pure function instead of through the live `proxy`;
+ *  - a cross-route guard that imports every cron route and proves it 401s an
+ *    unauthenticated request — making `/api/cron(.*)` safe to expose at the
+ *    proxy is only valid because each cron route self-enforces CRON_SECRET.
  */
-import { describe, it, expect } from 'vitest';
-import * as fs from 'fs';
-import * as path from 'path';
+import { readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createRouteMatcher } from '@clerk/nextjs/server';
 
-const proxySource = fs.readFileSync(
-  path.resolve(__dirname, '../proxy.ts'),
-  'utf-8',
-);
+import { buildPublicRoutes, applyAuthDecision } from '../proxy';
 
-describe('proxy public route configuration', () => {
-  it('includes /api/health in public routes', () => {
-    expect(proxySource).toContain('/api/health');
+vi.mock('server-only', () => ({}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function reqFor(pathname: string, init?: { method?: string; origin?: string }): any {
+  const url = `https://spawnforge.ai${pathname}`;
+  return {
+    nextUrl: new URL(url),
+    url,
+    method: init?.method ?? 'GET',
+    headers: new Headers(init?.origin ? { origin: init.origin } : {}),
+  };
+}
+
+describe('proxy public-route matcher (real Clerk matcher)', () => {
+  const isPublic = (() => {
+    const matcher = createRouteMatcher(buildPublicRoutes({ includeDev: false }));
+    return (pathname: string) => matcher(reqFor(pathname));
+  })();
+
+  it('treats Vercel cron subpaths as public so CRON_SECRET auth can run (#8605)', () => {
+    // The whole point of #8605: the *subpath* the scheduler actually calls must
+    // match. A bare `/api/cron` pattern (no `(.*)`) fails this assertion even
+    // though the old substring check passed — which is the bug class we are
+    // closing.
+    expect(isPublic('/api/cron/health-monitor')).toBe(true);
+    expect(isPublic('/api/cron')).toBe(true);
   });
 
-  it('includes /api/status in public routes', () => {
-    expect(proxySource).toContain('/api/status');
+  it('keeps authenticated endpoints protected (not public)', () => {
+    expect(isPublic('/api/generate/gdd')).toBe(false);
+    expect(isPublic('/api/generate')).toBe(false);
+    expect(isPublic('/api/projects')).toBe(false);
+    expect(isPublic('/dashboard')).toBe(false);
   });
 
-  it('includes /api/cron in public routes (#8605)', () => {
-    // Vercel Cron (e.g. /api/cron/health-monitor, scheduled */5 in vercel.json)
-    // calls the route with only its own `Authorization: Bearer <CRON_SECRET>`
-    // header — it carries no Clerk session. If the Clerk proxy treats /api/cron
-    // as protected it 401s the request before the route's own CRON_SECRET check
-    // runs, silently killing the scheduled health monitor. The route is
-    // self-protecting (401 without a valid CRON_SECRET), so it must be public
-    // at the proxy layer.
-    expect(proxySource).toContain('/api/cron');
+  it('keeps the other unauthenticated routes public', () => {
+    expect(isPublic('/api/health')).toBe(true);
+    expect(isPublic('/api/status/live')).toBe(true);
+    expect(isPublic('/api/auth/webhook')).toBe(true);
+    expect(isPublic('/api/stripe/webhook')).toBe(true);
+    expect(isPublic('/api/community/feed')).toBe(true);
+    expect(isPublic('/sign-in')).toBe(true);
+    expect(isPublic('/sign-up/sso-callback')).toBe(true);
   });
 
-  it('includes webhook routes in public routes', () => {
-    expect(proxySource).toContain('/api/auth/webhook');
-    expect(proxySource).toContain('/api/stripe/webhook');
+  it('only exposes the /dev auth-bypass route when includeDev (non-production) (#7915)', () => {
+    const prod = createRouteMatcher(buildPublicRoutes({ includeDev: false }));
+    const dev = createRouteMatcher(buildPublicRoutes({ includeDev: true }));
+    expect(prod(reqFor('/dev'))).toBe(false);
+    expect(dev(reqFor('/dev'))).toBe(true);
+  });
+});
+
+describe('proxy auth decision (applyAuthDecision, real matcher)', () => {
+  // The real matcher the production proxy uses (production gating: /dev protected).
+  const isPublicRoute = createRouteMatcher(buildPublicRoutes({ includeDev: false }));
+
+  const redirectToSignIn = vi.fn(
+    (opts: { returnBackUrl: string }) =>
+      new Response(null, { status: 307, headers: { 'x-return-url': opts.returnBackUrl } }),
+  );
+  // Unauthenticated session — the path #8605/#8529 care about.
+  const unauthed = async () => ({ userId: null, redirectToSignIn });
+  // Authenticated session — exercises the landing-page redirect branch.
+  const authed = async () => ({ userId: 'user_123', redirectToSignIn });
+
+  it('lets an unauthenticated request through to a public cron route (#8605)', async () => {
+    const res = await applyAuthDecision(unauthed, reqFor('/api/cron/health-monitor'), isPublicRoute);
+    expect(res.status).toBe(200);
+    // Never asked Clerk to redirect — the route was treated as public.
+    expect(redirectToSignIn).not.toHaveBeenCalled();
   });
 
-  it('includes sign-in and sign-up in public routes', () => {
-    expect(proxySource).toContain('/sign-in');
-    expect(proxySource).toContain('/sign-up');
+  it('returns 401 (not a redirect) for an unauthenticated protected API request (#8529)', async () => {
+    const res = await applyAuthDecision(unauthed, reqFor('/api/generate/gdd'), isPublicRoute);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
   });
 
-  it('includes community routes in public routes', () => {
-    expect(proxySource).toContain('/api/community');
+  it('redirects an unauthenticated protected page nav to sign-in, never /404 (#8529)', async () => {
+    redirectToSignIn.mockClear();
+    const res = await applyAuthDecision(unauthed, reqFor('/dashboard'), isPublicRoute);
+    expect(res.status).toBe(307);
+    // Must preserve the original URL so the user lands back where they started.
+    expect(redirectToSignIn).toHaveBeenCalledWith({ returnBackUrl: 'https://spawnforge.ai/dashboard' });
   });
 
-  it('does not expose /api/generate as a public route', () => {
-    // Generate endpoints require authentication — they should NOT be in publicRoutes
-    expect(proxySource).not.toMatch(/['"]\/api\/generate/);
+  it('redirects an authenticated user away from the landing page to the dashboard', async () => {
+    const res = await applyAuthDecision(authed, reqFor('/'), isPublicRoute);
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe('https://spawnforge.ai/dashboard');
+  });
+});
+
+describe('cron routes self-enforce auth (guard for the public-at-proxy decision)', () => {
+  // Exposing `/api/cron(.*)` at the proxy (#8605) is only safe because every
+  // cron route rejects an unauthenticated request itself. This guard imports
+  // EVERY cron route and proves it 401s without a CRON_SECRET — so a future
+  // cron route added without auth fails CI rather than silently shipping an
+  // open, Clerk-bypassed endpoint.
+  const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+  const cronDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '../app/api/cron');
+
+  // Recursively collect every `route.ts` under app/api/cron, skipping test dirs.
+  function findCronRoutes(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') continue;
+        out.push(...findCronRoutes(path.join(dir, entry.name)));
+      } else if (entry.name === 'route.ts' || entry.name === 'route.tsx') {
+        out.push(path.join(dir, entry.name));
+      }
+    }
+    return out;
+  }
+  const cronRoutes = findCronRoutes(cronDir);
+
+  beforeAll(() => {
+    vi.stubEnv('CRON_SECRET', ''); // unconfigured → every cron route must reject
+  });
+  afterAll(() => {
+    vi.unstubAllEnvs();
   });
 
-  it('redirects unauthenticated browser nav instead of rewriting to /404 (#8529)', () => {
-    // Clerk's `auth.protect()` default rewrites to /404 for browser navigations.
-    // That gives users no recovery path. We must call redirectToSignIn() so
-    // unauthenticated visitors land on /sign-in with a return URL.
-    expect(proxySource).toContain('redirectToSignIn');
-    expect(proxySource).toContain('returnBackUrl');
-    // And the proxy should NOT call auth.protect() any more, which would
-    // re-introduce the 404 regression. Strip comments before matching so the
-    // explanatory comment that mentions auth.protect() doesn't trigger this.
-    const codeWithoutComments = proxySource.replace(/\/\/.*$/gm, '');
-    expect(codeWithoutComments).not.toMatch(/auth\.protect\(\)/);
+  it('discovers at least one cron route to guard', () => {
+    expect(cronRoutes.length).toBeGreaterThan(0);
   });
 
-  it('returns 401 (not 307) for unauthenticated /api/* requests', () => {
-    // Browser nav -> 307 to sign-in. API requests -> 401 JSON so client code
-    // can distinguish "unauthenticated" from "not found" without parsing HTML.
-    expect(proxySource).toMatch(/pathname\.startsWith\(['"]\/api\//);
-    expect(proxySource).toMatch(/status:\s*401/);
-  });
+  for (const routePath of cronRoutes) {
+    const rel = path.relative(cronDir, routePath);
+    it(`${rel} returns 401 for an unauthenticated request`, async () => {
+      const mod = (await import(routePath)) as Record<string, unknown>;
+      const handlers = HTTP_METHODS.filter((m) => typeof mod[m] === 'function');
+      expect(handlers.length).toBeGreaterThan(0);
+      for (const method of handlers) {
+        const handler = mod[method] as (req: NextRequest) => Promise<Response>;
+        const res = await handler(
+          new NextRequest('https://spawnforge.ai/api/cron/x', { method }),
+        );
+        expect(res.status).toBe(401);
+      }
+    });
+  }
 });

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -26,6 +26,17 @@ describe('proxy public route configuration', () => {
     expect(proxySource).toContain('/api/status');
   });
 
+  it('includes /api/cron in public routes (#8605)', () => {
+    // Vercel Cron (e.g. /api/cron/health-monitor, scheduled */5 in vercel.json)
+    // calls the route with only its own `Authorization: Bearer <CRON_SECRET>`
+    // header — it carries no Clerk session. If the Clerk proxy treats /api/cron
+    // as protected it 401s the request before the route's own CRON_SECRET check
+    // runs, silently killing the scheduled health monitor. The route is
+    // self-protecting (401 without a valid CRON_SECRET), so it must be public
+    // at the proxy layer.
+    expect(proxySource).toContain('/api/cron');
+  });
+
   it('includes webhook routes in public routes', () => {
     expect(proxySource).toContain('/api/auth/webhook');
     expect(proxySource).toContain('/api/stripe/webhook');

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -85,6 +85,117 @@ function passthroughMiddleware(req: NextRequest): NextResponse {
 }
 
 /**
+ * Public (unauthenticated) route patterns for the Clerk proxy, in Clerk
+ * `createRouteMatcher` glob syntax.
+ *
+ * Exported so the proxy's public-vs-protected decision can be unit-tested
+ * against the REAL Clerk matcher (see `proxy.test.ts`) instead of grepping the
+ * source. A substring check over the source can't tell a live pattern from one
+ * buried in a comment, and — worse — can't catch a missing `(.*)` that would
+ * silently stop a subpath like `/api/cron/health-monitor` from matching while
+ * the bare `/api/cron` string still appears in the file.
+ *
+ * `includeDev` adds the `/dev` auth-bypass route. It is only ever true outside
+ * production: in production the `/dev` editor requires authentication like any
+ * other editor route, to prevent unauthenticated access to the full editor UI
+ * (#7915).
+ */
+export function buildPublicRoutes({ includeDev }: { includeDev: boolean }): string[] {
+  const publicRoutes = [
+    '/',
+    '/sign-in(.*)',
+    '/sign-up(.*)',
+    '/api/auth/webhook(.*)',
+    '/api/stripe/webhook(.*)',
+    '/pricing',
+    '/play(.*)',
+    '/terms(.*)',
+    '/privacy(.*)',
+    '/community(.*)',
+    '/api/community(.*)',
+    '/api/docs(.*)',
+    '/api-docs(.*)',
+    '/api/openapi(.*)',
+    '/api/health(.*)',
+    '/api/status(.*)',
+    // Vercel Cron jobs (e.g. /api/cron/health-monitor, vercel.json crons) carry
+    // only a CRON_SECRET bearer token, no Clerk session. The routes enforce that
+    // secret themselves (see the cron-self-enforcement guard in proxy.test.ts),
+    // so they must bypass the Clerk proxy or the scheduled call 401s before its
+    // own auth check runs (#8605).
+    '/api/cron(.*)',
+    '/api/sentry(.*)',
+    '/monitoring(.*)',
+    '/llms.txt',
+    '/llms-full.txt',
+    '/faq(.*)',
+    '/about(.*)',
+    '/compare(.*)',
+    '/use-cases(.*)',
+    '/changelog(.*)',
+    '/blog(.*)',
+  ];
+  if (includeDev) {
+    publicRoutes.push('/dev(.*)');
+  }
+  return publicRoutes;
+}
+
+/** Minimal shape of Clerk's `auth()` result that the proxy depends on. */
+type ProxyAuth = () => Promise<{
+  userId: string | null;
+  redirectToSignIn: (opts: { returnBackUrl: string }) => Response;
+}>;
+
+/**
+ * The proxy's per-request auth decision, factored out of the clerkMiddleware
+ * callback so it can be unit-tested directly.
+ *
+ * It cannot be tested through `proxy` itself: clerkMiddleware is pulled in via a
+ * runtime `require()` (to keep Clerk's import-time key validation out of the
+ * CI/E2E passthrough path), and the test runner cannot intercept that require to
+ * stub auth. Exposing the decision as a pure function — given an `auth` result
+ * and an `isPublicRoute` matcher — lets the real 401-vs-redirect logic be
+ * exercised with the real Clerk route matcher and no live keys (see
+ * `proxy.test.ts`).
+ */
+export async function applyAuthDecision(
+  auth: ProxyAuth,
+  req: NextRequest,
+  isPublicRoute: (req: NextRequest) => boolean,
+): Promise<Response> {
+  const corsResponse = handleCors(req);
+  if (corsResponse) return corsResponse;
+
+  // Redirect authenticated users from landing page to dashboard.
+  // This runs in the proxy so the landing page itself can be statically cached.
+  if (req.nextUrl.pathname === '/') {
+    const { userId } = await auth();
+    if (userId) {
+      return NextResponse.redirect(new URL('/dashboard', req.url));
+    }
+  }
+
+  if (!isPublicRoute(req)) {
+    const { userId, redirectToSignIn } = await auth();
+    if (!userId) {
+      // Browser navigations: redirect to sign-in (preserves the original URL
+      // as `redirect_url` so users land back where they started after auth).
+      // API requests: return 401 so client code can distinguish unauthenticated
+      // from "not found". Clerk's default `auth.protect()` would rewrite browser
+      // requests to /404 — bad UX (no recovery path) and breaks the prod smoke
+      // test. See #8529.
+      if (req.nextUrl.pathname.startsWith('/api/')) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+      return redirectToSignIn({ returnBackUrl: req.url });
+    }
+  }
+
+  return addSecurityHeaders(NextResponse.next(), req);
+}
+
+/**
  * Build the proxy middleware.
  *
  * When valid Clerk keys are present, use clerkMiddleware for auth.
@@ -107,46 +218,9 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { clerkMiddleware, createRouteMatcher } = require('@clerk/nextjs/server');
 
-  // /dev route bypasses auth for local development only.
-  // In production, /dev requires authentication like any other editor route
-  // to prevent unauthenticated access to the full editor UI (#7915).
-  const publicRoutes = [
-    '/',
-    '/sign-in(.*)',
-    '/sign-up(.*)',
-    '/api/auth/webhook(.*)',
-    '/api/stripe/webhook(.*)',
-    '/pricing',
-    '/play(.*)',
-    '/terms(.*)',
-    '/privacy(.*)',
-    '/community(.*)',
-    '/api/community(.*)',
-    '/api/docs(.*)',
-    '/api-docs(.*)',
-    '/api/openapi(.*)',
-    '/api/health(.*)',
-    '/api/status(.*)',
-    // Vercel Cron jobs (e.g. /api/cron/health-monitor, vercel.json crons) carry
-    // only a CRON_SECRET bearer token, no Clerk session. The routes enforce that
-    // secret themselves, so they must bypass the Clerk proxy or the scheduled
-    // call 401s before its own auth check runs (#8605).
-    '/api/cron(.*)',
-    '/api/sentry(.*)',
-    '/monitoring(.*)',
-    '/llms.txt',
-    '/llms-full.txt',
-    '/faq(.*)',
-    '/about(.*)',
-    '/compare(.*)',
-    '/use-cases(.*)',
-    '/changelog(.*)',
-    '/blog(.*)',
-  ];
-  if (process.env.NODE_ENV !== 'production') {
-    publicRoutes.push('/dev(.*)');
-  }
-  const isPublicRoute = createRouteMatcher(publicRoutes);
+  const isPublicRoute = createRouteMatcher(
+    buildPublicRoutes({ includeDev: process.env.NODE_ENV !== 'production' }),
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return clerkMiddleware(async (auth: any, req: NextRequest) => {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -148,16 +148,17 @@ type ProxyAuth = () => Promise<{
 }>;
 
 /**
- * The proxy's per-request auth decision, factored out of the clerkMiddleware
- * callback so it can be unit-tested directly.
+ * The proxy's per-request auth decision. This is the SINGLE implementation: the
+ * production clerkMiddleware callback in buildProxy() delegates straight to it, and
+ * proxy.test.ts drives it directly — so the unit tests exercise the exact code that
+ * runs in production, with no parallel copy that can silently diverge.
  *
- * It cannot be tested through `proxy` itself: clerkMiddleware is pulled in via a
- * runtime `require()` (to keep Clerk's import-time key validation out of the
+ * It cannot be reached through `proxy` itself in tests: clerkMiddleware is pulled in
+ * via a runtime `require()` (to keep Clerk's import-time key validation out of the
  * CI/E2E passthrough path), and the test runner cannot intercept that require to
- * stub auth. Exposing the decision as a pure function — given an `auth` result
- * and an `isPublicRoute` matcher — lets the real 401-vs-redirect logic be
- * exercised with the real Clerk route matcher and no live keys (see
- * `proxy.test.ts`).
+ * stub auth. Exposing the decision as a pure function — given an `auth` result and
+ * an `isPublicRoute` matcher — lets the real 401-vs-redirect logic be exercised with
+ * the real Clerk route matcher and no live keys (see `proxy.test.ts`).
  */
 export async function applyAuthDecision(
   auth: ProxyAuth,
@@ -222,38 +223,14 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     buildPublicRoutes({ includeDev: process.env.NODE_ENV !== 'production' }),
   );
 
+  // The production callback delegates to applyAuthDecision so the unit tests in
+  // proxy.test.ts exercise the EXACT logic that runs in production — not a parallel
+  // copy that can silently diverge. A single decision implementation is the whole
+  // point of #8605 (route tests that never hit the real request path left CI blind).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return clerkMiddleware(async (auth: any, req: NextRequest) => {
-    const corsResponse = handleCors(req);
-    if (corsResponse) return corsResponse;
-
-    // Redirect authenticated users from landing page to dashboard.
-    // This runs in the proxy so the landing page itself can be statically cached.
-    if (req.nextUrl.pathname === '/') {
-      const { userId } = await auth();
-      if (userId) {
-        return NextResponse.redirect(new URL('/dashboard', req.url));
-      }
-    }
-
-    if (!isPublicRoute(req)) {
-      const { userId, redirectToSignIn } = await auth();
-      if (!userId) {
-        // Browser navigations: redirect to sign-in (preserves the original URL
-        // as `redirect_url` so users land back where they started after auth).
-        // API requests: return 401 so client code can distinguish unauthenticated
-        // from "not found". Clerk's default `auth.protect()` would rewrite browser
-        // requests to /404 — bad UX (no recovery path) and breaks the prod smoke
-        // test. See #8529.
-        if (req.nextUrl.pathname.startsWith('/api/')) {
-          return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-        }
-        return redirectToSignIn({ returnBackUrl: req.url });
-      }
-    }
-
-    return addSecurityHeaders(NextResponse.next(), req);
-  });
+  return clerkMiddleware((auth: any, req: NextRequest) =>
+    applyAuthDecision(auth, req, isPublicRoute),
+  );
 }
 
 export const proxy = buildProxy();

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -127,6 +127,11 @@ function buildProxy(): (req: NextRequest) => NextResponse | Promise<NextResponse
     '/api/openapi(.*)',
     '/api/health(.*)',
     '/api/status(.*)',
+    // Vercel Cron jobs (e.g. /api/cron/health-monitor, vercel.json crons) carry
+    // only a CRON_SECRET bearer token, no Clerk session. The routes enforce that
+    // secret themselves, so they must bypass the Clerk proxy or the scheduled
+    // call 401s before its own auth check runs (#8605).
+    '/api/cron(.*)',
     '/api/sentry(.*)',
     '/monitoring(.*)',
     '/llms.txt',


### PR DESCRIPTION
## Summary
- Vercel Cron hits `/api/cron/*` with no Clerk session, so the proxy 401'd the scheduled health-monitor before its own `CRON_SECRET` bearer check could run — a silent monitoring outage in production.
- The proxy now treats `/api/cron/*` as a public route (auth delegated to the route's own bearer-secret check); the cron routes remain self-protected by `CRON_SECRET`.
- Auth-decision logic extracted/clarified and covered by expanded `proxy.test.ts`.

Closes #8605

## Test plan
- [x] `proxy.test.ts` — cron route passes the proxy unauthenticated; other protected API routes still 401; browser routes still redirect
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, targeted vitest green