### PR TITLE
ci(deps): ignore bare github/gh-aw-actions ref in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,4 +48,10 @@ updates:
       - dependencies
       - ci
     ignore:
-      - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+      # gh-aw-actions are managed by `gh aw compile` (version-locked to the gh-aw
+      # compiler) — Dependabot must never bump them. Both the bare repo ref AND any
+      # sub-action paths are ignored: the `/**` glob alone does NOT match the bare
+      # `github/gh-aw-actions` name, which is what let #8717 and #8738 slip through
+      # and fail the `gh-aw Lock Sync` gate by design.
+      - dependency-name: "github/gh-aw-actions"
+      - dependency-name: "github/gh-aw-actions/**"


### PR DESCRIPTION
## Summary

Dependabot kept opening github-actions PRs that bump `github/gh-aw-actions` (e.g. #8717, #8738), each of which fails the **gh-aw Lock Sync** gate **by design** — `gh-aw-actions` is version-locked to the gh-aw compiler and must only move through `gh aw compile --no-check-update --purge`, never a raw pin bump.

PR #8731 already added an ignore for `github/gh-aw-actions/**`, but that glob **never matches the bare `github/gh-aw-actions` ref** that Dependabot records for the top-level action. Dependabot's `dependency-name` glob semantics only treat a pattern as a glob when it contains `*`; `…/**` requires a path segment after the base, so the bare name slips straight through — which is exactly how #8717 and #8738 were opened after the glob ignore landed (empirically confirmed in commit history).

This adds the **exact-match** entry alongside the existing glob so both forms are ignored:

```yaml
ignore:
  - dependency-name: "github/gh-aw-actions"
  - dependency-name: "github/gh-aw-actions/**"
```

## Why both entries

- `github/gh-aw-actions` — the bare top-level action ref Dependabot actually records (exact, case-insensitive match).
- `github/gh-aw-actions/**` — any sub-action path under the repo.

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML; both ignore entries present under the github-actions ecosystem block.
- [x] security-reviewer: PASS — no unintended suppression; only `gh-aw-actions` is ignored, no other security-relevant action.
- [x] dx-guardian: PASS — glob-vs-bare-ref failure empirically proven by commit history (#8717/#8738 opened after the `/**`-only ignore); comment is accurate and rot-resistant.

Closes #8740