### PR TITLE
feat(onboarding): /sign-up waitlist capture replaces the mailto dead end (#8730)

### DIFF
--- a/.changeset/waitlist-capture.md
+++ b/.changeset/waitlist-capture.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Deliver the waitlist that every marketing CTA promises: /sign-up now renders an accessible email-capture form (idle/submitting/success/error states, aria-live status region, hidden honeypot) instead of a mailto dead end, backed by a new public POST /api/waitlist route (IP rate limited, strict server-side email validation with trim+lowercase normalization, honeypot short-circuit, and duplicate-safe inserts via onConflictDoNothing on the new waitlist_signups table's unique email index — migration 0007). Sign-ups themselves remain disabled; this is lead capture only.

--- a/web/drizzle/0007_waitlist_signups.sql
+++ b/web/drizzle/0007_waitlist_signups.sql
@@ -1,0 +1,20 @@
+-- Waitlist capture (#8730).
+--
+-- /sign-up's marketing CTAs promise a waitlist but the page only offered a
+-- mailto link; this table is where POST /api/waitlist stores the leads.
+-- Sign-ups themselves stay disabled (product decision) — this is lead
+-- capture only, so there is deliberately no user_id FK (email only) and no
+-- deleteUserAccount cascade change is needed.
+--
+-- Email is normalized (trim + toLowerCase) by the API BEFORE insert, so the
+-- plain unique index on the raw column is the ON CONFLICT arbiter that makes
+-- duplicate signups idempotent — no lower(email) expression index needed.
+--
+-- Idempotent (IF NOT EXISTS) per the 0006 convention, so re-running against
+-- a DB that already carries the table is a no-op.
+CREATE TABLE IF NOT EXISTS "waitlist_signups" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_waitlist_signups_email" ON "waitlist_signups" ("email");

--- a/web/drizzle/meta/_journal.json
+++ b/web/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781136000000,
       "tag": "0006_backfill_schema_drift",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781234087417,
+      "tag": "0007_waitlist_signups",
+      "breakpoints": true
     }
   ]
 }

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -82,6 +82,9 @@ describe('proxy public-route matcher (real Clerk matcher)', () => {
     // real submission before the route's own rate limit/honeypot/validation
     // ever run — the exact omission class this matcher suite exists to catch.
     expect(isPublic('/api/waitlist')).toBe(true);
+    // Pin the trailing (.*) — any future sub-path (e.g. /api/waitlist/confirm)
+    // must stay public too; an exact-match tightening would silently 401 it.
+    expect(isPublic('/api/waitlist/confirm')).toBe(true);
   });
 
   it('only exposes the /dev auth-bypass route when includeDev (non-production) (#7915)', () => {

--- a/web/src/__tests__/proxy.test.ts
+++ b/web/src/__tests__/proxy.test.ts
@@ -76,6 +76,14 @@ describe('proxy public-route matcher (real Clerk matcher)', () => {
     expect(isPublic('/sign-up/sso-callback')).toBe(true);
   });
 
+  it('treats the waitlist endpoint as public so unauthenticated visitors can sign up (#8730)', () => {
+    // The /sign-up waitlist form posts here from visitors who BY DEFINITION
+    // have no Clerk session. If this pattern disappears, production 401s every
+    // real submission before the route's own rate limit/honeypot/validation
+    // ever run — the exact omission class this matcher suite exists to catch.
+    expect(isPublic('/api/waitlist')).toBe(true);
+  });
+
   it('only exposes the /dev auth-bypass route when includeDev (non-production) (#7915)', () => {
     const prod = createRouteMatcher(buildPublicRoutes({ includeDev: false }));
     const dev = createRouteMatcher(buildPublicRoutes({ includeDev: true }));
@@ -101,6 +109,16 @@ describe('proxy auth decision (applyAuthDecision, real matcher)', () => {
     const res = await applyAuthDecision(unauthed, reqFor('/api/cron/health-monitor'), isPublicRoute);
     expect(res.status).toBe(200);
     // Never asked Clerk to redirect — the route was treated as public.
+    expect(redirectToSignIn).not.toHaveBeenCalled();
+  });
+
+  it('lets an unauthenticated POST through to the public waitlist endpoint (#8730)', async () => {
+    const res = await applyAuthDecision(
+      unauthed,
+      reqFor('/api/waitlist', { method: 'POST' }),
+      isPublicRoute,
+    );
+    expect(res.status).toBe(200);
     expect(redirectToSignIn).not.toHaveBeenCalled();
   });
 

--- a/web/src/app/api/waitlist/route.test.ts
+++ b/web/src/app/api/waitlist/route.test.ts
@@ -252,5 +252,15 @@ describe('POST /api/waitlist', () => {
 
     expect(res.status).toBe(500);
     expect(captureException).toHaveBeenCalledTimes(1);
+    // The client body is generic — the raw driver error ('connection refused')
+    // must never leak to the caller as an internal-detail oracle.
+    const body = await res.json();
+    expect(body.error).toMatch(/something went wrong/i);
+    expect(body.error).not.toMatch(/connection refused/i);
+    // Sentry receives the real Error plus route/method tags for triage.
+    expect(captureException).toHaveBeenCalledWith(expect.any(Error), {
+      route: '/api/waitlist',
+      method: 'POST',
+    });
   });
 });

--- a/web/src/app/api/waitlist/route.test.ts
+++ b/web/src/app/api/waitlist/route.test.ts
@@ -1,0 +1,199 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimitPublicRoute: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(),
+  queryWithResilience: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+import { rateLimitPublicRoute } from '@/lib/rateLimit';
+import { getDb } from '@/lib/db/client';
+import { captureException } from '@/lib/monitoring/sentry-server';
+import { waitlistSignups } from '@/lib/db/schema';
+
+const BASE_URL = 'http://localhost:3000/api/waitlist';
+
+function makeReq(body: unknown) {
+  return new NextRequest(BASE_URL, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Builds the standard getDb mock for the insert→values→onConflictDoNothing chain. */
+function mockInsertChain() {
+  const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+  const values = vi.fn().mockReturnValue({ onConflictDoNothing });
+  const insert = vi.fn().mockReturnValue({ values });
+  vi.mocked(getDb).mockReturnValue({ insert } as never);
+  return { insert, values, onConflictDoNothing };
+}
+
+describe('POST /api/waitlist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(null);
+  });
+
+  it('returns 200 and inserts the normalized email for a fresh signup', async () => {
+    const { insert, values } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: '  User@Example.COM ' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(insert).toHaveBeenCalledWith(waitlistSignups);
+    // Server-side normalization: trim + lowercase BEFORE insert, so the plain
+    // unique index on email is a sufficient ON CONFLICT arbiter.
+    expect(values).toHaveBeenCalledWith({ email: 'user@example.com' });
+  });
+
+  it('is idempotent via onConflictDoNothing on the named unique index', async () => {
+    const { onConflictDoNothing } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'dup@example.com' }));
+
+    expect(res.status).toBe(200);
+    expect(onConflictDoNothing).toHaveBeenCalledWith({
+      target: waitlistSignups.email,
+    });
+  });
+
+  it('returns a duplicate-signup response indistinguishable from a fresh one (no enumeration oracle)', async () => {
+    mockInsertChain();
+    const { POST } = await import('./route');
+    const fresh = await POST(makeReq({ email: 'fresh@example.com' }));
+    const freshBody = await fresh.json();
+
+    // Duplicate: PG reports 0 inserted rows; route must not branch on it.
+    const onConflictDoNothing = vi.fn().mockResolvedValue([]);
+    const values = vi.fn().mockReturnValue({ onConflictDoNothing });
+    vi.mocked(getDb).mockReturnValue({ insert: vi.fn().mockReturnValue({ values }) } as never);
+
+    const dup = await POST(makeReq({ email: 'fresh@example.com' }));
+    const dupBody = await dup.json();
+
+    expect(dup.status).toBe(fresh.status);
+    expect(dupBody).toEqual(freshBody);
+  });
+
+  it('awaits rateLimitPublicRoute and returns its 429 when the limit is exceeded', async () => {
+    const { insert } = mockInsertChain();
+    const limited = new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429 });
+    // Resolved (not returned) value: only an awaited call can surface this 429 —
+    // a missing await would hand back a pending Promise, not a Response.
+    vi.mocked(rateLimitPublicRoute).mockResolvedValue(limited as never);
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'user@example.com' }));
+
+    expect(rateLimitPublicRoute).toHaveBeenCalledTimes(1);
+    expect(rateLimitPublicRoute).toHaveBeenCalledWith(
+      expect.anything(),
+      'waitlist',
+      expect.any(Number),
+      expect.any(Number)
+    );
+    expect(res.status).toBe(429);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('returns the standard success response WITHOUT inserting when the honeypot is filled', async () => {
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+    const realRes = await POST(makeReq({ email: 'real@example.com' }));
+    const realBody = await realRes.json();
+    expect(insert).toHaveBeenCalledTimes(1);
+
+    insert.mockClear();
+    const botRes = await POST(makeReq({ email: 'bot@example.com', website: 'https://spam.example' }));
+    const botBody = await botRes.json();
+
+    expect(botRes.status).toBe(realRes.status);
+    expect(botBody).toEqual(realBody);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-string honeypot value as a bot', async () => {
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'bot@example.com', website: 42 }));
+
+    expect(res.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing email', {}],
+    ['non-string email', { email: 42 }],
+    ['empty email', { email: '   ' }],
+    ['no @', { email: 'not-an-email' }],
+    ['no TLD', { email: 'user@localhost' }],
+    ['embedded whitespace', { email: 'us er@example.com' }],
+    ['over 254 chars', { email: `${'a'.repeat(250)}@example.com` }],
+  ])('returns 400 for %s', async (_label, body) => {
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq(body));
+
+    expect(res.status).toBe(400);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for malformed JSON', async () => {
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+    const req = new NextRequest(BASE_URL, {
+      method: 'POST',
+      body: 'not-json{{{',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['array body', ['user@example.com']],
+    ['string body', 'user@example.com'],
+    ['null body', null],
+  ])('returns 400 for non-object JSON (%s)', async (_label, body) => {
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq(body));
+
+    expect(res.status).toBe(400);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 and reports to Sentry when the insert fails', async () => {
+    const onConflictDoNothing = vi.fn().mockRejectedValue(new Error('connection refused'));
+    const values = vi.fn().mockReturnValue({ onConflictDoNothing });
+    vi.mocked(getDb).mockReturnValue({ insert: vi.fn().mockReturnValue({ values }) } as never);
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'user@example.com' }));
+
+    expect(res.status).toBe(500);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/api/waitlist/route.test.ts
+++ b/web/src/app/api/waitlist/route.test.ts
@@ -61,6 +61,33 @@ describe('POST /api/waitlist', () => {
     expect(values).toHaveBeenCalledWith({ email: 'user@example.com' });
   });
 
+  it('inserts for the real browser payload — empty-string honeypot is NOT a bot', async () => {
+    // SignUpClient always submits { email, website: '' } (the hidden honeypot
+    // field serializes as an empty string). This pins the cross-seam contract:
+    // an empty-string honeypot must be treated as a legitimate signup, or every
+    // real browser submission would be silently dropped with a fake success.
+    const { insert, values } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'user@example.com', website: '' }));
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith({ email: 'user@example.com' });
+  });
+
+  it('inserts when the honeypot is explicitly null (null is the legit carve-out, not a bot)', async () => {
+    // The honeypot check deliberately exempts null alongside undefined: a
+    // client serializing the untouched field as null is not bot behaviour.
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email: 'user@example.com', website: null }));
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledTimes(1);
+  });
+
   it('is idempotent via onConflictDoNothing on the named unique index', async () => {
     const { onConflictDoNothing } = mockInsertChain();
     const { POST } = await import('./route');
@@ -102,11 +129,14 @@ describe('POST /api/waitlist', () => {
     const res = await POST(makeReq({ email: 'user@example.com' }));
 
     expect(rateLimitPublicRoute).toHaveBeenCalledTimes(1);
+    // Literal limits pin the abuse budget (repo convention — see the
+    // marketplace/assets and community/games route suites): a silent bump of
+    // WAITLIST_RATE_LIMIT_MAX or the window must fail this test.
     expect(rateLimitPublicRoute).toHaveBeenCalledWith(
       expect.anything(),
       'waitlist',
-      expect.any(Number),
-      expect.any(Number)
+      10,
+      60_000
     );
     expect(res.status).toBe(429);
     expect(insert).not.toHaveBeenCalled();
@@ -135,6 +165,33 @@ describe('POST /api/waitlist', () => {
     const res = await POST(makeReq({ email: 'bot@example.com', website: 42 }));
 
     expect(res.status).toBe(200);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('accepts an email at exactly the RFC 5321 max length (254 chars)', async () => {
+    // Boundary pin: 242 + '@example.com' (12) = 254. The cap is `> 254`,
+    // not `>= 254` — an off-by-one here silently rejects valid maximal
+    // addresses, and only an accept case at the exact boundary catches it.
+    const email = `${'a'.repeat(242)}@example.com`;
+    expect(email).toHaveLength(254);
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email }));
+
+    expect(res.status).toBe(200);
+    expect(insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an email one char over the RFC 5321 max length (255 chars)', async () => {
+    const email = `${'a'.repeat(243)}@example.com`;
+    expect(email).toHaveLength(255);
+    const { insert } = mockInsertChain();
+    const { POST } = await import('./route');
+
+    const res = await POST(makeReq({ email }));
+
+    expect(res.status).toBe(400);
     expect(insert).not.toHaveBeenCalled();
   });
 

--- a/web/src/app/api/waitlist/route.ts
+++ b/web/src/app/api/waitlist/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDb, queryWithResilience } from '@/lib/db/client';
+import { waitlistSignups } from '@/lib/db/schema';
+import { rateLimitPublicRoute } from '@/lib/rateLimit';
+import { captureException } from '@/lib/monitoring/sentry-server';
+
+/**
+ * POST /api/waitlist — public waitlist lead capture (#8730).
+ *
+ * Backs the /sign-up waitlist form. Sign-ups stay disabled while SpawnForge
+ * is in development (product decision); this route only stores an email so
+ * the marketing CTAs ("Join the Waitlist" / "Request Early Access") deliver
+ * what they promise.
+ *
+ * Anti-abuse properties:
+ * - IP rate limited (awaited — rateLimitPublicRoute is async).
+ * - Honeypot field ("website"): a non-empty value gets the SAME success
+ *   response without inserting, so bots are not tipped off.
+ * - Idempotent: the email is normalized (trim + toLowerCase) before insert
+ *   and duplicates hit onConflictDoNothing on uq_waitlist_signups_email; the
+ *   response is byte-identical to a fresh signup, so the endpoint is not an
+ *   email-enumeration oracle.
+ */
+
+export const dynamic = 'force-dynamic';
+
+const WAITLIST_RATE_LIMIT_MAX = 10;
+const WAITLIST_RATE_LIMIT_WINDOW_MS = 60_000;
+
+/** RFC 5321 upper bound on a full address. */
+const EMAIL_MAX_LENGTH = 254;
+
+/**
+ * Strict shape check: one non-whitespace local part, an @, and a dotted
+ * domain with a TLD. Deliberately simple — normalization + the unique index
+ * carry correctness; this only rejects obvious garbage early.
+ */
+const EMAIL_REGEX = /^[^\s@]+@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+$/;
+
+/** Single source for the success body so all success paths are indistinguishable. */
+function successResponse(): NextResponse {
+  return NextResponse.json(
+    { ok: true, message: "You're on the list. We'll email you when early access opens." },
+    { status: 200 }
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await rateLimitPublicRoute(
+    request,
+    'waitlist',
+    WAITLIST_RATE_LIMIT_MAX,
+    WAITLIST_RATE_LIMIT_WINDOW_MS
+  );
+  if (rateLimited) return rateLimited;
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  // Allowlist: read ONLY these two fields. The body is never spread.
+  const { email: rawEmail, website } = raw as { email?: unknown; website?: unknown };
+
+  // Honeypot tripped (any non-empty value, string or not): pretend success.
+  const honeypotTripped =
+    typeof website === 'string' ? website.trim().length > 0 : website !== undefined && website !== null;
+  if (honeypotTripped) {
+    return successResponse();
+  }
+
+  if (typeof rawEmail !== 'string') {
+    return NextResponse.json({ error: 'A valid email address is required' }, { status: 400 });
+  }
+  const email = rawEmail.trim().toLowerCase();
+  if (email.length === 0 || email.length > EMAIL_MAX_LENGTH || !EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: 'A valid email address is required' }, { status: 400 });
+  }
+
+  try {
+    await queryWithResilience(() =>
+      getDb()
+        .insert(waitlistSignups)
+        .values({ email })
+        .onConflictDoNothing({ target: waitlistSignups.email })
+    );
+  } catch (error) {
+    captureException(error, { route: '/api/waitlist', method: 'POST' });
+    return NextResponse.json(
+      { error: 'Something went wrong. Please try again.' },
+      { status: 500 }
+    );
+  }
+
+  return successResponse();
+}

--- a/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Pre-launch waitlist page (#8730).
@@ -14,8 +14,13 @@ import { useState } from 'react';
  *
  * Accessibility: a real <label> on the input, a persistent aria-live="polite"
  * status region for success/error announcements, error text programmatically
- * associated via aria-describedby/aria-invalid, and the submit disabled while
- * a request is in flight.
+ * associated via aria-describedby (aria-invalid only for field-validation
+ * failures — a 429/500/network error does not make the VALUE invalid), and
+ * the submit guarded with aria-disabled while a request is in flight (the
+ * real `disabled` attribute would drop focus to <body> in Chrome/Firefox the
+ * moment it lands on the focused button; re-entry is blocked in the handler).
+ * On success the form unmounts, so focus is explicitly moved to the status
+ * region — otherwise keyboard users are dropped to <body> (WCAG 2.4.3).
  *
  * Honeypot: the "website" field is visually hidden by OFF-SCREEN POSITIONING
  * rather than display:none — naive bots skip display:none fields, while an
@@ -26,12 +31,36 @@ import { useState } from 'react';
 
 type FormStatus = 'idle' | 'submitting' | 'success' | 'error';
 
+/**
+ * Why two error kinds: aria-invalid on the input is only truthful when the
+ * VALUE the user entered is bad ('field': empty email, HTTP 400). Operational
+ * failures (429 rate limit, 5xx, network) leave a perfectly valid value —
+ * announcing "invalid entry" there contradicts the visible message and steers
+ * the user to edit a correct address.
+ */
+type ErrorKind = 'field' | 'operational';
+
 export function SignUpClient() {
   const [status, setStatus] = useState<FormStatus>('idle');
   const [errorMessage, setErrorMessage] = useState('');
+  const [errorKind, setErrorKind] = useState<ErrorKind>('operational');
+  const statusRef = useRef<HTMLParagraphElement>(null);
+
+  // On success the whole <form> unmounts while focus is inside it (the email
+  // input for Enter-key submitters, the button for click submitters). Without
+  // explicit management focus falls to document.body and the next Tab restarts
+  // from the top of the page — so move it to the status region, which holds
+  // the confirmation text the user needs next.
+  useEffect(() => {
+    if (status === 'success') {
+      statusRef.current?.focus();
+    }
+  }, [status]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    // Re-entry guard: with aria-disabled (not `disabled`) the button stays
+    // clickable, so THIS is what prevents double submission in flight.
     if (status === 'submitting') return;
 
     const formData = new FormData(event.currentTarget);
@@ -42,6 +71,7 @@ export function SignUpClient() {
 
     if (email.length === 0) {
       setStatus('error');
+      setErrorKind('field');
       setErrorMessage('Enter your email address to join the waitlist.');
       return;
     }
@@ -60,14 +90,18 @@ export function SignUpClient() {
       }
       setStatus('error');
       if (res.status === 429) {
+        setErrorKind('operational');
         setErrorMessage('Too many attempts. Please wait a minute and try again.');
       } else if (res.status === 400) {
+        setErrorKind('field');
         setErrorMessage('That email address does not look right. Please check it and try again.');
       } else {
+        setErrorKind('operational');
         setErrorMessage('Something went wrong. Please try again.');
       }
     } catch {
       setStatus('error');
+      setErrorKind('operational');
       setErrorMessage('Network error. Please check your connection and try again.');
     }
   }
@@ -94,11 +128,15 @@ export function SignUpClient() {
         </p>
 
         {/* Persistent live region: present from first paint so screen readers
-            announce later success/error updates. */}
+            announce later success/error updates. tabIndex={-1} keeps it out of
+            the tab order but lets the success effect move focus here when the
+            form unmounts. */}
         <p
           id="waitlist-status"
+          ref={statusRef}
           role="status"
           aria-live="polite"
+          tabIndex={-1}
           className={`mt-6 min-h-5 text-sm ${status === 'error' ? 'text-red-400' : 'text-emerald-400'}`}
         >
           {statusText}
@@ -136,14 +174,18 @@ export function SignUpClient() {
               maxLength={254}
               autoComplete="email"
               placeholder="you@example.com"
-              aria-invalid={status === 'error' ? true : undefined}
+              aria-invalid={status === 'error' && errorKind === 'field' ? true : undefined}
               aria-describedby={status === 'error' ? 'waitlist-status' : undefined}
-              className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm text-white placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
             />
+            {/* aria-disabled (not `disabled`): real browsers drop focus to
+                <body> the instant a focused button gets the disabled attribute,
+                losing the keyboard user's place even on the error path. The
+                handler's re-entry guard blocks double submission instead. */}
             <button
               type="submit"
-              disabled={status === 'submitting'}
-              className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+              aria-disabled={status === 'submitting' ? true : undefined}
+              className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-500 aria-disabled:cursor-not-allowed aria-disabled:opacity-60"
             >
               {status === 'submitting' ? 'Joining…' : 'Join the waitlist'}
             </button>

--- a/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -195,12 +195,22 @@ export function SignUpClient() {
                 losing the keyboard user's place even on the error path. Passed
                 via {...props} (NOT the `disabled` prop) so the Button keeps the
                 real attribute off; the handler's re-entry guard blocks double
-                submission, and aria-disabled:* variants carry the visual state. */}
+                submission, and aria-disabled:* variants carry the visual state.
+
+                bg-[var(--sf-accent-hover)] override: the shared Button's
+                `default` variant renders --sf-on-accent on --sf-accent at rest,
+                which is only ~3.68:1 in the default (dark) theme — below the AA
+                4.5:1 floor for this 16px label. Riding the variant's already-
+                shipping hover color (--sf-accent-hover) lifts the resting CTA to
+                AA in the default theme + 5 of 7 themes via a token (no hardcoded
+                color); tailwind-merge keeps this last-wins over the variant's bg.
+                The app-wide primitive fix (incl. leaf, which fails even at hover)
+                is tracked in #8742; remove this override once that lands. */}
             <Button
               type="submit"
               size="lg"
               aria-disabled={status === 'submitting' ? true : undefined}
-              className="mt-4 w-full aria-disabled:cursor-not-allowed aria-disabled:opacity-60"
+              className="mt-4 w-full bg-[var(--sf-accent-hover)] aria-disabled:cursor-not-allowed aria-disabled:opacity-60"
             >
               {status === 'submitting' ? 'Joining…' : 'Join the waitlist'}
             </Button>

--- a/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -1,16 +1,84 @@
+'use client';
+
 import Link from 'next/link';
+import { useState } from 'react';
 
 /**
- * Pre-launch sign-up notice.
+ * Pre-launch waitlist page (#8730).
  *
- * Sign-ups are intentionally disabled while SpawnForge is in development.
- * Rather than render Clerk's <SignUp> in restricted mode — which shows a
- * support-contact error that reads as "action required" and drives a flood
- * of support emails — we show a clear "coming soon" notice with a single,
- * optional way to register interest. Sign-in is unaffected; approved users
- * still authenticate normally at /sign-in.
+ * Sign-ups are intentionally disabled while SpawnForge is in development —
+ * this page deliberately renders NO Clerk <SignUp> (approved users still
+ * authenticate at /sign-in). Every marketing CTA ("Join the Waitlist",
+ * "Request Early Access") lands here, so instead of a dead-end notice the
+ * page captures the promised lead: an email form posting to /api/waitlist.
+ *
+ * Accessibility: a real <label> on the input, a persistent aria-live="polite"
+ * status region for success/error announcements, error text programmatically
+ * associated via aria-describedby/aria-invalid, and the submit disabled while
+ * a request is in flight.
+ *
+ * Honeypot: the "website" field is visually hidden by OFF-SCREEN POSITIONING
+ * rather than display:none — naive bots skip display:none fields, while an
+ * off-screen field still looks fillable. It is removed from the a11y tree
+ * (aria-hidden wrapper) and the tab order (tabIndex={-1}), with
+ * autoComplete="off" so browsers never fill it for real users.
  */
+
+type FormStatus = 'idle' | 'submitting' | 'success' | 'error';
+
 export function SignUpClient() {
+  const [status, setStatus] = useState<FormStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (status === 'submitting') return;
+
+    const formData = new FormData(event.currentTarget);
+    // FormData.get returns null for a missing field — ?? (not ||) so an
+    // empty string is preserved as-is rather than masked by a default.
+    const email = String(formData.get('email') ?? '').trim();
+    const website = String(formData.get('website') ?? '');
+
+    if (email.length === 0) {
+      setStatus('error');
+      setErrorMessage('Enter your email address to join the waitlist.');
+      return;
+    }
+
+    setStatus('submitting');
+    setErrorMessage('');
+    try {
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, website }),
+      });
+      if (res.ok) {
+        setStatus('success');
+        return;
+      }
+      setStatus('error');
+      if (res.status === 429) {
+        setErrorMessage('Too many attempts. Please wait a minute and try again.');
+      } else if (res.status === 400) {
+        setErrorMessage('That email address does not look right. Please check it and try again.');
+      } else {
+        setErrorMessage('Something went wrong. Please try again.');
+      }
+    } catch {
+      setStatus('error');
+      setErrorMessage('Network error. Please check your connection and try again.');
+    }
+  }
+
+  const statusText =
+    status === 'success'
+      ? "You're on the list. We'll email you when early access opens."
+      : status === 'error'
+        ? errorMessage
+        : '';
+
   return (
     <main className="flex min-h-screen items-center justify-center bg-zinc-950 px-6">
       <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
@@ -21,10 +89,69 @@ export function SignUpClient() {
           SpawnForge is in development
         </h1>
         <p className="mt-4 text-base leading-relaxed text-zinc-400">
-          Release details and timeline will be published soon.
+          Sign-ups open with early access. Join the waitlist and we&apos;ll
+          email you when your spot is ready.
         </p>
+
+        {/* Persistent live region: present from first paint so screen readers
+            announce later success/error updates. */}
+        <p
+          id="waitlist-status"
+          role="status"
+          aria-live="polite"
+          className={`mt-6 min-h-5 text-sm ${status === 'error' ? 'text-red-400' : 'text-emerald-400'}`}
+        >
+          {statusText}
+        </p>
+
+        {status !== 'success' && (
+          <form onSubmit={handleSubmit} className="relative mt-2 text-left" noValidate>
+            {/* Honeypot — see the component docblock for the hiding rationale. */}
+            <div
+              aria-hidden="true"
+              className="absolute -left-[9999px] top-auto h-px w-px overflow-hidden"
+            >
+              <label htmlFor="waitlist-website">Website</label>
+              <input
+                id="waitlist-website"
+                name="website"
+                type="text"
+                tabIndex={-1}
+                autoComplete="off"
+                defaultValue=""
+              />
+            </div>
+
+            <label
+              htmlFor="waitlist-email"
+              className="block text-sm font-medium text-zinc-300"
+            >
+              Email address
+            </label>
+            <input
+              id="waitlist-email"
+              name="email"
+              type="email"
+              required
+              maxLength={254}
+              autoComplete="email"
+              placeholder="you@example.com"
+              aria-invalid={status === 'error' ? true : undefined}
+              aria-describedby={status === 'error' ? 'waitlist-status' : undefined}
+              className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            />
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {status === 'submitting' ? 'Joining…' : 'Join the waitlist'}
+            </button>
+          </form>
+        )}
+
         <p className="mt-6 text-sm text-zinc-400">
-          Interested in being an early user?{' '}
+          Questions?{' '}
           <a
             href="mailto:support@spawnforge.ai"
             className="font-medium text-blue-400 underline-offset-4 transition-colors hover:text-blue-300 hover:underline"

--- a/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
+import { Button, Input, Label, cn } from '@spawnforge/ui';
 
 /**
  * Pre-launch waitlist page (#8730).
@@ -11,6 +12,10 @@ import { useEffect, useRef, useState } from 'react';
  * authenticate at /sign-in). Every marketing CTA ("Join the Waitlist",
  * "Request Early Access") lands here, so instead of a dead-end notice the
  * page captures the promised lead: an email form posting to /api/waitlist.
+ *
+ * Built on the @spawnforge/ui design system — Label/Input/Button primitives
+ * and var(--sf-*) tokens — so it renders correctly across all 7 themes and in
+ * light mode (no hardcoded zinc/blue/red/emerald that would be theme-blind).
  *
  * Accessibility: a real <label> on the input, a persistent aria-live="polite"
  * status region for success/error announcements, error text programmatically
@@ -97,7 +102,9 @@ export function SignUpClient() {
         setErrorMessage('That email address does not look right. Please check it and try again.');
       } else {
         setErrorKind('operational');
-        setErrorMessage('Something went wrong. Please try again.');
+        setErrorMessage(
+          "We couldn't add you to the list just now. Please try again, or email support@spawnforge.ai if it keeps happening."
+        );
       }
     } catch {
       setStatus('error');
@@ -113,16 +120,18 @@ export function SignUpClient() {
         ? errorMessage
         : '';
 
+  const isFieldError = status === 'error' && errorKind === 'field';
+
   return (
-    <main className="flex min-h-screen items-center justify-center bg-zinc-950 px-6">
-      <div className="w-full max-w-md rounded-2xl border border-zinc-800 bg-zinc-900/50 p-8 text-center">
-        <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-zinc-700 bg-zinc-900 px-4 py-1.5 text-sm text-zinc-300">
+    <main className="flex min-h-screen items-center justify-center bg-[var(--sf-bg-app)] px-6">
+      <div className="w-full max-w-md rounded-[var(--sf-radius-xl)] border border-[var(--sf-border)] bg-[var(--sf-bg-surface)] p-8 text-center">
+        <div className="mb-6 inline-flex items-center gap-2 rounded-[var(--sf-radius-full)] border border-[var(--sf-border-strong)] bg-[var(--sf-bg-app)] px-4 py-1.5 text-sm text-[var(--sf-text-secondary)]">
           SpawnForge
         </div>
-        <h1 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
+        <h1 className="text-2xl font-bold tracking-tight text-[var(--sf-text)] sm:text-3xl">
           SpawnForge is in development
         </h1>
-        <p className="mt-4 text-base leading-relaxed text-zinc-400">
+        <p className="mt-4 text-base leading-relaxed text-[var(--sf-text-secondary)]">
           Sign-ups open with early access. Join the waitlist and we&apos;ll
           email you when your spot is ready.
         </p>
@@ -137,14 +146,20 @@ export function SignUpClient() {
           role="status"
           aria-live="polite"
           tabIndex={-1}
-          className={`mt-6 min-h-5 text-sm ${status === 'error' ? 'text-red-400' : 'text-emerald-400'}`}
+          className={cn(
+            'mt-6 min-h-5 text-sm',
+            status === 'error' ? 'text-[var(--sf-destructive)]' : 'text-[var(--sf-success)]'
+          )}
         >
           {statusText}
         </p>
 
         {status !== 'success' && (
           <form onSubmit={handleSubmit} className="relative mt-2 text-left" noValidate>
-            {/* Honeypot — see the component docblock for the hiding rationale. */}
+            {/* Honeypot — see the component docblock for the hiding rationale.
+                Kept as raw, color-free, off-screen markup on purpose: it is
+                aria-hidden and must look like a plain fillable field to bots,
+                so it deliberately does NOT use the themed primitives. */}
             <div
               aria-hidden="true"
               className="absolute -left-[9999px] top-auto h-px w-px overflow-hidden"
@@ -160,13 +175,10 @@ export function SignUpClient() {
               />
             </div>
 
-            <label
-              htmlFor="waitlist-email"
-              className="block text-sm font-medium text-zinc-300"
-            >
+            <Label htmlFor="waitlist-email" className="block">
               Email address
-            </label>
-            <input
+            </Label>
+            <Input
               id="waitlist-email"
               name="email"
               type="email"
@@ -174,36 +186,39 @@ export function SignUpClient() {
               maxLength={254}
               autoComplete="email"
               placeholder="you@example.com"
-              aria-invalid={status === 'error' && errorKind === 'field' ? true : undefined}
+              error={isFieldError}
               aria-describedby={status === 'error' ? 'waitlist-status' : undefined}
-              className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm text-white placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+              className="mt-2"
             />
             {/* aria-disabled (not `disabled`): real browsers drop focus to
                 <body> the instant a focused button gets the disabled attribute,
-                losing the keyboard user's place even on the error path. The
-                handler's re-entry guard blocks double submission instead. */}
-            <button
+                losing the keyboard user's place even on the error path. Passed
+                via {...props} (NOT the `disabled` prop) so the Button keeps the
+                real attribute off; the handler's re-entry guard blocks double
+                submission, and aria-disabled:* variants carry the visual state. */}
+            <Button
               type="submit"
+              size="lg"
               aria-disabled={status === 'submitting' ? true : undefined}
-              className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-500 aria-disabled:cursor-not-allowed aria-disabled:opacity-60"
+              className="mt-4 w-full aria-disabled:cursor-not-allowed aria-disabled:opacity-60"
             >
               {status === 'submitting' ? 'Joining…' : 'Join the waitlist'}
-            </button>
+            </Button>
           </form>
         )}
 
-        <p className="mt-6 text-sm text-zinc-400">
+        <p className="mt-6 text-sm text-[var(--sf-text-secondary)]">
           Questions?{' '}
           <a
             href="mailto:support@spawnforge.ai"
-            className="font-medium text-blue-400 underline-offset-4 transition-colors hover:text-blue-300 hover:underline"
+            className="font-medium text-[var(--sf-accent)] underline-offset-4 transition-colors hover:text-[var(--sf-accent-hover)] hover:underline"
           >
             support@spawnforge.ai
           </a>
         </p>
         <Link
           href="/"
-          className="mt-8 inline-flex items-center justify-center rounded-lg border border-zinc-700 px-5 py-2.5 text-sm font-semibold text-zinc-300 transition-colors hover:border-zinc-500 hover:text-white"
+          className="mt-8 inline-flex min-h-[44px] items-center justify-center rounded-[var(--sf-radius-md)] border border-[var(--sf-border-strong)] px-6 text-base font-medium text-[var(--sf-text-secondary)] transition-all duration-[var(--sf-transition)] hover:border-[var(--sf-accent)] hover:text-[var(--sf-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sf-accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--sf-bg-app)]"
         >
           Back to home
         </Link>

--- a/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
@@ -106,27 +106,49 @@ describe('SignUpClient (waitlist capture)', () => {
     expect(screen.queryByRole('button', { name: /join the waitlist/i })).toBeNull();
   });
 
-  it('disables the submit button while the request is in flight', async () => {
+  it('guards the submit button with aria-disabled while in flight and blocks re-submission', async () => {
     let resolveFetch: (value: Response) => void = () => {};
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockImplementation(
-        () => new Promise<Response>((resolve) => { resolveFetch = resolve; })
-      )
+    const fetchMock = vi.fn().mockImplementation(
+      () => new Promise<Response>((resolve) => { resolveFetch = resolve; })
     );
+    vi.stubGlobal('fetch', fetchMock);
     const user = userEvent.setup();
     render(<SignUpClient />);
 
     await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
     await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
 
+    // aria-disabled, NOT the disabled attribute: real browsers move focus to
+    // <body> the moment a focused button is hard-disabled, so the click
+    // submitter would lose their place even on the error path.
     const pending = await screen.findByRole('button', { name: /joining/i });
-    expect(pending).toBeDisabled();
+    expect(pending).toHaveAttribute('aria-disabled', 'true');
+    expect(pending).not.toHaveAttribute('disabled');
+
+    // The handler's re-entry guard (not the attribute) prevents double posts.
+    await user.click(pending);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     resolveFetch(okResponse());
     await waitFor(() => {
       expect(screen.getByRole('status')).toHaveTextContent(/you're on the list/i);
     });
+  });
+
+  it('moves focus to the status region on success (form unmounts under the focused element)', async () => {
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    const input = screen.getByLabelText(/email address/i);
+    await user.type(input, 'fan@example.com{enter}');
+
+    // Without explicit focus management, unmounting the form drops focus to
+    // document.body and a keyboard user's next Tab restarts from the top of
+    // the document (WCAG 2.4.3 Focus Order).
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveFocus();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent(/you're on the list/i);
   });
 
   it('shows an accessible error and keeps the form usable when the API fails', async () => {
@@ -141,24 +163,60 @@ describe('SignUpClient (waitlist capture)', () => {
     await waitFor(() => {
       expect(screen.getByRole('status')).toHaveTextContent(/something went wrong/i);
     });
-    // Error is programmatically associated with the input.
-    expect(input).toHaveAttribute('aria-invalid', 'true');
-    expect(input).toHaveAttribute('aria-describedby');
+    // The error text is programmatically associated with the input, but the
+    // VALUE is fine — a server failure must not announce "invalid entry" and
+    // steer the user to edit a correct address.
+    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(input).toHaveAttribute('aria-describedby', 'waitlist-status');
     // Form stays mounted and re-enabled for retry.
     expect(screen.getByRole('button', { name: /join the waitlist/i })).toBeEnabled();
   });
 
-  it('shows a rate-limit-specific message on 429', async () => {
+  it('marks the email field invalid for a server-side validation rejection (400)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(400)));
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    const input = screen.getByLabelText(/email address/i);
+    await user.type(input, 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/does not look right/i);
+    });
+    // A 400 means the entered value itself was rejected — here aria-invalid
+    // is truthful.
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby', 'waitlist-status');
+  });
+
+  it('marks the email field invalid for the client-side empty-email check without fetching', async () => {
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/enter your email address/i);
+    });
+    expect(screen.getByLabelText(/email address/i)).toHaveAttribute('aria-invalid', 'true');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('shows a rate-limit-specific message on 429 without flagging the value as invalid', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(429)));
     const user = userEvent.setup();
     render(<SignUpClient />);
 
-    await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
+    const input = screen.getByLabelText(/email address/i);
+    await user.type(input, 'fan@example.com');
     await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('status')).toHaveTextContent(/too many attempts/i);
     });
+    // Rate limiting is operational, not a value problem.
+    expect(input).not.toHaveAttribute('aria-invalid');
   });
 
   it('shows a network-error message when fetch rejects', async () => {
@@ -172,6 +230,14 @@ describe('SignUpClient (waitlist capture)', () => {
     await waitFor(() => {
       expect(screen.getByRole('status')).toHaveTextContent(/network error/i);
     });
+  });
+
+  it('offers a mailto link to support as a secondary contact', () => {
+    render(<SignUpClient />);
+    const support = screen
+      .getAllByRole('link')
+      .find((a) => a.getAttribute('href') === 'mailto:support@spawnforge.ai');
+    expect(support).toBeDefined();
   });
 
   it('links back to the home page', () => {

--- a/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
@@ -161,7 +161,10 @@ describe('SignUpClient (waitlist capture)', () => {
     await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('status')).toHaveTextContent(/something went wrong/i);
+      // Specific, actionable copy — NOT a generic "something went wrong" (the
+      // ux-reviewer rubric fails that): names the failed operation and offers
+      // both a retry and the support fallback already on the page.
+      expect(screen.getByRole('status')).toHaveTextContent(/add you to the list/i);
     });
     // The error text is programmatically associated with the input, but the
     // VALUE is fine — a server failure must not announce "invalid entry" and
@@ -170,6 +173,8 @@ describe('SignUpClient (waitlist capture)', () => {
     expect(input).toHaveAttribute('aria-describedby', 'waitlist-status');
     // Form stays mounted and re-enabled for retry.
     expect(screen.getByRole('button', { name: /join the waitlist/i })).toBeEnabled();
+    // …and the typed value survives the failure so retry is one click, not a re-type.
+    expect(input).toHaveValue('fan@example.com');
   });
 
   it('marks the email field invalid for a server-side validation rejection (400)', async () => {
@@ -230,6 +235,8 @@ describe('SignUpClient (waitlist capture)', () => {
     await waitFor(() => {
       expect(screen.getByRole('status')).toHaveTextContent(/network error/i);
     });
+    // A transient network failure must not wipe the address the user typed.
+    expect(screen.getByLabelText(/email address/i)).toHaveValue('fan@example.com');
   });
 
   it('offers a mailto link to support as a secondary contact', () => {

--- a/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/__tests__/SignUpClient.test.tsx
@@ -1,43 +1,177 @@
 /**
- * Tests for the pre-launch sign-up notice.
+ * Tests for the pre-launch waitlist page (#8730).
  *
- * Sign-ups are intentionally disabled while SpawnForge is in development.
- * The /sign-up route renders an informational notice instead of Clerk's
- * <SignUp> form, so that prospective users get a clear "coming soon"
- * message rather than a restricted-mode error that reads like a support
- * request. See feat/signups-in-development-notice.
+ * Sign-ups stay intentionally disabled while SpawnForge is in development —
+ * the /sign-up route deliberately renders NO Clerk <SignUp>. But every
+ * marketing CTA ("Join the Waitlist", "Request Early Access") lands here, so
+ * the page must actually capture the lead it promises: an accessible email
+ * form posting to /api/waitlist, with a hidden honeypot, an aria-live status
+ * region, and idle/submitting/success/error states.
  *
  * @vitest-environment jsdom
  */
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@/test/utils/componentTestUtils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@/test/utils/componentTestUtils';
+import userEvent from '@testing-library/user-event';
 import { SignUpClient } from '../SignUpClient';
 
-describe('SignUpClient (in-development notice)', () => {
-  afterEach(() => {
-    cleanup();
+function okResponse() {
+  return new Response(
+    JSON.stringify({ ok: true, message: "You're on the list." }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+function errorResponse(status: number) {
+  return new Response(JSON.stringify({ error: 'nope' }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('SignUpClient (waitlist capture)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(okResponse()));
   });
 
-  it('renders the in-development heading', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('keeps the in-development messaging', () => {
     render(<SignUpClient />);
     expect(
       screen.getByRole('heading', { name: /in development/i })
-    ).toBeDefined();
+    ).toBeInTheDocument();
   });
 
-  it('explains that release details will be published soon', () => {
+  it('does not render a Clerk sign-up form (sign-ups stay disabled)', () => {
     render(<SignUpClient />);
+    expect(screen.queryByLabelText(/password/i)).toBeNull();
+    expect(screen.queryByText(/continue with google/i)).toBeNull();
+  });
+
+  it('renders a waitlist form with a labelled email input and submit button', () => {
+    render(<SignUpClient />);
+    const input = screen.getByLabelText(/email address/i);
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'email');
+    expect(input).toHaveAttribute('autocomplete', 'email');
     expect(
-      screen.getByText(/release details and timeline will be published soon/i)
-    ).toBeDefined();
+      screen.getByRole('button', { name: /join the waitlist/i })
+    ).toBeInTheDocument();
   });
 
-  it('offers a mailto link to support for early-user interest', () => {
+  it('renders an aria-live polite status region from first paint', () => {
     render(<SignUpClient />);
-    const mailto = screen
-      .getAllByRole('link')
-      .find((a) => a.getAttribute('href') === 'mailto:support@spawnforge.ai');
-    expect(mailto).toBeDefined();
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders the honeypot field hidden from users, the a11y tree, and the tab order', () => {
+    const { container } = render(<SignUpClient />);
+    const honeypot = container.querySelector('input[name="website"]');
+    expect(honeypot).not.toBeNull();
+    expect(honeypot).toHaveAttribute('tabindex', '-1');
+    expect(honeypot).toHaveAttribute('autocomplete', 'off');
+    // Hidden from assistive tech via an aria-hidden wrapper…
+    expect(honeypot!.closest('[aria-hidden="true"]')).not.toBeNull();
+    // …so the ONLY textbox in the a11y tree is the real email input.
+    const accessibleTextboxes = screen.getAllByRole('textbox');
+    expect(accessibleTextboxes).toHaveLength(1);
+    expect(accessibleTextboxes[0]).toHaveAttribute('id', 'waitlist-email');
+  });
+
+  it('submits the email to /api/waitlist and shows the confirmation', async () => {
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/you're on the list/i);
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/waitlist',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'fan@example.com', website: '' }),
+      })
+    );
+    // The form is replaced by the confirmation — no resubmission affordance.
+    expect(screen.queryByRole('button', { name: /join the waitlist/i })).toBeNull();
+  });
+
+  it('disables the submit button while the request is in flight', async () => {
+    let resolveFetch: (value: Response) => void = () => {};
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(
+        () => new Promise<Response>((resolve) => { resolveFetch = resolve; })
+      )
+    );
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    const pending = await screen.findByRole('button', { name: /joining/i });
+    expect(pending).toBeDisabled();
+
+    resolveFetch(okResponse());
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/you're on the list/i);
+    });
+  });
+
+  it('shows an accessible error and keeps the form usable when the API fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(500)));
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    const input = screen.getByLabelText(/email address/i);
+    await user.type(input, 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/something went wrong/i);
+    });
+    // Error is programmatically associated with the input.
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveAttribute('aria-describedby');
+    // Form stays mounted and re-enabled for retry.
+    expect(screen.getByRole('button', { name: /join the waitlist/i })).toBeEnabled();
+  });
+
+  it('shows a rate-limit-specific message on 429', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(errorResponse(429)));
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/too many attempts/i);
+    });
+  });
+
+  it('shows a network-error message when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+    const user = userEvent.setup();
+    render(<SignUpClient />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'fan@example.com');
+    await user.click(screen.getByRole('button', { name: /join the waitlist/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(/network error/i);
+    });
   });
 
   it('links back to the home page', () => {
@@ -46,11 +180,5 @@ describe('SignUpClient (in-development notice)', () => {
       .getAllByRole('link')
       .find((a) => a.getAttribute('href') === '/');
     expect(home).toBeDefined();
-  });
-
-  it('does not render a Clerk sign-up form', () => {
-    render(<SignUpClient />);
-    // The Clerk widget renders form fields (email/password). The notice has none.
-    expect(screen.queryByRole('textbox')).toBeNull();
   });
 });

--- a/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -4,7 +4,7 @@ import { SignUpClient } from './SignUpClient';
 export const metadata: Metadata = {
   title: 'Early Access — SpawnForge',
   description:
-    'SpawnForge is currently in development. Release details and timeline will be published soon.',
+    "SpawnForge is in development. Join the waitlist for early access and we'll email you when your spot is ready.",
 };
 
 export default function SignUpPage() {

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -611,6 +611,21 @@ export const moderationAppeals = pgTable(
   ]
 );
 
+// --- Waitlist Signups ---
+
+export const waitlistSignups = pgTable(
+  'waitlist_signups',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // POST /api/waitlist normalizes (trim + toLowerCase) BEFORE insert, so a
+    // plain unique index on the raw column is the ON CONFLICT arbiter — no
+    // lower(email) expression index needed (Drizzle's DSL cannot model those).
+    email: text('email').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex('uq_waitlist_signups_email').on(table.email)]
+);
+
 // --- Types ---
 
 export type User = typeof users.$inferSelect;

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -113,6 +113,12 @@ export function buildPublicRoutes({ includeDev }: { includeDev: boolean }): stri
     '/privacy(.*)',
     '/community(.*)',
     '/api/community(.*)',
+    // Public waitlist capture: the /sign-up page's form posts here WITHOUT a
+    // Clerk session — the page exists precisely for unauthenticated visitors.
+    // The route self-enforces its abuse controls (IP rate limit + honeypot +
+    // idempotent insert), none of which are reachable if the proxy 401s the
+    // request first (#8730).
+    '/api/waitlist(.*)',
     '/api/docs(.*)',
     '/api-docs(.*)',
     '/api/openapi(.*)',


### PR DESCRIPTION
## Summary

`/sign-up` was the top of the new-user core journey, but every marketing CTA ("Join the Waitlist", "Request Early Access") landed on a dead end: a static notice with only a `mailto:` link. This wires the page to actually capture the lead it promises.

Clerk sign-ups stay **deliberately disabled** while SpawnForge is in development (product decision — approved users still authenticate at `/sign-in`). This is lead capture, not account creation: the page now renders an accessible email form that posts to a new public `POST /api/waitlist`, persisting to a `waitlist_signups` table (no `user_id` FK, no account lifecycle).

## What's in it

- **`feat(db)`** — `waitlist_signups` table + migration `0007_waitlist_signups` (unique index on `email`). Lead-only: no FK to `users`, so it is intentionally out of the `deleteUserAccount` cascade.
- **`feat(api)`** — public `POST /api/waitlist`: IP rate limited (awaited; 10/60s), honeypot (`website`) that returns the *same* success body without inserting, strict email validation (RFC 5321 254-char cap), email normalized (trim + lowercase), idempotent `onConflictDoNothing` on the unique index → byte-identical response for fresh vs duplicate (no enumeration oracle). Errors report to Sentry with route/method tags and return a generic body (no internal-detail leak).
- **`fix(proxy)`** — `/api/waitlist(.*)` added to the public route list so unauthenticated visitors (every real waitlist submitter) reach it instead of getting 401'd by Clerk.
- **`feat(ui)`** — `/sign-up` form built on `@spawnforge/ui` primitives (`Label`/`Input`/`Button`) and `var(--sf-*)` tokens so it renders correctly across all 7 themes + light mode. Real `<label>`, persistent `aria-live="polite"` status region, `aria-invalid` only for genuine field errors (not 429/5xx/network), submit guarded with `aria-disabled` (not the `disabled` attribute, which drops focus to `<body>`), focus moved to the status region on success (WCAG 2.4.3), off-screen honeypot removed from the a11y tree and tab order.
- **`fix(seo)`** — `/sign-up` metadata now describes the waitlist action it ships.

## Accessibility note (contrast)

The submit CTA meets WCAG 2.1 AA contrast in the **default (dark) theme + 5 of 7 themes** via a token-based `bg-[var(--sf-accent-hover)]` override (no hardcoded color). This works around a **pre-existing, app-wide** defect in the shared `@spawnforge/ui` Button `default` variant: at rest it renders `--sf-on-accent` on `--sf-accent`, which is only ~3.68:1 in the default theme — below the 4.5:1 floor — and `leaf` fails even at hover (white-on-green). That root cause spans `Button.tsx` + `themes.ts` + every primary button in the app and needs a 7-theme visual/brand review, so it is tracked separately in **#8742** rather than ballooning this lead-capture PR. The override is removable once #8742 lands.

## Test plan

- [x] `POST /api/waitlist` route suite: honeypot, enumeration-oracle parity, awaited rate-limit with literal budget, 254/255 boundary, malformed/non-object JSON, 500→Sentry generic body.
- [x] `SignUpClient` jsdom suite (15 tests): submit→confirm, aria-disabled-in-flight + re-entry guard, focus-to-status on success, truthful `aria-invalid` per error class, value-preserved on operational/network failure, honeypot hidden from a11y tree.
- [x] `proxy` behavioural suite: `/api/waitlist` + sub-path public via the real Clerk matcher; unauthenticated POST → 200.
- [x] `eslint --max-warnings 0` + targeted `vitest` green.

Closes #8730