### PR TITLE
ci(coverage-gate): stop swallowing vitest coverage-threshold failures

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -166,8 +166,9 @@ jobs:
       - name: Run tests
         working-directory: web
         # Timeout safety net: vitest hangs after test completion due to jsdom open
-        # handles (known issue vitest#3077). Exit 124 = timeout killed a hung process
-        # after tests already completed successfully -- treat as warning, not failure.
+        # handles (known issue vitest#3077). Exit 124 = the timeout killed the process;
+        # the gate below swallows it ONLY when the captured output proves a fully
+        # passing run -- a timed-out run with test/coverage failures still fails.
         run: |
           set +e
           timeout 600 npx vitest run 2>&1 | tee /tmp/vitest-output.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -166,9 +166,10 @@ jobs:
       - name: Run tests
         working-directory: web
         # Timeout safety net: vitest hangs after test completion due to jsdom open
-        # handles (known issue vitest#3077). Exit 124 = the timeout killed the process;
-        # the gate below swallows it ONLY when the captured output proves a fully
-        # passing run -- a timed-out run with test/coverage failures still fails.
+        # handles (known issue vitest#3077). A non-zero exit (timeout 124, OOM 137,
+        # segfault 139, ...) is swallowed by the gate below ONLY when the captured
+        # output proves a fully passing run -- a run killed mid-tests (or with
+        # test/coverage failures on record) still fails.
         run: |
           set +e
           timeout 600 npx vitest run 2>&1 | tee /tmp/vitest-output.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -173,20 +173,14 @@ jobs:
           timeout 600 npx vitest run 2>&1 | tee /tmp/vitest-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
-          if [ $EXIT_CODE -eq 124 ]; then
-            echo "::warning::vitest process was killed after 600s -- likely hung during cleanup (vitest#3077)"
-            exit 0
-          fi
-          # vitest 4.x may exit non-zero due to open handles even when all tests pass.
-          # Check if any tests actually failed before propagating the exit code.
-          if [ $EXIT_CODE -ne 0 ]; then
-            if sed 's/\x1b\[[0-9;]*m//g' /tmp/vitest-output.txt | grep -q "Test Files.*failed"; then
-              exit $EXIT_CODE
-            else
-              echo "::warning::vitest exited with code $EXIT_CODE but no test failures detected -- likely open handle issue (vitest#3077)"
-              exit 0
-            fi
-          fi
+          # Adjudicate the exit code via the single tested gate
+          # (scripts/check-vitest-exit.sh, unit-tested by the CI Self-Defense
+          # Tests job) — the same gate quality-gates.yml uses, so the two no
+          # longer drift. It propagates real test failures (and coverage-threshold
+          # failures, though this job runs without --coverage) and swallows only
+          # the vitest#3077 open-handle / timeout false positives. Invoked by
+          # repo-root path because this step runs with working-directory: web.
+          bash "$GITHUB_WORKSPACE/scripts/check-vitest-exit.sh" "$EXIT_CODE" /tmp/vitest-output.txt
 
   test-mcp:
     name: MCP Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,6 +624,7 @@ jobs:
             scripts/check-taskboard-onboarding-hygiene.sh scripts/__tests__/check-taskboard-onboarding-hygiene.test.sh \
             scripts/check-codex-config-safety.sh scripts/__tests__/check-codex-config-safety.test.sh \
             scripts/check-ghaw-lock-sync.sh scripts/get-ghaw-compiler-version.sh scripts/__tests__/check-ghaw-lock-sync.test.sh \
+            scripts/check-vitest-exit.sh scripts/__tests__/check-vitest-exit.test.sh \
             .claude/tools/dx-audit.sh .claude/tools/__tests__/dx-audit.test.sh
 
       - name: Run lockfile gate test suite
@@ -643,6 +644,9 @@ jobs:
 
       - name: Run gh-aw lock-sync gate test suite
         run: bash scripts/__tests__/check-ghaw-lock-sync.test.sh
+
+      - name: Run vitest exit-gate test suite
+        run: bash scripts/__tests__/check-vitest-exit.test.sh
 
       - name: Run cross-provider DX-audit contract test
         run: bash .claude/tools/__tests__/dx-audit.test.sh

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -164,9 +164,11 @@ jobs:
         # environments) but workspace mode does not enforce root-level coverage
         # thresholds — so CI uses the standalone config instead.
         # Timeout safety net: vitest hangs after test completion due to jsdom/coverage
-        # open handles (known issue vitest#3077). Exit 124 = the timeout killed the
-        # process; the gate below swallows it ONLY when the captured output proves a
-        # fully passing run — a timed-out run with test/coverage failures still fails.
+        # open handles (known issue vitest#3077). A non-zero exit (timeout 124, OOM
+        # 137, segfault 139, ...) is swallowed by the gate below ONLY when the
+        # captured output proves a fully COMPLETED run — green test summary AND
+        # (because this job runs --coverage) the coverage report — so a run killed
+        # mid-tests or before coverage thresholds were adjudicated still fails.
         run: |
           set +e
           timeout 600 npx vitest run --coverage 2>&1 | tee /tmp/vitest-output.txt
@@ -177,9 +179,13 @@ jobs:
           # Tests job). It propagates real test failures AND coverage-threshold
           # failures (#8598 — these were previously swallowed because a coverage
           # miss has no "Test Files ... failed" line), and swallows only the
-          # vitest#3077 open-handle / timeout false positives. Invoked by repo-root
-          # path because this step runs with working-directory: web.
-          bash "$GITHUB_WORKSPACE/scripts/check-vitest-exit.sh" "$EXIT_CODE" /tmp/vitest-output.txt
+          # vitest#3077 open-handle / timeout false positives. The --coverage flag
+          # makes the gate also require the "Coverage report from" marker before
+          # swallowing — a green test summary alone does not prove the coverage
+          # thresholds were ever adjudicated (report generation is the hang-prone
+          # tail of the run). Invoked by repo-root path because this step runs
+          # with working-directory: web.
+          bash "$GITHUB_WORKSPACE/scripts/check-vitest-exit.sh" "$EXIT_CODE" /tmp/vitest-output.txt --coverage
 
       - name: Upload coverage artifact
         if: always()

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -164,8 +164,9 @@ jobs:
         # environments) but workspace mode does not enforce root-level coverage
         # thresholds — so CI uses the standalone config instead.
         # Timeout safety net: vitest hangs after test completion due to jsdom/coverage
-        # open handles (known issue vitest#3077). Exit 124 = timeout killed a hung
-        # process after tests already completed successfully — treat as warning, not failure.
+        # open handles (known issue vitest#3077). Exit 124 = the timeout killed the
+        # process; the gate below swallows it ONLY when the captured output proves a
+        # fully passing run — a timed-out run with test/coverage failures still fails.
         run: |
           set +e
           timeout 600 npx vitest run --coverage 2>&1 | tee /tmp/vitest-output.txt

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -166,9 +166,14 @@ jobs:
         # Timeout safety net: vitest hangs after test completion due to jsdom/coverage
         # open handles (known issue vitest#3077). A non-zero exit (timeout 124, OOM
         # 137, segfault 139, ...) is swallowed by the gate below ONLY when the
-        # captured output proves a fully COMPLETED run — green test summary AND
-        # (because this job runs --coverage) the coverage report — so a run killed
-        # mid-tests or before coverage thresholds were adjudicated still fails.
+        # captured output shows a green test summary AND (because this job runs
+        # --coverage) the "Coverage report from" marker — proof the tests completed
+        # and the coverage phase reached report generation. A run killed mid-tests
+        # or before report generation began still fails. The marker prints just
+        # BEFORE the reporters and threshold adjudication run, so a kill inside
+        # that brief tail window is still swallowed — strongest in-band evidence
+        # available; defense-in-depth, not airtight (see
+        # scripts/check-vitest-exit.sh header for the full guarantee).
         run: |
           set +e
           timeout 600 npx vitest run --coverage 2>&1 | tee /tmp/vitest-output.txt
@@ -183,8 +188,10 @@ jobs:
           # makes the gate also require the "Coverage report from" marker before
           # swallowing — a green test summary alone does not prove the coverage
           # thresholds were ever adjudicated (report generation is the hang-prone
-          # tail of the run). Invoked by repo-root path because this step runs
-          # with working-directory: web.
+          # tail of the run). The marker itself proves reporting BEGAN, not that
+          # adjudication finished — see the gate script header for the exact
+          # guarantee and accepted residual window. Invoked by repo-root path
+          # because this step runs with working-directory: web.
           bash "$GITHUB_WORKSPACE/scripts/check-vitest-exit.sh" "$EXIT_CODE" /tmp/vitest-output.txt --coverage
 
       - name: Upload coverage artifact

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -171,20 +171,14 @@ jobs:
           timeout 600 npx vitest run --coverage 2>&1 | tee /tmp/vitest-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
           set -e
-          if [ $EXIT_CODE -eq 124 ]; then
-            echo "::warning::vitest process was killed after 600s — likely hung during cleanup (vitest#3077)"
-            exit 0
-          fi
-          # vitest 4.x may exit non-zero due to open handles even when all tests pass.
-          # Check if any tests actually failed before propagating the exit code.
-          if [ $EXIT_CODE -ne 0 ]; then
-            if sed 's/\x1b\[[0-9;]*m//g' /tmp/vitest-output.txt | grep -q "Test Files.*failed"; then
-              exit $EXIT_CODE
-            else
-              echo "::warning::vitest exited with code $EXIT_CODE but no test failures detected — likely open handle issue (vitest#3077)"
-              exit 0
-            fi
-          fi
+          # Adjudicate the exit code via the single tested gate
+          # (scripts/check-vitest-exit.sh, unit-tested by the CI Self-Defense
+          # Tests job). It propagates real test failures AND coverage-threshold
+          # failures (#8598 — these were previously swallowed because a coverage
+          # miss has no "Test Files ... failed" line), and swallows only the
+          # vitest#3077 open-handle / timeout false positives. Invoked by repo-root
+          # path because this step runs with working-directory: web.
+          bash "$GITHUB_WORKSPACE/scripts/check-vitest-exit.sh" "$EXIT_CODE" /tmp/vitest-output.txt
 
       - name: Upload coverage artifact
         if: always()

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -60,8 +60,16 @@ OPENHANDLE_OUTPUT=' Test Files  120 passed (120)
 
 Error: A worker process has failed to exit gracefully'
 
-# ANSI-colored coverage error (vitest colorizes ERROR lines).
-ANSI_COVERAGE_OUTPUT=$' Test Files  120 passed (120)\n\x1b[31mERROR: Coverage for branches (55%) does not meet global threshold (60%)\x1b[0m'
+# ANSI-colored coverage error (vitest colorizes ERROR lines). The escapes here
+# SPLIT two regex-load-bearing tokens mid-word — "Co\x1b[31mverage" and
+# "thr\x1b[0meshold" — NOT just colorize at the line boundary. That distinction
+# is what gives test #7 teeth: the detection regex's `.*` wildcards already span
+# a boundary escape, so a boundary-only fixture would still match even if the
+# sed ANSI-strip were deleted (a surviving mutant). With the escapes inside the
+# tokens, the literal substrings "coverage"/"threshold" only exist AFTER the
+# strip runs, so removing the strip makes the gate miss the line and the test
+# fails — proving the strip line is the code under test, not decoration.
+ANSI_COVERAGE_OUTPUT=$' Test Files  120 passed (120)\n\x1b[31mERROR: Co\x1b[31mverage for branches (55%) does not meet global thr\x1b[0meshold (60%)\x1b[0m'
 
 # vitest's SECOND threshold-failure form (negative / max-uncovered threshold):
 # "Uncovered X (N) exceed global threshold (M)". All tests pass, exit still 1.
@@ -106,10 +114,12 @@ f="$(mkfile oh.txt "$OPENHANDLE_OUTPUT")"
 rc="$(run_gate 1 "$f")"
 if [ "$rc" = "0" ]; then pass "open-handle noise → gate 0 (workaround preserved)"; else fail "open-handle noise → expected 0, got $rc"; fi
 
-# 7. ANSI-colored coverage error still detected → propagate.
+# 7. ANSI escapes split the "coverage"/"threshold" tokens mid-word → the gate
+#    only matches after the sed strip runs (delete the strip and this regresses
+#    to a swallowed miss). Real teeth on the ANSI-strip line, not boundary color.
 f="$(mkfile ansi.txt "$ANSI_COVERAGE_OUTPUT")"
 rc="$(run_gate 1 "$f")"
-if [ "$rc" = "1" ]; then pass "ANSI coverage miss → gate 1 (ANSI stripped)"; else fail "ANSI coverage miss → expected 1, got $rc"; fi
+if [ "$rc" = "1" ]; then pass "ANSI mid-token coverage miss → gate 1 (strip is load-bearing)"; else fail "ANSI mid-token coverage miss → expected 1, got $rc"; fi
 
 # 8. Fail closed: non-zero exit but evidence file MISSING → propagate, never swallow.
 rc="$(run_gate 1 "$TMPDIR_T/does-not-exist.txt")"

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -82,6 +82,20 @@ COVERAGE_UNCOVERED_PERFILE_OUTPUT=' Test Files  120 passed (120)
       Tests  1400 passed (1400)
 ERROR: Uncovered lines (12) exceed "src/math.ts" threshold (10)'
 
+# ANSI-colored TEST-FAILURE marker with the load-bearing tokens split mid-word
+# ("Fi\x1b[31mles", "fai\x1b[1mled") — the marker is only detectable AFTER the
+# ANSI strip, same teeth rationale as ANSI_COVERAGE_OUTPUT above.
+ANSI_TESTFAIL_OUTPUT=$' Test Fi\x1b[31mles  2 fai\x1b[1mled | 118 passed (120)\x1b[0m\n      Tests  3 failed | 1397 passed (1400)'
+
+# Truncated mid-run output: the CI `timeout` wrapper killed vitest BEFORE the
+# "Test Files ..." summary printed. Non-empty, no failure markers — but also no
+# positive proof the run completed. A 124 with this evidence MUST fail closed:
+# absence of failure markers proves nothing when the run never finished.
+TRUNCATED_OUTPUT=' RUN  v4.1.7 /home/runner/work/project-forge/web
+
+ ✓ src/lib/tokens/creditManager.test.ts (12 tests) 34ms
+ ✓ src/stores/slices/selectionSlice.test.ts (8 tests) 21ms'
+
 echo "== check-vitest-exit.sh =="
 
 # 1. Clean pass (exit 0) → gate passes.
@@ -89,10 +103,12 @@ f="$(mkfile pass.txt "$PASS_OUTPUT")"
 rc="$(run_gate 0 "$f")"
 if [ "$rc" = "0" ]; then pass "exit 0 → gate 0"; else fail "exit 0 → expected 0, got $rc"; fi
 
-# 2. Timeout (exit 124) → swallowed as warning (vitest#3077 hang on cleanup).
+# 2. Timeout (exit 124) WITH evidence of a fully passing run → swallowed as a
+#    warning (vitest#3077 hang on cleanup). 124 alone is NOT a free pass — see
+#    cases 15-21 — but timeout + proven-green run stays green.
 f="$(mkfile to.txt "$PASS_OUTPUT")"
 rc="$(run_gate 124 "$f")"
-if [ "$rc" = "0" ]; then pass "exit 124 → gate 0 (timeout warning)"; else fail "exit 124 → expected 0, got $rc"; fi
+if [ "$rc" = "0" ]; then pass "exit 124 + passing evidence → gate 0 (timeout warning)"; else fail "exit 124 + passing evidence → expected 0, got $rc"; fi
 
 # 3. Real test failures → propagate non-zero.
 f="$(mkfile tf.txt "$TESTFAIL_OUTPUT")"
@@ -156,6 +172,60 @@ if [ "$rc" = "1" ]; then pass "uncovered global miss → gate 1 (form B NOT swal
 f="$(mkfile uncpf.txt "$COVERAGE_UNCOVERED_PERFILE_OUTPUT")"
 rc="$(run_gate 1 "$f")"
 if [ "$rc" = "1" ]; then pass "uncovered per-file miss → gate 1 (form B)"; else fail "uncovered per-file miss → expected 1, got $rc"; fi
+
+# ── Exit 124 must NOT bypass the evidence checks (PR #8721 P0, Sentry
+#    r3391661666). The old gate exited 0 on 124 BEFORE the fail-closed evidence
+#    check and the marker scans, so a timed-out run that ALSO failed tests or
+#    coverage thresholds was silently green. 124 must flow through the SAME
+#    evidence pipeline; only a proven fully-passing run may be swallowed. ──────
+
+# 15. THE P0 FIX: 124 + coverage-threshold failure → propagate 124, never swallow.
+f="$(mkfile to-cov.txt "$COVERAGE_GLOBAL_OUTPUT")"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "124" ]; then pass "124 + coverage miss → gate 124 (NOT swallowed)"; else fail "124 + coverage miss → expected 124, got $rc (REGRESSION: timeout swallowed a coverage failure)"; fi
+
+# 16. 124 + real test failures → propagate 124.
+f="$(mkfile to-tf.txt "$TESTFAIL_OUTPUT")"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "124" ]; then pass "124 + test failures → gate 124 (NOT swallowed)"; else fail "124 + test failures → expected 124, got $rc (REGRESSION: timeout swallowed test failures)"; fi
+
+# 17. 124 + ANSI mid-token coverage marker → propagate 124. The marker must be
+#     detected THROUGH color codes; this fixture's first line is an UNSPLIT
+#     passing summary, so a mutant that deletes the ANSI strip would match the
+#     positive-proof check and exit 0 — making this case fail. Teeth on both
+#     the 124 routing AND the strip.
+f="$(mkfile to-ansi.txt "$ANSI_COVERAGE_OUTPUT")"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "124" ]; then pass "124 + ANSI coverage miss → gate 124 (marker seen through color)"; else fail "124 + ANSI coverage miss → expected 124, got $rc"; fi
+
+# 18. 124 + ANSI mid-token test-failure marker → propagate 124 via the MARKER
+#     path, not the fail-closed fallback (assert no fail-closed message), so the
+#     failure is detected through color codes rather than accidentally caught.
+f="$(mkfile to-ansitf.txt "$ANSI_TESTFAIL_OUTPUT")"
+GATE_OUT="$(bash "$GATE" 124 "$f" 2>&1)"; rc=$?
+if [ "$rc" = "124" ] && ! printf '%s' "$GATE_OUT" | grep -q "failing closed"; then
+  pass "124 + ANSI test-fail marker → gate 124 via marker detection"
+else
+  fail "124 + ANSI test-fail marker → expected 124 via marker path, got rc=$rc out='$GATE_OUT'"
+fi
+
+# 19. Fail closed: 124 with evidence file MISSING → propagate, never swallow.
+rc="$(run_gate 124 "$TMPDIR_T/timeout-no-evidence.txt")"
+if [ "$rc" = "124" ]; then pass "124 + missing evidence → gate 124 (fail closed)"; else fail "124 + missing evidence → expected 124, got $rc"; fi
+
+# 20. Fail closed: 124 with EMPTY evidence file → propagate.
+f="$(mkfile to-empty.txt "")"
+: > "$f"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "124" ]; then pass "124 + empty evidence → gate 124 (fail closed)"; else fail "124 + empty evidence → expected 124, got $rc"; fi
+
+# 21. Fail closed: 124 with TRUNCATED evidence (timeout killed vitest before the
+#     summary printed — no markers, but no proof of a completed run either) →
+#     propagate. Absence of failure markers is NOT evidence of success when the
+#     run never finished.
+f="$(mkfile to-trunc.txt "$TRUNCATED_OUTPUT")"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "124" ]; then pass "124 + truncated evidence → gate 124 (no positive proof)"; else fail "124 + truncated evidence → expected 124, got $rc"; fi
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -112,9 +112,12 @@ TRUNCATED_OUTPUT=' RUN  v4.1.7 /home/runner/work/project-forge/web
  ✓ src/stores/slices/selectionSlice.test.ts (8 tests) 21ms'
 
 # A --coverage run that completed BOTH phases: green test summary AND the
-# coverage report (vitest prints " % Coverage report from v8" before the table,
-# and threshold adjudication happens right after the report). This is the only
-# evidence strong enough to swallow a non-zero exit in --coverage mode.
+# coverage report (vitest prints " % Coverage report from v8" after the remap,
+# immediately BEFORE the reporters execute and thresholds are adjudicated).
+# The marker is the strongest in-band evidence available — a passing
+# adjudication prints nothing — and the minimum required to swallow a non-zero
+# exit in --coverage mode; it proves report generation began, not that
+# adjudication finished (accepted residual, see the gate header).
 COVERAGE_PASS_OUTPUT=' Test Files  120 passed (120)
       Tests  1400 passed (1400)
  % Coverage report from v8
@@ -312,7 +315,10 @@ rc="$(run_gate 124 "$f" --coverage)"
 if [ "$rc" = "124" ]; then pass "--coverage: 124 + green tests, no coverage report → gate 124 (thresholds never adjudicated)"; else fail "--coverage: 124 + green tests, no coverage report → expected 124, got $rc (REGRESSION: unadjudicated coverage swallowed)"; fi
 
 # 27. Coverage mode swallow: 124 + green summary + coverage report marker →
-#     both phases proven complete → gate 0 (#3077 workaround intact).
+#     tests proven complete + coverage proven to have reached report generation
+#     (the marker prints BEFORE reporters/threshold adjudication — strongest
+#     in-band evidence available, not proof adjudication finished; see the gate
+#     header) → gate 0 (#3077 workaround intact).
 f="$(mkfile cov-mode-full.txt "$COVERAGE_PASS_OUTPUT")"
 rc="$(run_gate 124 "$f" --coverage)"
 if [ "$rc" = "0" ]; then pass "--coverage: 124 + green tests + coverage report → gate 0"; else fail "--coverage: 124 + green tests + coverage report → expected 0, got $rc"; fi

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -63,6 +63,17 @@ Error: A worker process has failed to exit gracefully'
 # ANSI-colored coverage error (vitest colorizes ERROR lines).
 ANSI_COVERAGE_OUTPUT=$' Test Files  120 passed (120)\n\x1b[31mERROR: Coverage for branches (55%) does not meet global threshold (60%)\x1b[0m'
 
+# vitest's SECOND threshold-failure form (negative / max-uncovered threshold):
+# "Uncovered X (N) exceed global threshold (M)". All tests pass, exit still 1.
+# Missing this form re-opens #8598 for max-uncovered thresholds (F06 follow-up).
+COVERAGE_UNCOVERED_GLOBAL_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ERROR: Uncovered statements (33) exceed global threshold (30)'
+
+COVERAGE_UNCOVERED_PERFILE_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ERROR: Uncovered lines (12) exceed "src/math.ts" threshold (10)'
+
 echo "== check-vitest-exit.sh =="
 
 # 1. Clean pass (exit 0) → gate passes.
@@ -125,6 +136,16 @@ f="$(mkfile both.txt "$TESTFAIL_OUTPUT
 ERROR: Coverage for lines (1%) does not meet global threshold (72%)")"
 rc="$(run_gate 1 "$f")"
 if [ "$rc" = "1" ]; then pass "both test-fail + coverage → gate 1"; else fail "both → expected 1, got $rc"; fi
+
+# 13. THE FOLLOW-UP FIX: form-B (max-uncovered) global threshold miss → propagate.
+f="$(mkfile unc.txt "$COVERAGE_UNCOVERED_GLOBAL_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "uncovered global miss → gate 1 (form B NOT swallowed)"; else fail "uncovered global miss → expected 1, got $rc (REGRESSION: form B swallowed)"; fi
+
+# 14. Form-B per-file (quoted path, no 'global') threshold miss → propagate.
+f="$(mkfile uncpf.txt "$COVERAGE_UNCOVERED_PERFILE_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "uncovered per-file miss → gate 1 (form B)"; else fail "uncovered per-file miss → expected 1, got $rc"; fi
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -6,12 +6,26 @@
 # and .github/workflows/cd.yml (without). The workaround swallows a non-zero
 # vitest exit when no tests actually failed (open handles after a green run).
 #
-# The bug this suite locks down (#8598 / F06): a COVERAGE-THRESHOLD failure
-# also exits non-zero with NO "Test Files ... failed" line, so the old inline
-# `grep "Test Files.*failed"` check mistook it for an open-handle false positive
-# and exited 0 — silently green-lighting a coverage regression. The gate MUST
-# propagate coverage failures (fail closed), and MUST fail closed when the exit
-# is non-zero but the evidence file is missing/empty.
+# The bugs this suite locks down:
+#   - #8598 / F06: a COVERAGE-THRESHOLD failure also exits non-zero with NO
+#     "Test Files ... failed" line, so the old inline `grep "Test Files.*failed"`
+#     check mistook it for an open-handle false positive and exited 0 — silently
+#     green-lighting a coverage regression. Coverage failures MUST propagate.
+#   - PR #8721 P0 (Sentry r3391661666): exit 124 used to get an early `exit 0`
+#     that bypassed every evidence check. 124 must flow through the same
+#     pipeline as every other code.
+#   - PR #8721 review follow-up: the positive-proof rule ("Test Files ... passed"
+#     required before swallowing) is generalized to EVERY non-zero exit code —
+#     a mid-run kill via OOM SIGKILL (137), segfault (134/139), SIGTERM (143),
+#     or worker crash (1) leaves truncated output with no markers, and the old
+#     lenient path swallowed it green exactly like the 124 class.
+#   - PR #8721 review follow-up (--coverage mode): for the --coverage caller,
+#     the green summary proves only TEST-phase completion — coverage report
+#     generation + threshold adjudication happen after it. In --coverage mode
+#     the gate additionally requires the "Coverage report from" marker before
+#     swallowing, or a kill in that window hides never-adjudicated thresholds.
+# The gate MUST also fail closed when the exit is non-zero but the evidence
+# file is missing/empty.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -25,9 +39,9 @@ fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
 
 [ -f "$GATE" ] || { echo "gate script not found: $GATE"; exit 1; }
 
-# Run the gate, capturing its exit code. Usage: run_gate <code> <file>
+# Run the gate, capturing its exit code. Usage: run_gate <code> <file> [--coverage]
 run_gate() {
-  bash "$GATE" "$1" "$2" >/dev/null 2>&1
+  bash "$GATE" "$1" "$2" ${3:+"$3"} >/dev/null 2>&1
   echo $?
 }
 
@@ -87,14 +101,36 @@ ERROR: Uncovered lines (12) exceed "src/math.ts" threshold (10)'
 # ANSI strip, same teeth rationale as ANSI_COVERAGE_OUTPUT above.
 ANSI_TESTFAIL_OUTPUT=$' Test Fi\x1b[31mles  2 fai\x1b[1mled | 118 passed (120)\x1b[0m\n      Tests  3 failed | 1397 passed (1400)'
 
-# Truncated mid-run output: the CI `timeout` wrapper killed vitest BEFORE the
-# "Test Files ..." summary printed. Non-empty, no failure markers — but also no
-# positive proof the run completed. A 124 with this evidence MUST fail closed:
-# absence of failure markers proves nothing when the run never finished.
+# Truncated mid-run output: vitest was killed BEFORE the "Test Files ..."
+# summary printed (timeout 124, OOM SIGKILL 137, segfault 134/139, SIGTERM 143,
+# worker crash 1, ...). Non-empty, no failure markers — but also no positive
+# proof the run completed. ANY non-zero exit with this evidence MUST fail
+# closed: absence of failure markers proves nothing when the run never finished.
 TRUNCATED_OUTPUT=' RUN  v4.1.7 /home/runner/work/project-forge/web
 
  ✓ src/lib/tokens/creditManager.test.ts (12 tests) 34ms
  ✓ src/stores/slices/selectionSlice.test.ts (8 tests) 21ms'
+
+# A --coverage run that completed BOTH phases: green test summary AND the
+# coverage report (vitest prints " % Coverage report from v8" before the table,
+# and threshold adjudication happens right after the report). This is the only
+# evidence strong enough to swallow a non-zero exit in --coverage mode.
+COVERAGE_PASS_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ % Coverage report from v8
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
+All files |   75.21 |    64.03 |   70.11 |   76.42 |'
+
+# --coverage-mode open-handle false positive: both phases completed, then the
+# worker failed to exit (vitest#3077). Must still be swallowed in coverage mode.
+COVERAGE_OPENHANDLE_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ % Coverage report from v8
+----------|---------|----------|---------|---------|-------------------
+All files |   75.21 |    64.03 |   70.11 |   76.42 |
+
+Error: A worker process has failed to exit gracefully'
 
 echo "== check-vitest-exit.sh =="
 
@@ -125,7 +161,11 @@ f="$(mkfile covpf.txt "$COVERAGE_PERFILE_OUTPUT")"
 rc="$(run_gate 1 "$f")"
 if [ "$rc" = "1" ]; then pass "coverage per-file miss → gate 1"; else fail "coverage per-file miss → expected 1, got $rc"; fi
 
-# 6. Open-handle false positive → swallowed (preserve #3077 workaround).
+# 6. Open-handle false positive → swallowed (preserve #3077 workaround). The
+#    fixture contains the green "Test Files ... passed" summary — that POSITIVE
+#    proof of a completed run is what licenses the swallow, not the mere absence
+#    of failure markers (every legitimate vitest#3077 scenario has it: the hang
+#    occurs after the summary prints).
 f="$(mkfile oh.txt "$OPENHANDLE_OUTPUT")"
 rc="$(run_gate 1 "$f")"
 if [ "$rc" = "0" ]; then pass "open-handle noise → gate 0 (workaround preserved)"; else fail "open-handle noise → expected 0, got $rc"; fi
@@ -226,6 +266,79 @@ if [ "$rc" = "124" ]; then pass "124 + empty evidence → gate 124 (fail closed)
 f="$(mkfile to-trunc.txt "$TRUNCATED_OUTPUT")"
 rc="$(run_gate 124 "$f")"
 if [ "$rc" = "124" ]; then pass "124 + truncated evidence → gate 124 (no positive proof)"; else fail "124 + truncated evidence → expected 124, got $rc"; fi
+
+# ── The positive-proof rule applies to EVERY non-zero exit, not just 124
+#    (PR #8721 review follow-up). An OOM SIGKILL (137), a segfault (139, a
+#    documented Node gotcha in this repo), a SIGTERM (143), or a worker crash
+#    (1) kills vitest mid-run exactly like the timeout does — truncated output
+#    with no markers must fail closed for ALL of them, or a killed half-run is
+#    silently green through the lenient path the 124 fix removed. ──────────────
+
+# 22. Fail closed: 137 (OOM SIGKILL) + truncated evidence → propagate 137.
+f="$(mkfile oom-trunc.txt "$TRUNCATED_OUTPUT")"
+rc="$(run_gate 137 "$f")"
+if [ "$rc" = "137" ]; then pass "137 + truncated evidence → gate 137 (no positive proof)"; else fail "137 + truncated evidence → expected 137, got $rc (REGRESSION: OOM-killed half-run swallowed)"; fi
+
+# 23. Fail closed: 139 (segfault) + truncated evidence → propagate 139.
+f="$(mkfile segv-trunc.txt "$TRUNCATED_OUTPUT")"
+rc="$(run_gate 139 "$f")"
+if [ "$rc" = "139" ]; then pass "139 + truncated evidence → gate 139 (no positive proof)"; else fail "139 + truncated evidence → expected 139, got $rc (REGRESSION: segfaulted half-run swallowed)"; fi
+
+# 24. Fail closed: exit 1 (worker crash) + truncated evidence, no markers and no
+#     green summary → propagate. This was the old lenient path (3): it inferred
+#     a green run from marker ABSENCE, the exact inference the 124 fix declared
+#     invalid.
+f="$(mkfile one-trunc.txt "$TRUNCATED_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "1 + truncated evidence → gate 1 (fail closed, lenient path removed)"; else fail "1 + truncated evidence → expected 1, got $rc (REGRESSION: crashed half-run swallowed)"; fi
+
+# 25. The generalized rule does NOT over-block: 137 AFTER a proven green run
+#     (summary present, open-handle noise) is still the #3077 class → swallowed.
+f="$(mkfile oom-green.txt "$OPENHANDLE_OUTPUT")"
+rc="$(run_gate 137 "$f")"
+if [ "$rc" = "0" ]; then pass "137 + proven green run → gate 0 (workaround preserved)"; else fail "137 + proven green run → expected 0, got $rc"; fi
+
+# ── --coverage mode (PR #8721 review follow-up): the green summary proves the
+#    TEST phase only — coverage report generation + threshold adjudication
+#    happen AFTER it and are the hang-prone tail. Swallowing in this mode also
+#    requires the "Coverage report from" marker, or a kill in that window hides
+#    never-adjudicated thresholds (the ratchet skips silently without
+#    coverage-summary.json). ──────────────────────────────────────────────────
+
+# 26. Coverage mode fail closed: 124 + green summary but NO coverage report →
+#     thresholds were never adjudicated → propagate.
+f="$(mkfile cov-mode-nocov.txt "$PASS_OUTPUT")"
+rc="$(run_gate 124 "$f" --coverage)"
+if [ "$rc" = "124" ]; then pass "--coverage: 124 + green tests, no coverage report → gate 124 (thresholds never adjudicated)"; else fail "--coverage: 124 + green tests, no coverage report → expected 124, got $rc (REGRESSION: unadjudicated coverage swallowed)"; fi
+
+# 27. Coverage mode swallow: 124 + green summary + coverage report marker →
+#     both phases proven complete → gate 0 (#3077 workaround intact).
+f="$(mkfile cov-mode-full.txt "$COVERAGE_PASS_OUTPUT")"
+rc="$(run_gate 124 "$f" --coverage)"
+if [ "$rc" = "0" ]; then pass "--coverage: 124 + green tests + coverage report → gate 0"; else fail "--coverage: 124 + green tests + coverage report → expected 0, got $rc"; fi
+
+# 28. Coverage mode swallow: exit 1 open-handle noise after BOTH phases → gate 0.
+f="$(mkfile cov-mode-oh.txt "$COVERAGE_OPENHANDLE_OUTPUT")"
+rc="$(run_gate 1 "$f" --coverage)"
+if [ "$rc" = "0" ]; then pass "--coverage: 1 + both phases complete + open-handle noise → gate 0"; else fail "--coverage: 1 + both phases + noise → expected 0, got $rc"; fi
+
+# 29. Coverage mode fail closed: exit 1 + green summary, no coverage report →
+#     propagate (same window as case 26, non-timeout code).
+f="$(mkfile cov-mode-one.txt "$PASS_OUTPUT")"
+rc="$(run_gate 1 "$f" --coverage)"
+if [ "$rc" = "1" ]; then pass "--coverage: 1 + green tests, no coverage report → gate 1"; else fail "--coverage: 1 + green tests, no coverage report → expected 1, got $rc"; fi
+
+# 30. Coverage mode still propagates a threshold failure (marker check (2) runs
+#     before the mode logic — the mode must never weaken it).
+f="$(mkfile cov-mode-miss.txt "$COVERAGE_GLOBAL_OUTPUT")"
+rc="$(run_gate 1 "$f" --coverage)"
+if [ "$rc" = "1" ]; then pass "--coverage: threshold miss → gate 1 (mode does not weaken #8598 fix)"; else fail "--coverage: threshold miss → expected 1, got $rc"; fi
+
+# 31. Usage error: unknown third arg (misconfigured call site) → exit 2, never a
+#     silent behavior change.
+f="$(mkfile badflag.txt "$PASS_OUTPUT")"
+bash "$GATE" 1 "$f" "--coverag" >/dev/null 2>&1; rc=$?
+if [ "$rc" = "2" ]; then pass "unknown third arg → exit 2 (usage)"; else fail "unknown third arg → expected 2, got $rc"; fi
 
 echo ""
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/__tests__/check-vitest-exit.test.sh
+++ b/scripts/__tests__/check-vitest-exit.test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/check-vitest-exit.sh — the vitest exit-code gate.
+#
+# This gate is the single source of truth for the vitest#3077 open-handle
+# workaround used by BOTH .github/workflows/quality-gates.yml (with --coverage)
+# and .github/workflows/cd.yml (without). The workaround swallows a non-zero
+# vitest exit when no tests actually failed (open handles after a green run).
+#
+# The bug this suite locks down (#8598 / F06): a COVERAGE-THRESHOLD failure
+# also exits non-zero with NO "Test Files ... failed" line, so the old inline
+# `grep "Test Files.*failed"` check mistook it for an open-handle false positive
+# and exited 0 — silently green-lighting a coverage regression. The gate MUST
+# propagate coverage failures (fail closed), and MUST fail closed when the exit
+# is non-zero but the evidence file is missing/empty.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HERE/../check-vitest-exit.sh"
+FAILURES=0
+TMPDIR_T="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_T"' EXIT
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+[ -f "$GATE" ] || { echo "gate script not found: $GATE"; exit 1; }
+
+# Run the gate, capturing its exit code. Usage: run_gate <code> <file>
+run_gate() {
+  bash "$GATE" "$1" "$2" >/dev/null 2>&1
+  echo $?
+}
+
+mkfile() {
+  local path="$TMPDIR_T/$1"
+  printf '%s\n' "$2" > "$path"
+  echo "$path"
+}
+
+# ── Real vitest fixtures ──────────────────────────────────────────────────────
+PASS_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)'
+
+TESTFAIL_OUTPUT=' Test Files  2 failed | 118 passed (120)
+      Tests  3 failed | 1397 passed (1400)'
+
+# Coverage-threshold failure: all tests pass, vitest still exits 1.
+COVERAGE_GLOBAL_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ERROR: Coverage for lines (68.51%) does not meet global threshold (72%)
+ERROR: Coverage for statements (69.2%) does not meet global threshold (70%)'
+
+COVERAGE_PERFILE_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+ERROR: Coverage for functions (40%) does not meet threshold (65%)'
+
+# Open-handle false positive: green run, non-zero exit, no coverage section.
+OPENHANDLE_OUTPUT=' Test Files  120 passed (120)
+      Tests  1400 passed (1400)
+
+Error: A worker process has failed to exit gracefully'
+
+# ANSI-colored coverage error (vitest colorizes ERROR lines).
+ANSI_COVERAGE_OUTPUT=$' Test Files  120 passed (120)\n\x1b[31mERROR: Coverage for branches (55%) does not meet global threshold (60%)\x1b[0m'
+
+echo "== check-vitest-exit.sh =="
+
+# 1. Clean pass (exit 0) → gate passes.
+f="$(mkfile pass.txt "$PASS_OUTPUT")"
+rc="$(run_gate 0 "$f")"
+if [ "$rc" = "0" ]; then pass "exit 0 → gate 0"; else fail "exit 0 → expected 0, got $rc"; fi
+
+# 2. Timeout (exit 124) → swallowed as warning (vitest#3077 hang on cleanup).
+f="$(mkfile to.txt "$PASS_OUTPUT")"
+rc="$(run_gate 124 "$f")"
+if [ "$rc" = "0" ]; then pass "exit 124 → gate 0 (timeout warning)"; else fail "exit 124 → expected 0, got $rc"; fi
+
+# 3. Real test failures → propagate non-zero.
+f="$(mkfile tf.txt "$TESTFAIL_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "test failures → gate 1 (propagate)"; else fail "test failures → expected 1, got $rc"; fi
+
+# 4. THE FIX: coverage-threshold failure (global) with no failed tests → propagate.
+f="$(mkfile cov.txt "$COVERAGE_GLOBAL_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "coverage global miss → gate 1 (NOT swallowed)"; else fail "coverage global miss → expected 1, got $rc (REGRESSION: swallowed)"; fi
+
+# 5. Coverage-threshold failure (per-file, no 'global') → propagate.
+f="$(mkfile covpf.txt "$COVERAGE_PERFILE_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "coverage per-file miss → gate 1"; else fail "coverage per-file miss → expected 1, got $rc"; fi
+
+# 6. Open-handle false positive → swallowed (preserve #3077 workaround).
+f="$(mkfile oh.txt "$OPENHANDLE_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "0" ]; then pass "open-handle noise → gate 0 (workaround preserved)"; else fail "open-handle noise → expected 0, got $rc"; fi
+
+# 7. ANSI-colored coverage error still detected → propagate.
+f="$(mkfile ansi.txt "$ANSI_COVERAGE_OUTPUT")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "ANSI coverage miss → gate 1 (ANSI stripped)"; else fail "ANSI coverage miss → expected 1, got $rc"; fi
+
+# 8. Fail closed: non-zero exit but evidence file MISSING → propagate, never swallow.
+rc="$(run_gate 1 "$TMPDIR_T/does-not-exist.txt")"
+if [ "$rc" != "0" ]; then pass "missing output + non-zero → gate non-zero (fail closed)"; else fail "missing output + non-zero → expected non-zero, got $rc"; fi
+
+# 9. Fail closed: non-zero exit with EMPTY evidence file → propagate.
+f="$(mkfile empty.txt "")"
+: > "$f"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" != "0" ]; then pass "empty output + non-zero → gate non-zero (fail closed)"; else fail "empty output + non-zero → expected non-zero, got $rc"; fi
+
+# 10. Usage error: wrong arg count → exit 2 (surface misconfig, never silent-pass).
+bash "$GATE" 1 >/dev/null 2>&1; rc=$?
+if [ "$rc" = "2" ]; then pass "missing file arg → exit 2 (usage)"; else fail "missing file arg → expected 2, got $rc"; fi
+
+# 11. Usage error: non-numeric exit code → exit 2.
+f="$(mkfile nn.txt "$PASS_OUTPUT")"
+bash "$GATE" "notanumber" "$f" >/dev/null 2>&1; rc=$?
+if [ "$rc" = "2" ]; then pass "non-numeric code → exit 2 (usage)"; else fail "non-numeric code → expected 2, got $rc"; fi
+
+# 12. Coverage miss takes precedence even if a test-fail line is ALSO present
+#     (still a failure either way — must propagate).
+f="$(mkfile both.txt "$TESTFAIL_OUTPUT
+ERROR: Coverage for lines (1%) does not meet global threshold (72%)")"
+rc="$(run_gate 1 "$f")"
+if [ "$rc" = "1" ]; then pass "both test-fail + coverage → gate 1"; else fail "both → expected 1, got $rc"; fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All check-vitest-exit.sh tests passed."
+  exit 0
+else
+  echo "$FAILURES test(s) failed."
+  exit 1
+fi

--- a/scripts/check-vitest-exit.sh
+++ b/scripts/check-vitest-exit.sh
@@ -10,10 +10,18 @@
 #
 # vitest exits non-zero in three distinct situations:
 #   1. A test actually failed              → summary has "Test Files ... failed"
-#   2. A coverage threshold was not met    → "Coverage for X does not meet threshold",
-#                                            but NO "Test Files ... failed" line
+#   2. A coverage threshold was not met    → one of vitest's two threshold-failure
+#                                            forms (see below), but NO
+#                                            "Test Files ... failed" line
 #   3. Open handles after a green run      → non-zero exit, neither marker present
 # Only (3) is a false positive. (1) and (2) MUST propagate.
+#
+# vitest emits the coverage-threshold failure in TWO forms (vitest source
+# coverage chunk; verified against 4.1.7), and BOTH must be caught or the gate
+# silently swallows them — the #8598 regression class:
+#   A. positive % threshold:  "ERROR: Coverage for statements (50%) does not meet global threshold (85%)"
+#   B. negative (max-uncovered) threshold: "ERROR: Uncovered statements (33) exceed global threshold (30)"
+# Per-file variants substitute "\"path\" threshold" for "global threshold".
 #
 # Usage: check-vitest-exit.sh <vitest_exit_code> <output_file>
 #   <output_file> is the captured (tee'd) combined stdout+stderr of the run.
@@ -64,9 +72,13 @@ if printf '%s\n' "$CLEAN" | grep -qE "Test Files.*failed"; then
   exit "$EXIT_CODE"
 fi
 
-# (2) A coverage threshold was not met → propagate (the #8598 fix). Matches both
-#     "does not meet global threshold" and per-file "does not meet threshold".
-if printf '%s\n' "$CLEAN" | grep -qiE "coverage for .*does not meet.*threshold"; then
+# (2) A coverage threshold was not met → propagate (the #8598 fix). Matches BOTH
+#     vitest forms: the positive-% "Coverage for X does not meet ... threshold"
+#     and the negative-count "Uncovered X exceed ... threshold" — global and
+#     per-file variants alike. Missing form B would re-open #8598 for any repo
+#     (or future config) that sets a max-uncovered threshold.
+if printf '%s\n' "$CLEAN" \
+  | grep -qiE "coverage for .*does not meet .*threshold|uncovered .*exceed .*threshold"; then
   echo "::error::vitest coverage thresholds not met — failing the build (this was previously swallowed: #8598)"
   exit "$EXIT_CODE"
 fi

--- a/scripts/check-vitest-exit.sh
+++ b/scripts/check-vitest-exit.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check-vitest-exit.sh — decide whether a non-zero `vitest run` exit is a real
+# failure or the known vitest#3077 open-handle false positive.
+#
+# Single source of truth for the exit-code workaround used by BOTH
+# .github/workflows/quality-gates.yml (vitest --coverage) and
+# .github/workflows/cd.yml (vitest). Keeping it in one tested script stops the
+# two inline copies from drifting and — the reason this script exists (#8598) —
+# stops a COVERAGE-THRESHOLD failure from being silently swallowed.
+#
+# vitest exits non-zero in three distinct situations:
+#   1. A test actually failed              → summary has "Test Files ... failed"
+#   2. A coverage threshold was not met    → "Coverage for X does not meet threshold",
+#                                            but NO "Test Files ... failed" line
+#   3. Open handles after a green run      → non-zero exit, neither marker present
+# Only (3) is a false positive. (1) and (2) MUST propagate.
+#
+# Usage: check-vitest-exit.sh <vitest_exit_code> <output_file>
+#   <output_file> is the captured (tee'd) combined stdout+stderr of the run.
+# Exit: 0 = treat as success; the original code = real failure; 2 = usage error.
+#
+# Fail-closed contract: if the exit code is non-zero and the evidence file is
+# missing or empty, we CANNOT prove it was an open-handle false positive, so we
+# propagate the failure rather than swallow it.
+set -uo pipefail
+
+usage() {
+  echo "usage: $(basename "$0") <vitest_exit_code> <output_file>" >&2
+  exit 2
+}
+
+[ "$#" -eq 2 ] || usage
+EXIT_CODE="$1"
+OUTPUT_FILE="$2"
+
+# Exit code must be a non-negative integer.
+case "$EXIT_CODE" in
+  ''|*[!0-9]*) usage ;;
+esac
+
+# 124 = `timeout` killed a process that hung during cleanup after tests already
+# completed (vitest#3077). Treat as a warning, not a failure.
+if [ "$EXIT_CODE" -eq 124 ]; then
+  echo "::warning::vitest process was killed after timeout — likely hung during cleanup (vitest#3077)"
+  exit 0
+fi
+
+# Clean exit — nothing to adjudicate.
+if [ "$EXIT_CODE" -eq 0 ]; then
+  exit 0
+fi
+
+# Non-zero from here on. We need the evidence file to classify it.
+if [ ! -s "$OUTPUT_FILE" ]; then
+  echo "::error::vitest exited with code $EXIT_CODE but no output was captured at '$OUTPUT_FILE' — failing closed (cannot prove an open-handle false positive)"
+  exit "$EXIT_CODE"
+fi
+
+# Strip ANSI color codes once; both markers can be colorized by vitest.
+CLEAN="$(sed 's/\x1b\[[0-9;]*m//g' "$OUTPUT_FILE")"
+
+# (1) A test actually failed → propagate.
+if printf '%s\n' "$CLEAN" | grep -qE "Test Files.*failed"; then
+  exit "$EXIT_CODE"
+fi
+
+# (2) A coverage threshold was not met → propagate (the #8598 fix). Matches both
+#     "does not meet global threshold" and per-file "does not meet threshold".
+if printf '%s\n' "$CLEAN" | grep -qiE "coverage for .*does not meet.*threshold"; then
+  echo "::error::vitest coverage thresholds not met — failing the build (this was previously swallowed: #8598)"
+  exit "$EXIT_CODE"
+fi
+
+# (3) Neither marker → assume the vitest#3077 open-handle false positive.
+echo "::warning::vitest exited with code $EXIT_CODE but no test failures or coverage-threshold failures detected — likely open handle issue (vitest#3077)"
+exit 0

--- a/scripts/check-vitest-exit.sh
+++ b/scripts/check-vitest-exit.sh
@@ -3,26 +3,35 @@
 # failure or the known vitest#3077 open-handle false positive.
 #
 # Single source of truth for the exit-code workaround used by BOTH
-# .github/workflows/quality-gates.yml (vitest --coverage) and
-# .github/workflows/cd.yml (vitest). Keeping it in one tested script stops the
-# two inline copies from drifting and — the reason this script exists (#8598) —
-# stops a COVERAGE-THRESHOLD failure from being silently swallowed.
+# .github/workflows/quality-gates.yml (vitest --coverage, invoked with the
+# --coverage mode flag) and .github/workflows/cd.yml (vitest). Keeping it in
+# one tested script stops the two inline copies from drifting and — the reason
+# this script exists (#8598) — stops a COVERAGE-THRESHOLD failure from being
+# silently swallowed.
 #
 # vitest exits non-zero in four distinct situations:
 #   1. A test actually failed              → summary has "Test Files ... failed"
 #   2. A coverage threshold was not met    → one of vitest's two threshold-failure
 #                                            forms (see below), but NO
 #                                            "Test Files ... failed" line
-#   3. Open handles after a green run      → non-zero exit, neither marker present
-#   4. The CI `timeout` wrapper killed it  → exit 124; the run may have hung
-#                                            during cleanup AFTER passing
-#                                            (vitest#3077) OR been killed mid-run
-#                                            with failures already on record
-# Only (3), and (4) when the evidence proves a fully passing run, are false
-# positives. (1) and (2) MUST propagate — INCLUDING when the exit code is 124.
-# An early `exit 0` on 124 used to bypass every evidence check below, silently
-# green-lighting timed-out runs that also failed tests or coverage thresholds
-# (PR #8721 P0, Sentry r3391661666).
+#   3. The process died/hung AFTER a green run → open handles (vitest#3077) or a
+#                                            late kill (e.g. the CI `timeout`
+#                                            wrapper, exit 124); the
+#                                            "Test Files ... passed" summary IS
+#                                            present in the output
+#   4. The process died MID-RUN            → killed before the summary printed:
+#                                            timeout (124), OOM SIGKILL (137),
+#                                            V8 abort/segfault (134/139),
+#                                            SIGTERM (143), worker crash (1), …
+#                                            Output is truncated — no summary.
+# Only (3) is a false positive. (1) and (2) MUST propagate regardless of the
+# exit code. (4) MUST fail closed: when the run never finished, the ABSENCE of
+# failure markers proves nothing, so swallowing requires POSITIVE evidence of a
+# completed passing run — the "Test Files ... passed" summary. That rule applies
+# to EVERY non-zero exit code, not just 124: an early `exit 0` on 124 used to
+# bypass every evidence check (PR #8721 P0, Sentry r3391661666), and the same
+# silent-green class remained open for 137/139/143/1 with truncated output
+# until the positive-proof rule was generalized (review of PR #8721).
 #
 # vitest emits the coverage-threshold failure in TWO forms (vitest source
 # coverage chunk; verified against 4.1.7), and BOTH must be caught or the gate
@@ -31,8 +40,16 @@
 #   B. negative (max-uncovered) threshold: "ERROR: Uncovered statements (33) exceed global threshold (30)"
 # Per-file variants substitute "\"path\" threshold" for "global threshold".
 #
-# Usage: check-vitest-exit.sh <vitest_exit_code> <output_file>
+# Usage: check-vitest-exit.sh <vitest_exit_code> <output_file> [--coverage]
 #   <output_file> is the captured (tee'd) combined stdout+stderr of the run.
+#   --coverage: the caller ran `vitest run --coverage` (quality-gates.yml). The
+#     "Test Files ... passed" summary then proves only that the TEST phase
+#     completed — coverage report generation and threshold adjudication happen
+#     AFTER the summary prints, and are the slow (hang-prone) tail of the run.
+#     In this mode, swallowing additionally requires the coverage-report marker
+#     ("Coverage report from ...") as positive proof that coverage was produced
+#     and adjudicated before the process died; otherwise a kill in that window
+#     would swallow never-adjudicated thresholds.
 # Exit: 0 = treat as success; the original code = real failure; 2 = usage error.
 #
 # Fail-closed contract: if the exit code is non-zero and the evidence file is
@@ -41,21 +58,28 @@
 set -uo pipefail
 
 usage() {
-  echo "usage: $(basename "$0") <vitest_exit_code> <output_file>" >&2
+  echo "usage: $(basename "$0") <vitest_exit_code> <output_file> [--coverage]" >&2
   exit 2
 }
 
-[ "$#" -eq 2 ] || usage
+[ "$#" -eq 2 ] || [ "$#" -eq 3 ] || usage
 EXIT_CODE="$1"
 OUTPUT_FILE="$2"
+COVERAGE_MODE=0
+if [ "$#" -eq 3 ]; then
+  # Only the exact mode flag is valid — anything else is a misconfigured call
+  # site and must surface as a usage error, never silently change behavior.
+  [ "$3" = "--coverage" ] || usage
+  COVERAGE_MODE=1
+fi
 
 # Exit code must be a non-negative integer.
 case "$EXIT_CODE" in
   ''|*[!0-9]*) usage ;;
 esac
 
-# NOTE: 124 (`timeout` kill) deliberately gets NO early exit — it must flow
-# through the same evidence checks as every other non-zero code. See header.
+# NOTE: no exit code gets an early exit — every non-zero code (124, 137, 139,
+# 143, 1, …) flows through the same evidence checks below. See header.
 
 # Clean exit — nothing to adjudicate.
 if [ "$EXIT_CODE" -eq 0 ]; then
@@ -68,7 +92,7 @@ if [ ! -s "$OUTPUT_FILE" ]; then
   exit "$EXIT_CODE"
 fi
 
-# Strip ANSI color codes once; both markers can be colorized by vitest.
+# Strip ANSI color codes once; the markers below can be colorized by vitest.
 CLEAN="$(sed 's/\x1b\[[0-9;]*m//g' "$OUTPUT_FILE")"
 
 # (1) A test actually failed → propagate.
@@ -87,21 +111,36 @@ if printf '%s\n' "$CLEAN" \
   exit "$EXIT_CODE"
 fi
 
-# (4) Exit 124 with neither failure marker: the `timeout` wrapper can kill
-#     vitest BEFORE the summary prints, so for 124 the ABSENCE of failure
-#     markers proves nothing. Swallowing a timeout requires POSITIVE evidence
-#     of a completed passing run — the "Test Files ... passed" summary. Any
-#     "Test Files ... failed" line was already propagated above, so a match
-#     here can only be a fully green summary. Without it, fail closed.
-if [ "$EXIT_CODE" -eq 124 ]; then
-  if printf '%s\n' "$CLEAN" | grep -qE "Test Files.*passed"; then
-    echo "::warning::vitest was killed by the timeout wrapper after a fully passing run — likely hung during cleanup (vitest#3077)"
-    exit 0
-  fi
-  echo "::error::vitest was killed by the timeout wrapper (exit 124) and the captured output shows no completed passing run — failing closed (cannot prove the vitest#3077 false positive)"
+# (4) No failure markers — but that alone is NOT enough to swallow: any abnormal
+#     termination (timeout 124, OOM SIGKILL 137, segfault 134/139, SIGTERM 143,
+#     worker crash 1, …) can kill vitest BEFORE the summary prints, so for a
+#     truncated run the absence of failure markers proves nothing. Swallowing
+#     requires POSITIVE evidence of a completed passing run — the
+#     "Test Files ... passed" summary. Any "Test Files ... failed" line was
+#     already propagated above, so a match here can only be a fully green
+#     summary. Without it, fail closed.
+if ! printf '%s\n' "$CLEAN" | grep -qE "Test Files.*passed"; then
+  echo "::error::vitest exited with code $EXIT_CODE and the captured output shows no completed passing run — failing closed (likely killed mid-run; cannot prove the vitest#3077 false positive)"
   exit "$EXIT_CODE"
 fi
 
-# (3) Neither marker → assume the vitest#3077 open-handle false positive.
-echo "::warning::vitest exited with code $EXIT_CODE but no test failures or coverage-threshold failures detected — likely open handle issue (vitest#3077)"
+# (--coverage mode) The green summary proves the TEST phase completed, but
+# coverage report generation + threshold adjudication happen AFTER it and are
+# the hang-prone tail of the run. Require the coverage-report marker too — a
+# kill in that window means the thresholds were never adjudicated, and nothing
+# downstream catches it (the coverage ratchet skips with a warning when
+# coverage-summary.json is absent).
+if [ "$COVERAGE_MODE" -eq 1 ] \
+  && ! printf '%s\n' "$CLEAN" | grep -qiE "coverage report from"; then
+  echo "::error::vitest exited with code $EXIT_CODE after a passing test run but BEFORE the coverage report was produced — coverage thresholds were never adjudicated; failing closed"
+  exit "$EXIT_CODE"
+fi
+
+# (3) Proven completed passing run with no threshold failures → the vitest#3077
+#     false positive (open handles / hang after green). Safe to swallow.
+if [ "$EXIT_CODE" -eq 124 ]; then
+  echo "::warning::vitest was killed by the timeout wrapper after a fully passing run — likely hung during cleanup (vitest#3077)"
+else
+  echo "::warning::vitest exited with code $EXIT_CODE after a fully passing run with no coverage-threshold failures — likely open handle noise (vitest#3077)"
+fi
 exit 0

--- a/scripts/check-vitest-exit.sh
+++ b/scripts/check-vitest-exit.sh
@@ -47,9 +47,25 @@
 #     completed — coverage report generation and threshold adjudication happen
 #     AFTER the summary prints, and are the slow (hang-prone) tail of the run.
 #     In this mode, swallowing additionally requires the coverage-report marker
-#     ("Coverage report from ...") as positive proof that coverage was produced
-#     and adjudicated before the process died; otherwise a kill in that window
-#     would swallow never-adjudicated thresholds.
+#     ("Coverage report from ...").
+#     What the marker actually proves (verified against the pinned
+#     @vitest/coverage-v8 4.1.7, dist/provider.js generateReports()): it prints
+#     AFTER the expensive v8→istanbul remap completes but BEFORE the reporters
+#     execute and BEFORE reportThresholds() runs. So it is positive proof the
+#     coverage phase reached report generation — the strongest in-band evidence
+#     available, since a passing adjudication prints nothing — NOT proof that
+#     thresholds were adjudicated. A kill landing inside the remaining
+#     reporter-write + threshold-math window (typically seconds of a ~600s
+#     budget) is still swallowed. This narrows the unprotected window
+#     enormously but does not close it: defense-in-depth, not an airtight
+#     proof (same honesty contract as check-ci-success.sh).
+#     CI-redness trap, not a security hole: vitest prints the marker only when
+#     coverage.reporter includes a terminal reporter (text / text-summary /
+#     text-lcov / teamcity — vitest's DEFAULT reporters include "text", which
+#     this repo relies on). If coverage.reporter is ever overridden to
+#     file-only reporters (e.g. ['json-summary'] alone), coverage mode fails
+#     closed on EVERY vitest#3077 hang. That is the fail-safe direction, but
+#     the fix is to restore a terminal reporter — never to loosen this gate.
 # Exit: 0 = treat as success; the original code = real failure; 2 = usage error.
 #
 # Fail-closed contract: if the exit code is non-zero and the evidence file is
@@ -126,10 +142,17 @@ fi
 
 # (--coverage mode) The green summary proves the TEST phase completed, but
 # coverage report generation + threshold adjudication happen AFTER it and are
-# the hang-prone tail of the run. Require the coverage-report marker too — a
-# kill in that window means the thresholds were never adjudicated, and nothing
-# downstream catches it (the coverage ratchet skips with a warning when
+# the hang-prone tail of the run. Require the coverage-report marker too: it
+# prints after the expensive remap and immediately BEFORE the reporters and
+# threshold adjudication (see header), so — given a terminal coverage reporter
+# is configured (vitest default "text"; see the header's reporter-override
+# trap) — its ABSENCE means thresholds were never adjudicated, and nothing
+# downstream catches that (the coverage ratchet skips with a warning when
 # coverage-summary.json is absent).
+# Its PRESENCE proves report generation began, not that adjudication finished:
+# a kill inside the brief remaining reporter-write/threshold window is still
+# swallowed (accepted residual — no in-band output exists after a passing
+# adjudication that could anchor a stronger check).
 if [ "$COVERAGE_MODE" -eq 1 ] \
   && ! printf '%s\n' "$CLEAN" | grep -qiE "coverage report from"; then
   echo "::error::vitest exited with code $EXIT_CODE after a passing test run but BEFORE the coverage report was produced — coverage thresholds were never adjudicated; failing closed"

--- a/scripts/check-vitest-exit.sh
+++ b/scripts/check-vitest-exit.sh
@@ -8,13 +8,21 @@
 # two inline copies from drifting and — the reason this script exists (#8598) —
 # stops a COVERAGE-THRESHOLD failure from being silently swallowed.
 #
-# vitest exits non-zero in three distinct situations:
+# vitest exits non-zero in four distinct situations:
 #   1. A test actually failed              → summary has "Test Files ... failed"
 #   2. A coverage threshold was not met    → one of vitest's two threshold-failure
 #                                            forms (see below), but NO
 #                                            "Test Files ... failed" line
 #   3. Open handles after a green run      → non-zero exit, neither marker present
-# Only (3) is a false positive. (1) and (2) MUST propagate.
+#   4. The CI `timeout` wrapper killed it  → exit 124; the run may have hung
+#                                            during cleanup AFTER passing
+#                                            (vitest#3077) OR been killed mid-run
+#                                            with failures already on record
+# Only (3), and (4) when the evidence proves a fully passing run, are false
+# positives. (1) and (2) MUST propagate — INCLUDING when the exit code is 124.
+# An early `exit 0` on 124 used to bypass every evidence check below, silently
+# green-lighting timed-out runs that also failed tests or coverage thresholds
+# (PR #8721 P0, Sentry r3391661666).
 #
 # vitest emits the coverage-threshold failure in TWO forms (vitest source
 # coverage chunk; verified against 4.1.7), and BOTH must be caught or the gate
@@ -46,12 +54,8 @@ case "$EXIT_CODE" in
   ''|*[!0-9]*) usage ;;
 esac
 
-# 124 = `timeout` killed a process that hung during cleanup after tests already
-# completed (vitest#3077). Treat as a warning, not a failure.
-if [ "$EXIT_CODE" -eq 124 ]; then
-  echo "::warning::vitest process was killed after timeout — likely hung during cleanup (vitest#3077)"
-  exit 0
-fi
+# NOTE: 124 (`timeout` kill) deliberately gets NO early exit — it must flow
+# through the same evidence checks as every other non-zero code. See header.
 
 # Clean exit — nothing to adjudicate.
 if [ "$EXIT_CODE" -eq 0 ]; then
@@ -80,6 +84,21 @@ fi
 if printf '%s\n' "$CLEAN" \
   | grep -qiE "coverage for .*does not meet .*threshold|uncovered .*exceed .*threshold"; then
   echo "::error::vitest coverage thresholds not met — failing the build (this was previously swallowed: #8598)"
+  exit "$EXIT_CODE"
+fi
+
+# (4) Exit 124 with neither failure marker: the `timeout` wrapper can kill
+#     vitest BEFORE the summary prints, so for 124 the ABSENCE of failure
+#     markers proves nothing. Swallowing a timeout requires POSITIVE evidence
+#     of a completed passing run — the "Test Files ... passed" summary. Any
+#     "Test Files ... failed" line was already propagated above, so a match
+#     here can only be a fully green summary. Without it, fail closed.
+if [ "$EXIT_CODE" -eq 124 ]; then
+  if printf '%s\n' "$CLEAN" | grep -qE "Test Files.*passed"; then
+    echo "::warning::vitest was killed by the timeout wrapper after a fully passing run — likely hung during cleanup (vitest#3077)"
+    exit 0
+  fi
+  echo "::error::vitest was killed by the timeout wrapper (exit 124) and the captured output shows no completed passing run — failing closed (cannot prove the vitest#3077 false positive)"
   exit "$EXIT_CODE"
 fi
 


### PR DESCRIPTION
## Summary
- The vitest#3077 exit-code workaround (treating `timeout` exit 124 as a warning) was also swallowing real coverage-threshold failures: a run that failed thresholds could exit through the workaround path and report green. Coverage gates in `quality-gates.yml` and `cd.yml` were therefore advisory in practice ([F06]).
- Extract the exit-code decision into `scripts/check-vitest-exit.sh`: exit 124 (jsdom open-handle hang after tests complete) stays a warning, but any output matching vitest's coverage-threshold failure forms — including the max-uncovered form — fails the job regardless of exit code. ANSI escape sequences are stripped before matching (covered by a split-token mid-word test case).
- TDD: `scripts/__tests__/check-vitest-exit.test.sh` covers the boundary cases (plain threshold form, max-uncovered form, ANSI-split tokens, timeout-only exit, malformed input fail-safe).
- Wired into `ci.yml`, `quality-gates.yml`, and `cd.yml` so all three coverage paths share one verifier.

Closes #8598

## Test plan
- [x] `shellcheck` clean on `scripts/check-vitest-exit.sh` + test suite
- [x] `bash scripts/__tests__/check-vitest-exit.test.sh` — PASS
- [x] `actionlint` on all three workflows — no new findings vs origin/main (net −6: branch fixes 6 pre-existing SC2086s in rewritten regions; remaining legacy findings tracked in #8719)
- [ ] CI green on this PR