### PR TITLE
fix: delete Clerk identity on account deletion (no orphaned/resurrected account)

### DIFF
--- a/.changeset/fix-orphaned-clerk-user-on-delete.md
+++ b/.changeset/fix-orphaned-clerk-user-on-delete.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix account deletion leaving an orphaned Clerk identity. `POST /api/user/delete` purged all DB data but never deleted the Clerk user, so the Clerk session/user survived and the next authenticated request re-synced a fresh empty DB user — silently resurrecting the "deleted" account. The route now deletes the Clerk identity after the DB purge, in its own try/catch: the DB delete is the privacy-critical step and runs first (a failure 500s and keeps the Clerk user intact), while a Clerk-side failure after the DB commit reports success and captures to Sentry for manual cleanup rather than 500ing (#8606).

--- a/web/src/app/api/user/delete/route.test.ts
+++ b/web/src/app/api/user/delete/route.test.ts
@@ -4,15 +4,32 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import { authenticateRequest } from '@/lib/auth/api-auth';
 import { deleteUserAccount } from '@/lib/auth/user-service';
+import { clerkClient } from '@clerk/nextjs/server';
+import { captureException } from '@/lib/monitoring/sentry-server';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth/api-auth');
 vi.mock('@/lib/auth/user-service');
+vi.mock('@clerk/nextjs/server', () => ({ clerkClient: vi.fn() }));
+vi.mock('@/lib/monitoring/sentry-server', () => ({ captureException: vi.fn() }));
+// Always allow through the rate limiter so account-delete tests don't share a
+// per-user bucket across cases.
+vi.mock('@/lib/rateLimit/distributed', () => ({
+  distributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 5, resetAt: 0 }),
+  aggregateGenerationRateLimit: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mockClerk(deleteUser: ReturnType<typeof vi.fn>): any {
+  return { users: { deleteUser } };
+}
 
 describe('POST /api/user/delete', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: a working Clerk client so the happy path doesn't hit the error branch.
+    vi.mocked(clerkClient).mockResolvedValue(mockClerk(vi.fn()));
   });
 
   it('returns 401 if unauthenticated', async () => {
@@ -32,26 +49,75 @@ describe('POST /api/user/delete', () => {
 
     const res = await POST(new NextRequest('http://localhost/api/user/delete'));
     const data = await res.json();
-    
+
     expect(res.status).toBe(200);
     expect(data.deleted).toBe(true);
     expect(deleteUserAccount).toHaveBeenCalledWith(user.id);
   });
 
-  it('returns 500 if deletion fails', async () => {
+  it('returns 500 if DB deletion fails', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
     vi.mocked(deleteUserAccount).mockRejectedValue(new Error('DB connection failed'));
 
-    // Suppress console.error for this test
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await POST(new NextRequest('http://localhost/api/user/delete'));
+    const data = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(data.error).toBe('Failed to delete account');
+    expect(captureException).toHaveBeenCalled();
+  });
+
+  it('does not delete the Clerk identity when the DB purge fails (#8606)', async () => {
+    // If the DB delete throws, we must NOT delete the Clerk user — otherwise the
+    // user is locked out of an account whose data still exists.
+    const user = makeUser({ id: 'u-del-guard' });
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'clerk-guard', user } });
+    vi.mocked(deleteUserAccount).mockRejectedValue(new Error('DB connection failed'));
+    const deleteUser = vi.fn();
+    vi.mocked(clerkClient).mockResolvedValue(mockClerk(deleteUser));
+
+    const res = await POST(new NextRequest('http://localhost/api/user/delete'));
+    expect(res.status).toBe(500);
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  it('deletes the orphaned Clerk identity AFTER purging the DB account (#8606)', async () => {
+    // The DB purge alone leaves the Clerk session/user intact; the next
+    // authenticated request re-syncs a fresh empty DB user from Clerk, silently
+    // resurrecting the "deleted" account. The route must delete the Clerk user
+    // too — and only after the DB data is gone.
+    const user = makeUser({ id: 'u-del-1' });
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'clerk-del-1', user } });
+
+    const order: string[] = [];
+    vi.mocked(deleteUserAccount).mockImplementation(async () => { order.push('db'); });
+    const deleteUser = vi.fn().mockImplementation(async () => { order.push('clerk'); });
+    vi.mocked(clerkClient).mockResolvedValue(mockClerk(deleteUser));
+
+    const res = await POST(new NextRequest('http://localhost/api/user/delete'));
+
+    expect(res.status).toBe(200);
+    expect(deleteUserAccount).toHaveBeenCalledWith('u-del-1');
+    expect(deleteUser).toHaveBeenCalledWith('clerk-del-1');
+    expect(order).toEqual(['db', 'clerk']);
+  });
+
+  it('still returns 200 and captures to Sentry when Clerk deletion fails after the DB purge (#8606)', async () => {
+    const user = makeUser({ id: 'u-del-2' });
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'clerk-del-2', user } });
+    vi.mocked(deleteUserAccount).mockResolvedValue(undefined);
+    const deleteUser = vi.fn().mockRejectedValue(new Error('Clerk API 503'));
+    vi.mocked(clerkClient).mockResolvedValue(mockClerk(deleteUser));
 
     const res = await POST(new NextRequest('http://localhost/api/user/delete'));
     const data = await res.json();
-    
-    expect(res.status).toBe(500);
-    expect(data.error).toBe('Failed to delete account');
-    
-    consoleSpy.mockRestore();
+
+    // The destructive DB delete already committed — a Clerk-side failure must not
+    // surface as a 500 (which would imply nothing was deleted). Report success
+    // and alert Sentry so the orphaned Clerk identity can be cleaned up manually.
+    expect(res.status).toBe(200);
+    expect(data.deleted).toBe(true);
+    expect(captureException).toHaveBeenCalled();
   });
 });

--- a/web/src/app/api/user/delete/route.ts
+++ b/web/src/app/api/user/delete/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { clerkClient } from '@clerk/nextjs/server';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { deleteUserAccount } from '@/lib/auth/user-service';
 import { captureException } from '@/lib/monitoring/sentry-server';
@@ -15,9 +16,12 @@ export async function POST(req: NextRequest) {
   });
   if (mid.error) return mid.error;
 
+  // 1. Purge all DB data first. This is the privacy-critical step (PII,
+  //    projects, financial records), so it must succeed before we touch Clerk —
+  //    if it fails we 500 and leave the Clerk identity intact so the user isn't
+  //    locked out of an account whose data still exists.
   try {
     await deleteUserAccount(mid.userId!);
-    return NextResponse.json({ deleted: true });
   } catch (err) {
     captureException(err, { route: '/api/user/delete' });
     return NextResponse.json(
@@ -25,4 +29,24 @@ export async function POST(req: NextRequest) {
       { status: 500 }
     );
   }
+
+  // 2. Delete the Clerk identity. Without this the Clerk session/user survives,
+  //    and the next authenticated request re-syncs a fresh empty DB user from
+  //    Clerk — silently resurrecting the "deleted" account (#8606). The
+  //    destructive DB delete has already committed, so a Clerk-side failure must
+  //    NOT surface as a 500 (that would imply nothing was deleted and invite a
+  //    confusing retry). Report success and alert Sentry for manual cleanup of
+  //    the orphaned Clerk user.
+  try {
+    const client = await clerkClient();
+    await client.users.deleteUser(mid.authContext!.clerkId);
+  } catch (err) {
+    captureException(err, {
+      route: '/api/user/delete',
+      step: 'clerk-delete',
+      clerkId: mid.authContext!.clerkId,
+    });
+  }
+
+  return NextResponse.json({ deleted: true });
 }


### PR DESCRIPTION
## Summary
- `POST /api/user/delete` purged all DB data but never deleted the Clerk user, so the Clerk session survived and the next authenticated request re-synced a fresh empty DB user — silently resurrecting the "deleted" account.
- The route now deletes the Clerk identity **after** the DB purge, in its own try/catch:
  - DB delete is the privacy-critical step and runs first; a failure 500s and leaves the Clerk user intact (safe to retry).
  - A Clerk-side failure after the DB commit reports success and captures to Sentry for manual cleanup, rather than 500ing on an already-purged account.
- Uses `authContext.clerkId` for the deletion target.

Closes #8606

## Test plan
- [x] `user/delete/route.test.ts` — Clerk user deleted after DB purge; DB-failure path 500s and skips Clerk delete; Clerk-failure-after-DB path returns success + Sentry capture
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, targeted vitest green