### PR TITLE
fix(billing): admin tier comp grants the tier's token allocation (paid-only alpha unblock)

### DIFF
--- a/.changeset/admin-tier-comp-token-grant.md
+++ b/.changeset/admin-tier-comp-token-grant.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Grant the new tier's full monthly token allocation (and write a credit_transactions audit row) when an admin changes a user's tier via PATCH /api/admin/users/[id]. Previously a comped paid tier wrote the tier column alone with no tokens, leaving the user with a zero balance and blocked at every AI generation route — the paid-only alpha core journey never started.

--- a/web/src/app/api/admin/users/[id]/route.test.ts
+++ b/web/src/app/api/admin/users/[id]/route.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, PATCH } from './route';
 import { authenticateRequest, assertAdmin } from '@/lib/auth/api-auth';
 import { getDb } from '@/lib/db/client';
+import { rateLimitAdminRoute } from '@/lib/rateLimit';
 import { applyAdminTierChange } from '@/lib/billing/admin-tier-grant';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { NextRequest } from 'next/server';
@@ -11,6 +12,13 @@ import { NextRequest } from 'next/server';
 vi.mock('@/lib/auth/api-auth');
 vi.mock('@/lib/db/client');
 vi.mock('@/lib/billing/admin-tier-grant');
+vi.mock('@/lib/monitoring/sentry-server', () => ({ captureException: vi.fn() }));
+// The admin route calls rateLimitAdminRoute directly (not via the middleware).
+// Mock it so every test starts from "allowed" (null) — otherwise the REAL
+// in-memory limiter accumulates across the sequentially-run cases that share one
+// userId and the 11th request returns 429 where the test expects another status.
+// Individual tests override with mockResolvedValueOnce to exercise the 429 path.
+vi.mock('@/lib/rateLimit', () => ({ rateLimitAdminRoute: vi.fn().mockResolvedValue(null) }));
 
 /** getDb mock whose select().from().where() resolves each call in sequence. */
 function mockSelectSequence(...resultsPerCall: unknown[][]) {
@@ -20,9 +28,12 @@ function mockSelectSequence(...resultsPerCall: unknown[][]) {
   return { select: vi.fn().mockReturnValue(selectChain) };
 }
 
-const PARAMS = { params: Promise.resolve({ id: 'user-uuid-1' }) };
+// `users.id` is a uuid column, so route params + assertions use a real UUID —
+// the route's UUID_RE guard rejects anything else with a 404 before any DB read.
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const PARAMS = { params: Promise.resolve({ id: USER_ID }) };
 
-function makeReq(url = 'http://localhost/api/admin/users/user-uuid-1', method = 'GET', body?: unknown): NextRequest {
+function makeReq(url = `http://localhost/api/admin/users/${USER_ID}`, method = 'GET', body?: unknown): NextRequest {
   if (body !== undefined) {
     return new NextRequest(url, {
       method,
@@ -177,7 +188,7 @@ describe('PATCH /api/admin/users/[id]', () => {
     expect(data.user.tier).toBe('pro');
     expect(data.user.monthlyTokens).toBe(3000);
     // The grant ran with the previous tier + the acting admin's clerk id.
-    expect(applyAdminTierChange).toHaveBeenCalledWith('user-uuid-1', 'pro', {
+    expect(applyAdminTierChange).toHaveBeenCalledWith(USER_ID, 'pro', {
       previousTier: 'starter',
       grantedByClerkId: 'admin_123',
       banned: undefined,
@@ -202,7 +213,7 @@ describe('PATCH /api/admin/users/[id]', () => {
       PARAMS,
     );
     expect(res.status).toBe(200);
-    expect(applyAdminTierChange).toHaveBeenCalledWith('user-uuid-1', 'creator', {
+    expect(applyAdminTierChange).toHaveBeenCalledWith(USER_ID, 'creator', {
       previousTier: 'starter',
       grantedByClerkId: 'admin_123',
       banned: true,
@@ -227,6 +238,31 @@ describe('PATCH /api/admin/users/[id]', () => {
 
     const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { tier: 'starter' }), PARAMS);
     expect(res.status).toBe(200);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the row vanishes between read and plain update (TOCTOU)', async () => {
+    // The banned-only / same-tier path reads the row, then UPDATEs. If the row is
+    // hard-deleted between those two statements, `.returning()` is empty and the
+    // route must 404 (not 200 with { user: undefined }) — the no-grant analogue of
+    // the post-grant re-read guard.
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+
+    const selectMock = mockSelectSequence([makeUser({ tier: 'starter' })]);
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([]), // row gone between read and write
+    };
+    vi.mocked(getDb).mockReturnValue({
+      ...selectMock,
+      update: vi.fn().mockReturnValue(updateChain),
+    } as unknown as ReturnType<typeof getDb>);
+
+    const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { banned: true }), PARAMS);
+    expect(res.status).toBe(404);
     expect(applyAdminTierChange).not.toHaveBeenCalled();
   });
 
@@ -283,12 +319,85 @@ describe('PATCH /api/admin/users/[id]', () => {
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
 
-    const req = new NextRequest('http://localhost/api/admin/users/user-uuid-1', {
+    const req = new NextRequest(`http://localhost/api/admin/users/${USER_ID}`, {
       method: 'PATCH',
       body: 'not-json',
       headers: { 'content-type': 'application/json' },
     });
     const res = await PATCH(req, PARAMS);
     expect(res.status).toBe(400);
+  });
+
+  it('returns 429 when the admin rate limit is exceeded (no grant attempted)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+    vi.mocked(rateLimitAdminRoute).mockResolvedValueOnce(
+      mockNextResponse({ error: 'Too many requests' }, { status: 429 }),
+    );
+
+    const res = await PATCH(makeReq(`http://localhost/api/admin/users/${USER_ID}`, 'PATCH', { tier: 'pro' }), PARAMS);
+    expect(res.status).toBe(429);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the [id] param is not a valid UUID (before any DB read)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+
+    const res = await PATCH(
+      makeReq('http://localhost/api/admin/users/not-a-uuid', 'PATCH', { tier: 'pro' }),
+      { params: Promise.resolve({ id: 'not-a-uuid' }) },
+    );
+    expect(res.status).toBe(404);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when an admin targets their own account (self-comp blocked)', async () => {
+    // The acting admin's own users.id equals the target [id] → self-modification.
+    const user = makeUser({ id: USER_ID });
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+
+    const res = await PATCH(makeReq(`http://localhost/api/admin/users/${USER_ID}`, 'PATCH', { tier: 'pro' }), PARAMS);
+    const data = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(data.code).toBe('SELF_MODIFICATION_FORBIDDEN');
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when applyAdminTierChange throws (error is captured)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+    vi.mocked(applyAdminTierChange).mockRejectedValueOnce(new Error('db error'));
+
+    // current row found → tier changes → grant invoked → rejects → catch → 500.
+    vi.mocked(getDb).mockReturnValue(
+      mockSelectSequence([makeUser({ tier: 'starter' })]) as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await PATCH(makeReq(`http://localhost/api/admin/users/${USER_ID}`, 'PATCH', { tier: 'pro' }), PARAMS);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when the post-grant re-read finds no row', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+    vi.mocked(applyAdminTierChange).mockResolvedValue(undefined);
+
+    // First select = current row (grant proceeds); second select (re-read) = [].
+    vi.mocked(getDb).mockReturnValue(
+      mockSelectSequence([makeUser({ tier: 'starter' })], []) as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await PATCH(makeReq(`http://localhost/api/admin/users/${USER_ID}`, 'PATCH', { tier: 'pro' }), PARAMS);
+    expect(res.status).toBe(500);
+    expect(applyAdminTierChange).toHaveBeenCalled();
   });
 });

--- a/web/src/app/api/admin/users/[id]/route.test.ts
+++ b/web/src/app/api/admin/users/[id]/route.test.ts
@@ -4,11 +4,21 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GET, PATCH } from './route';
 import { authenticateRequest, assertAdmin } from '@/lib/auth/api-auth';
 import { getDb } from '@/lib/db/client';
+import { applyAdminTierChange } from '@/lib/billing/admin-tier-grant';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth/api-auth');
 vi.mock('@/lib/db/client');
+vi.mock('@/lib/billing/admin-tier-grant');
+
+/** getDb mock whose select().from().where() resolves each call in sequence. */
+function mockSelectSequence(...resultsPerCall: unknown[][]) {
+  const where = vi.fn();
+  for (const rows of resultsPerCall) where.mockResolvedValueOnce(rows);
+  const selectChain = { from: vi.fn().mockReturnThis(), where };
+  return { select: vi.fn().mockReturnValue(selectChain) };
+}
 
 const PARAMS = { params: Promise.resolve({ id: 'user-uuid-1' }) };
 
@@ -135,75 +145,137 @@ describe('PATCH /api/admin/users/[id]', () => {
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
 
-    const updateChain = {
-      set: vi.fn().mockReturnThis(),
-      where: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockResolvedValue([]),
-    };
-    vi.mocked(getDb).mockReturnValue({ update: vi.fn().mockReturnValue(updateChain) } as unknown as ReturnType<typeof getDb>);
+    // Read-first: the missing row surfaces on the initial select, before any
+    // grant or update is attempted.
+    vi.mocked(getDb).mockReturnValue(
+      mockSelectSequence([]) as unknown as ReturnType<typeof getDb>,
+    );
 
     const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { tier: 'pro' }), PARAMS);
     expect(res.status).toBe(404);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
   });
 
-  it('updates user tier successfully', async () => {
+  it('grants the new tier allocation when the tier actually changes', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
+    vi.mocked(applyAdminTierChange).mockResolvedValue(undefined);
 
-    const updatedUser = makeUser({ tier: 'pro' });
-    const updateChain = {
-      set: vi.fn().mockReturnThis(),
-      where: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockResolvedValue([updatedUser]),
-    };
-    vi.mocked(getDb).mockReturnValue({ update: vi.fn().mockReturnValue(updateChain) } as unknown as ReturnType<typeof getDb>);
+    // First select = current row (starter); second select = post-grant re-read.
+    vi.mocked(getDb).mockReturnValue(
+      mockSelectSequence(
+        [makeUser({ tier: 'starter' })],
+        [makeUser({ tier: 'pro', monthlyTokens: 3000 })],
+      ) as unknown as ReturnType<typeof getDb>,
+    );
 
     const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { tier: 'pro' }), PARAMS);
     const data = await res.json();
 
     expect(res.status).toBe(200);
     expect(data.user.tier).toBe('pro');
+    expect(data.user.monthlyTokens).toBe(3000);
+    // The grant ran with the previous tier + the acting admin's clerk id.
+    expect(applyAdminTierChange).toHaveBeenCalledWith('user-uuid-1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'admin_123',
+      banned: undefined,
+    });
   });
 
-  it('bans a user successfully', async () => {
+  it('folds a ban into the grant when tier and banned change together', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+    vi.mocked(applyAdminTierChange).mockResolvedValue(undefined);
+
+    vi.mocked(getDb).mockReturnValue(
+      mockSelectSequence(
+        [makeUser({ tier: 'starter' })],
+        [makeUser({ tier: 'creator' })],
+      ) as unknown as ReturnType<typeof getDb>,
+    );
+
+    const res = await PATCH(
+      makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { tier: 'creator', banned: true }),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    expect(applyAdminTierChange).toHaveBeenCalledWith('user-uuid-1', 'creator', {
+      previousTier: 'starter',
+      grantedByClerkId: 'admin_123',
+      banned: true,
+    });
+  });
+
+  it('does NOT grant tokens when the tier is unchanged (same-tier PATCH)', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
 
-    const updatedUser = { ...makeUser(), banned: 1 };
+    const selectMock = mockSelectSequence([makeUser({ tier: 'starter' })]);
     const updateChain = {
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockResolvedValue([updatedUser]),
+      returning: vi.fn().mockResolvedValue([makeUser({ tier: 'starter' })]),
     };
-    vi.mocked(getDb).mockReturnValue({ update: vi.fn().mockReturnValue(updateChain) } as unknown as ReturnType<typeof getDb>);
+    vi.mocked(getDb).mockReturnValue({
+      ...selectMock,
+      update: vi.fn().mockReturnValue(updateChain),
+    } as unknown as ReturnType<typeof getDb>);
+
+    const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { tier: 'starter' }), PARAMS);
+    expect(res.status).toBe(200);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
+  });
+
+  it('bans a user successfully (plain update, no token grant)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
+    vi.mocked(assertAdmin).mockReturnValue(null);
+
+    const selectMock = mockSelectSequence([makeUser()]);
+    const updateChain = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ ...makeUser(), banned: 1 }]),
+    };
+    vi.mocked(getDb).mockReturnValue({
+      ...selectMock,
+      update: vi.fn().mockReturnValue(updateChain),
+    } as unknown as ReturnType<typeof getDb>);
 
     const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { banned: true }), PARAMS);
     const data = await res.json();
 
     expect(res.status).toBe(200);
     expect(data.user.banned).toBe(1);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
   });
 
-  it('unbans a user successfully', async () => {
+  it('unbans a user successfully (plain update, no token grant)', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_123', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
 
-    const updatedUser = { ...makeUser(), banned: 0 };
+    const selectMock = mockSelectSequence([{ ...makeUser(), banned: 1 }]);
     const updateChain = {
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockResolvedValue([updatedUser]),
+      returning: vi.fn().mockResolvedValue([{ ...makeUser(), banned: 0 }]),
     };
-    vi.mocked(getDb).mockReturnValue({ update: vi.fn().mockReturnValue(updateChain) } as unknown as ReturnType<typeof getDb>);
+    vi.mocked(getDb).mockReturnValue({
+      ...selectMock,
+      update: vi.fn().mockReturnValue(updateChain),
+    } as unknown as ReturnType<typeof getDb>);
 
     const res = await PATCH(makeReq('http://localhost/api/admin/users/user-uuid-1', 'PATCH', { banned: false }), PARAMS);
     const data = await res.json();
 
     expect(res.status).toBe(200);
     expect(data.user.banned).toBe(0);
+    expect(applyAdminTierChange).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid JSON body', async () => {

--- a/web/src/app/api/admin/users/[id]/route.ts
+++ b/web/src/app/api/admin/users/[id]/route.ts
@@ -4,9 +4,11 @@ import { assertAdmin } from '@/lib/auth/api-auth';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { getDb, queryWithResilience } from '@/lib/db/client';
 import { users } from '@/lib/db/schema';
+import type { Tier } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 import { rateLimitAdminRoute } from '@/lib/rateLimit';
 import { captureException } from '@/lib/monitoring/sentry-server';
+import { applyAdminTierChange } from '@/lib/billing/admin-tier-grant';
 
 const patchUserSchema = z
   .object({
@@ -66,11 +68,46 @@ export async function PATCH(
   const { id } = await params;
   const body = mid.body as z.infer<typeof patchUserSchema>;
 
-  const updates: Partial<{ tier: 'starter' | 'hobbyist' | 'creator' | 'pro'; banned: number }> = {};
-  if (body.tier !== undefined) updates.tier = body.tier;
-  if (body.banned !== undefined) updates.banned = body.banned ? 1 : 0;
-
   try {
+    // Load the current row first: it backs the 404, supplies the previous tier
+    // for the audit trail, and decides whether the tier actually changed.
+    const [current] = await queryWithResilience(() =>
+      getDb().select().from(users).where(eq(users.id, id))
+    );
+
+    if (!current) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const previousTier = current.tier as Tier;
+    const tierChanged = body.tier !== undefined && body.tier !== previousTier;
+
+    if (tierChanged) {
+      // A real tier change must ALSO grant the new tier's monthly token
+      // allotment + write a credit_transactions audit row, atomically — else a
+      // comped paid user holds 0 tokens and is blocked at every /api/generate/*
+      // route, so the 5-10 min core journey never starts (#8744). Any `banned`
+      // change is folded into the same transaction.
+      await applyAdminTierChange(id, body.tier as Tier, {
+        previousTier,
+        grantedByClerkId: clerkId,
+        banned: body.banned,
+      });
+
+      // Re-read so the admin UI sees the granted balance + new tier/ban state.
+      const [granted] = await queryWithResilience(() =>
+        getDb().select().from(users).where(eq(users.id, id))
+      );
+      return NextResponse.json({ user: granted });
+    }
+
+    // Banned-only edit (or tier set to its current value): a plain update with
+    // NO token grant. Re-granting on a no-op tier change would zero accrued
+    // spend, so the grant path is reserved for genuine tier changes.
+    const updates: Partial<{ tier: Tier; banned: number }> = {};
+    if (body.tier !== undefined) updates.tier = body.tier;
+    if (body.banned !== undefined) updates.banned = body.banned ? 1 : 0;
+
     const [updated] = await queryWithResilience(() =>
       getDb()
         .update(users)

--- a/web/src/app/api/admin/users/[id]/route.ts
+++ b/web/src/app/api/admin/users/[id]/route.ts
@@ -19,6 +19,14 @@ const patchUserSchema = z
     message: 'No valid fields to update',
   });
 
+// `users.id` is a Postgres `uuid` column. A non-UUID `[id]` path segment would be
+// forwarded into the `eq(users.id, id)` query and raise an "invalid input syntax
+// for type uuid" cast error — caught by the generic 500 handler and surfaced to
+// Sentry as avoidable noise. Reject malformed ids early with a 404 (not 400, so
+// we don't confirm the expected id format to an enumerator).
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -34,6 +42,9 @@ export async function GET(
   if (limited) return limited;
 
   const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
 
   try {
     const [user] = await queryWithResilience(() =>
@@ -66,6 +77,23 @@ export async function PATCH(
   if (limited) return limited;
 
   const { id } = await params;
+  if (!UUID_RE.test(id)) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  // An admin must not modify their OWN account through the user-admin endpoint:
+  // self-targeting here is a privilege-escalation vector (an admin could comp
+  // themselves a higher tier + full token allocation, or self-unban). Tier and
+  // ban state for one's own account go through billing/Stripe, never this route.
+  // `mid.userId` is the acting admin's `users.id`; `id` is the target's — both
+  // live in the same id space, so an exact match means self-targeting.
+  if (id === mid.userId) {
+    return NextResponse.json(
+      { error: 'Admins cannot modify their own account here', code: 'SELF_MODIFICATION_FORBIDDEN' },
+      { status: 403 }
+    );
+  }
+
   const body = mid.body as z.infer<typeof patchUserSchema>;
 
   try {
@@ -98,6 +126,15 @@ export async function PATCH(
       const [granted] = await queryWithResilience(() =>
         getDb().select().from(users).where(eq(users.id, id))
       );
+      // The grant committed but the row is gone on re-read (concurrent hard
+      // delete, or a partition between statements) — signal an error rather than
+      // returning { user: undefined } with a 200, matching every other read path.
+      if (!granted) {
+        return NextResponse.json(
+          { error: 'Grant succeeded but user row not found on re-read' },
+          { status: 500 }
+        );
+      }
       return NextResponse.json({ user: granted });
     }
 

--- a/web/src/lib/billing/__tests__/adminTierGrant.db.test.ts
+++ b/web/src/lib/billing/__tests__/adminTierGrant.db.test.ts
@@ -63,6 +63,21 @@ function bySource(rows: QueryRow[], source: string): QueryRow {
   return matches[0];
 }
 
+/**
+ * Find the single audit row for a source AND assert the two invariants that hold
+ * for EVERY grant code path: the row is an 'adjustment' (the literal lives in the
+ * SQL template, not a bound param, so only a real-DB assertion can reach it), and
+ * its reference_id is non-null (the partial unique idempotency index fires only
+ * WHERE reference_id IS NOT NULL — a null would silently disarm it). Returns the
+ * row for source-specific amount/balance_after assertions.
+ */
+function expectAdjustment(rows: QueryRow[], source: string): QueryRow {
+  const audit = bySource(rows, source);
+  expect(audit.transaction_type).toBe('adjustment');
+  expect(audit.reference_id).not.toBeNull();
+  return audit;
+}
+
 describe('applyAdminTierChange — real Postgres (#8744)', () => {
   beforeAll(async () => {
     harnessRef.current = await createTestHarness();
@@ -103,8 +118,7 @@ describe('applyAdminTierChange — real Postgres (#8744)', () => {
     expect(balance).toBe(TIER_MONTHLY_TOKENS.pro);
 
     const rows = await txns(seeded.id);
-    const audit = bySource(rows, 'admin_tier_change:starter->pro');
-    expect(audit.transaction_type).toBe('adjustment');
+    const audit = expectAdjustment(rows, 'admin_tier_change:starter->pro');
     expect(num(audit.amount)).toBe(TIER_MONTHLY_TOKENS.pro);
     expect(num(audit.balance_after)).toBe(TIER_MONTHLY_TOKENS.pro);
   });
@@ -123,7 +137,7 @@ describe('applyAdminTierChange — real Postgres (#8744)', () => {
     });
 
     const rows = await txns(seeded.id);
-    const audit = bySource(rows, 'admin_tier_change:starter->creator');
+    const audit = expectAdjustment(rows, 'admin_tier_change:starter->creator');
     // allocation + addon + earned = 1000 + 200 + 50
     expect(num(audit.balance_after)).toBe(TIER_MONTHLY_TOKENS.creator + 200 + 50);
 
@@ -149,6 +163,9 @@ describe('applyAdminTierChange — real Postgres (#8744)', () => {
     expect(row!.tier).toBe('creator');
     expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.creator); // absolute, not +=
     expect(num(row!.monthly_tokens_used)).toBe(0); // cycle reset
+
+    const audit = expectAdjustment(await txns(seeded.id), 'admin_tier_change:pro->creator');
+    expect(num(audit.amount)).toBe(TIER_MONTHLY_TOKENS.creator);
   });
 
   it('folds banned:true into the same atomic write', async () => {
@@ -164,6 +181,9 @@ describe('applyAdminTierChange — real Postgres (#8744)', () => {
     expect(num(row!.banned)).toBe(1);
     expect(row!.tier).toBe('pro');
     expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.pro);
+
+    // The grant + audit row are written even when the ban flag rides along.
+    expectAdjustment(await txns(seeded.id), 'admin_tier_change:starter->pro');
   });
 
   it('preserves the existing banned value when the option is omitted', async () => {
@@ -214,8 +234,16 @@ describe('applyAdminTierChange — real Postgres (#8744)', () => {
 
     const rows = await txns(seeded.id);
     // Two starter->pro grants + one pro->starter grant = three distinct rows.
+    expect(rows).toHaveLength(3);
     expect(rows.filter((r) => r.source === 'admin_tier_change:starter->pro')).toHaveLength(2);
     expect(rows.filter((r) => r.source === 'admin_tier_change:pro->starter')).toHaveLength(1);
+    // Every row is an adjustment with a non-null reference_id — a null would
+    // silently disarm the partial unique idempotency index (WHERE reference_id
+    // IS NOT NULL), so distinct intentional grants must each carry one.
+    rows.forEach((r) => {
+      expect(r.transaction_type).toBe('adjustment');
+      expect(r.reference_id).not.toBeNull();
+    });
 
     const row = await getUserRow(harness().neonSql, seeded.id);
     expect(row!.tier).toBe('pro');

--- a/web/src/lib/billing/__tests__/adminTierGrant.db.test.ts
+++ b/web/src/lib/billing/__tests__/adminTierGrant.db.test.ts
@@ -1,0 +1,224 @@
+// @vitest-environment node
+/**
+ * applyAdminTierChange — REAL Postgres behavioral tests (#8744).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The paid-only alpha comps a tester by setting their `tier` via the admin
+ * endpoint. Before #8744 that wrote tier alone — no token grant — so a comped
+ * "pro" user held 0 tokens and was blocked at every `/api/generate/*` route
+ * (the core 5-10 min journey never starts). This handler closes that gap by
+ * granting the tier's full monthly allocation + an audit row, atomically.
+ *
+ * Like the subscription-lifecycle real-DB suite, this runs the handler against
+ * a real Postgres (PGlite, in-process, schema built by replaying the production
+ * migrations) and asserts on the resulting `users` and `credit_transactions`
+ * ROW STATE using the REAL `TIER_MONTHLY_TOKENS` — not interpolated-SQL
+ * substrings, not a hand-copied allocation fixture. No production code import
+ * changes: the SUT imports `@/lib/db/client`; we `vi.mock` only that module so
+ * `getNeonSql()`/`getDb()`/`queryWithResilience()` resolve to the shared harness.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import {
+  createTestHarness,
+  seedUser,
+  getUserRow,
+  type TestHarness,
+  type QueryRow,
+} from '@/lib/db/__tests__/pgliteHarness';
+
+vi.mock('server-only', () => ({}));
+
+const harnessRef = vi.hoisted(() => ({ current: null as unknown as TestHarness }));
+function harness(): TestHarness {
+  if (!harnessRef.current) throw new Error('harness not initialised');
+  return harnessRef.current;
+}
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: () => harness().db,
+  getNeonSql: () => harness().neonSql,
+  queryWithResilience: (fn: () => Promise<unknown>) => fn(),
+}));
+
+// Real pricing, real schema, real drizzle-orm — NOT mocked. That is the point.
+import { applyAdminTierChange } from '../admin-tier-grant';
+import { TIER_MONTHLY_TOKENS } from '@/lib/tokens/pricing';
+
+const num = (v: unknown): number => Number(v);
+
+/** All credit_transactions for a user (order-independent; assert by source). */
+async function txns(userId: string): Promise<QueryRow[]> {
+  return harness().neonSql`
+    SELECT transaction_type, amount, balance_after, source, reference_id
+    FROM credit_transactions
+    WHERE user_id = ${userId}::uuid
+  `;
+}
+
+/** Find the single txn matching a source; fail loudly if absent/duplicated. */
+function bySource(rows: QueryRow[], source: string): QueryRow {
+  const matches = rows.filter((r) => r.source === source);
+  expect(matches, `expected exactly one txn with source "${source}"`).toHaveLength(1);
+  return matches[0];
+}
+
+describe('applyAdminTierChange — real Postgres (#8744)', () => {
+  beforeAll(async () => {
+    harnessRef.current = await createTestHarness();
+  });
+  afterAll(async () => {
+    await harness().close();
+  });
+  beforeEach(async () => {
+    await harness().truncateAll();
+  });
+
+  it('grants the new tier allocation to a comped-from-zero user and writes one audit row', async () => {
+    // The exact gap #8744 fixes: a freshly-approved tester with 0 tokens.
+    const seeded = await seedUser(harness().neonSql, {
+      tier: 'starter',
+      monthlyTokens: 0,
+      monthlyTokensUsed: 0,
+      addonTokens: 0,
+      earnedCredits: 0,
+    });
+
+    await applyAdminTierChange(seeded.id, 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(row!.tier).toBe('pro');
+    expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.pro);
+    expect(num(row!.monthly_tokens_used)).toBe(0);
+    expect(row!.billing_cycle_start).not.toBeNull();
+
+    // Spendable balance is now the full pro allotment — the journey can start.
+    const balance =
+      Math.max(0, num(row!.monthly_tokens) - num(row!.monthly_tokens_used)) +
+      num(row!.addon_tokens) +
+      num(row!.earned_credits);
+    expect(balance).toBe(TIER_MONTHLY_TOKENS.pro);
+
+    const rows = await txns(seeded.id);
+    const audit = bySource(rows, 'admin_tier_change:starter->pro');
+    expect(audit.transaction_type).toBe('adjustment');
+    expect(num(audit.amount)).toBe(TIER_MONTHLY_TOKENS.pro);
+    expect(num(audit.balance_after)).toBe(TIER_MONTHLY_TOKENS.pro);
+  });
+
+  it('computes balance_after from live addon + earned credits at execution time', async () => {
+    const seeded = await seedUser(harness().neonSql, {
+      tier: 'starter',
+      monthlyTokens: 0,
+      addonTokens: 200,
+      earnedCredits: 50,
+    });
+
+    await applyAdminTierChange(seeded.id, 'creator', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const rows = await txns(seeded.id);
+    const audit = bySource(rows, 'admin_tier_change:starter->creator');
+    // allocation + addon + earned = 1000 + 200 + 50
+    expect(num(audit.balance_after)).toBe(TIER_MONTHLY_TOKENS.creator + 200 + 50);
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(num(row!.addon_tokens)).toBe(200); // addon untouched by a tier grant
+    expect(num(row!.earned_credits)).toBe(50);
+  });
+
+  it('absolute-sets the allocation (does not stack) when re-comping an already-granted user', async () => {
+    const seeded = await seedUser(harness().neonSql, {
+      tier: 'pro',
+      monthlyTokens: TIER_MONTHLY_TOKENS.pro,
+      monthlyTokensUsed: 1200, // user has spent some
+    });
+
+    // Admin downgrades then the journey continues at the new tier's full amount.
+    await applyAdminTierChange(seeded.id, 'creator', {
+      previousTier: 'pro',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(row!.tier).toBe('creator');
+    expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.creator); // absolute, not +=
+    expect(num(row!.monthly_tokens_used)).toBe(0); // cycle reset
+  });
+
+  it('folds banned:true into the same atomic write', async () => {
+    const seeded = await seedUser(harness().neonSql, { tier: 'starter', monthlyTokens: 0 });
+
+    await applyAdminTierChange(seeded.id, 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+      banned: true,
+    });
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(num(row!.banned)).toBe(1);
+    expect(row!.tier).toBe('pro');
+    expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.pro);
+  });
+
+  it('preserves the existing banned value when the option is omitted', async () => {
+    const seeded = await seedUser(harness().neonSql, { tier: 'starter', monthlyTokens: 0 });
+    // Seed a banned user directly (seedUser has no banned override).
+    await harness().neonSql`UPDATE users SET banned = 1 WHERE id = ${seeded.id}::uuid`;
+
+    await applyAdminTierChange(seeded.id, 'hobbyist', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(num(row!.banned)).toBe(1); // unchanged — COALESCE(NULL, banned)
+    expect(row!.tier).toBe('hobbyist');
+  });
+
+  it('clears banned with banned:false while granting the tier', async () => {
+    const seeded = await seedUser(harness().neonSql, { tier: 'starter', monthlyTokens: 0 });
+    await harness().neonSql`UPDATE users SET banned = 1 WHERE id = ${seeded.id}::uuid`;
+
+    await applyAdminTierChange(seeded.id, 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+      banned: false,
+    });
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(num(row!.banned)).toBe(0);
+    expect(row!.tier).toBe('pro');
+  });
+
+  it('records a distinct audit row for each admin change (not idempotency-collapsed)', async () => {
+    const seeded = await seedUser(harness().neonSql, { tier: 'starter', monthlyTokens: 0 });
+
+    await applyAdminTierChange(seeded.id, 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+    await applyAdminTierChange(seeded.id, 'starter', {
+      previousTier: 'pro',
+      grantedByClerkId: 'clerk_admin',
+    });
+    await applyAdminTierChange(seeded.id, 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const rows = await txns(seeded.id);
+    // Two starter->pro grants + one pro->starter grant = three distinct rows.
+    expect(rows.filter((r) => r.source === 'admin_tier_change:starter->pro')).toHaveLength(2);
+    expect(rows.filter((r) => r.source === 'admin_tier_change:pro->starter')).toHaveLength(1);
+
+    const row = await getUserRow(harness().neonSql, seeded.id);
+    expect(row!.tier).toBe('pro');
+    expect(num(row!.monthly_tokens)).toBe(TIER_MONTHLY_TOKENS.pro);
+  });
+});

--- a/web/src/lib/billing/__tests__/adminTierGrant.test.ts
+++ b/web/src/lib/billing/__tests__/adminTierGrant.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for applyAdminTierChange — admin comp-tier token grant (#8744).
+ *
+ * STRUCTURE ONLY. This suite proves the call SHAPE: a single atomic
+ * neonSql.transaction batching the tier/allocation UPDATE and the
+ * `admin_tier_change` audit INSERT, with the right values interpolated
+ * (new allocation, audit source, the optional `banned` param). It deliberately
+ * does NOT assert SQL substrings beyond locating a statement — a query can
+ * contain the right literals and still grant the wrong amount. The BEHAVIOUR
+ * (absolute set to the new allocation, exactly one audit row, comped-from-zero
+ * user ends spendable, banned folded atomically) is proven against real
+ * Postgres in adminTierGrant.db.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const mockNeonTransaction = vi.fn().mockResolvedValue([]);
+const mockNeonSqlCalls: { strings: TemplateStringsArray; values: unknown[] }[] = [];
+const mockNeonSql = Object.assign(
+  vi.fn((_strings: TemplateStringsArray, ..._values: unknown[]): Promise<unknown[]> => {
+    mockNeonSqlCalls.push({ strings: _strings, values: _values });
+    return Promise.resolve([]);
+  }),
+  { transaction: mockNeonTransaction },
+);
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => ({})),
+  getNeonSql: vi.fn(() => mockNeonSql),
+  queryWithResilience: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock('@/lib/tokens/pricing', () => ({
+  TIER_MONTHLY_TOKENS: { starter: 50, hobbyist: 300, creator: 1000, pro: 3000 },
+}));
+
+import { applyAdminTierChange } from '../admin-tier-grant';
+
+function findUpdate() {
+  return mockNeonSqlCalls.find((c) => c.strings.some((s) => s.includes('UPDATE users')));
+}
+function findInsert() {
+  return mockNeonSqlCalls.find((c) =>
+    c.strings.some((s) => s.includes('INSERT INTO credit_transactions')),
+  );
+}
+
+describe('applyAdminTierChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNeonSqlCalls.length = 0;
+  });
+
+  it('runs ONE atomic transaction batching the UPDATE and the audit INSERT', async () => {
+    await applyAdminTierChange('user_1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    expect(mockNeonTransaction).toHaveBeenCalledOnce();
+    expect(mockNeonTransaction.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('sets the new tier and its full monthly allocation on the user', async () => {
+    await applyAdminTierChange('user_1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const update = findUpdate();
+    expect(update).toBeDefined();
+    expect(update!.values).toContain('pro'); // tier
+    expect(update!.values).toContain(3000); // pro allocation (absolute set)
+    expect(update!.values).toContain('user_1');
+  });
+
+  it('writes an admin_tier_change audit row for the granted allocation', async () => {
+    await applyAdminTierChange('user_1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const insert = findInsert();
+    expect(insert).toBeDefined();
+    expect(insert!.values).toContain(3000); // amount = new allocation
+    expect(insert!.values).toContain('admin_tier_change:starter->pro');
+    // reference_id is `<clerkId>:<ISO timestamp>` — unique per admin action so a
+    // repeated old->new change is never collapsed by the idempotency index.
+    expect(
+      insert!.values.some((v) => typeof v === 'string' && v.startsWith('clerk_admin:')),
+    ).toBe(true);
+  });
+
+  it('passes null for banned when the option is omitted (preserves the column)', async () => {
+    await applyAdminTierChange('user_1', 'creator', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+    });
+
+    const update = findUpdate();
+    expect(update!.values).toContain(1000); // creator allocation
+    expect(update!.values).toContain(null); // banned COALESCE param
+  });
+
+  it('passes 1 for banned:true and 0 for banned:false (folded into the same UPDATE)', async () => {
+    await applyAdminTierChange('user_1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+      banned: true,
+    });
+    expect(findUpdate()!.values).toContain(1);
+
+    vi.clearAllMocks();
+    mockNeonSqlCalls.length = 0;
+
+    await applyAdminTierChange('user_1', 'pro', {
+      previousTier: 'starter',
+      grantedByClerkId: 'clerk_admin',
+      banned: false,
+    });
+    expect(findUpdate()!.values).toContain(0);
+  });
+});

--- a/web/src/lib/billing/admin-tier-grant.ts
+++ b/web/src/lib/billing/admin-tier-grant.ts
@@ -1,0 +1,111 @@
+/**
+ * Admin comp-tier token grant (#8744).
+ *
+ * THE GAP THIS CLOSES
+ * -------------------
+ * The alpha is paid-only: an approved tester is comped a paid tier by an admin
+ * setting `users.tier` via `PATCH /api/admin/users/[id]`. Before this module
+ * that PATCH wrote the tier column alone — it granted NO tokens. Because
+ * `createGenerationHandler` meters every `/api/generate/*` call through the
+ * platform token path, a comped "pro" user holding 0 tokens was blocked at the
+ * very first generation, so the 5-10 minute "idea -> playable game" journey
+ * never started. A tier with no tokens is a tier in name only.
+ *
+ * WHAT IT DOES
+ * ------------
+ * `applyAdminTierChange` performs the tier change AND the token grant as one
+ * atomic `neonSql.transaction([...])` (neon-http; `db.transaction()` throws),
+ * mirroring the subscription-lifecycle grant idiom:
+ *   1. UPDATE users — set the new tier, ABSOLUTE-set monthly_tokens to the new
+ *      tier's full allocation, reset monthly_tokens_used, stamp a fresh billing
+ *      cycle, and fold the optional `banned` flag into the same write.
+ *   2. INSERT a `credit_transactions` audit row (type 'adjustment') whose
+ *      balance_after is read from the LIVE addon_tokens + earned_credits at
+ *      execution time (INSERT...SELECT), not a stale JS snapshot.
+ *
+ * Absolute-set (not upgrade-diff) is deliberate: a comped-from-zero user would
+ * be under-granted by a difference calculation, and an absolute set makes a
+ * repeated PATCH balance-idempotent — re-comping the same tier lands the same
+ * spendable balance rather than stacking.
+ *
+ * Idempotency: each admin action is an intentional one-shot, so reference_id is
+ * `<grantedByClerkId>:<ISO timestamp>` — unique per call so a legitimately
+ * repeated old->new tier change is NOT collapsed by the partial unique index on
+ * (user_id, source, reference_id). `ON CONFLICT DO NOTHING` is kept purely as a
+ * defensive backstop; unlike the webhook handlers there is no `NOT EXISTS` gate
+ * (admin edits are not redelivered events).
+ *
+ * Caller contract: invoke ONLY when the tier actually changes. A banned-only or
+ * same-tier edit must stay a plain UPDATE in the route — calling this on a
+ * no-op tier change would re-grant a full allocation and wipe accrued spend.
+ */
+
+import { getNeonSql, queryWithResilience } from '@/lib/db/client';
+import type { Tier } from '@/lib/db/schema';
+import { TIER_MONTHLY_TOKENS } from '@/lib/tokens/pricing';
+
+export interface AdminTierChangeOptions {
+  /**
+   * The user's tier BEFORE this change. Passed in (not re-read) because the
+   * route already loaded the user for its 404 + tier-changed check — this
+   * avoids a redundant read and makes the audit `source` deterministic.
+   */
+  previousTier: Tier;
+  /** Clerk ID of the admin performing the change (for the audit reference_id). */
+  grantedByClerkId: string;
+  /**
+   * Optional ban-state change to fold into the same atomic write.
+   * `true` -> banned=1, `false` -> banned=0, omitted -> preserve the column.
+   */
+  banned?: boolean;
+}
+
+/**
+ * Apply an admin tier change: set the tier, grant the new tier's full monthly
+ * allocation, and write an audit row — atomically. See module header for the
+ * full rationale and the caller contract (only call on a real tier change).
+ */
+export async function applyAdminTierChange(
+  userId: string,
+  newTier: Tier,
+  options: AdminTierChangeOptions
+): Promise<void> {
+  const neonSql = getNeonSql();
+  const allocation = TIER_MONTHLY_TOKENS[newTier];
+  const now = new Date().toISOString();
+
+  // null -> COALESCE preserves the existing column; 1/0 -> explicit set.
+  // The ::int cast guards neon-http's text-param type inference for the null.
+  const bannedParam = options.banned === undefined ? null : options.banned ? 1 : 0;
+
+  const source = `admin_tier_change:${options.previousTier}->${newTier}`;
+  // Unique per admin action so repeated old->new changes each record (and the
+  // idempotency index never collapses two distinct intentional grants).
+  const referenceId = `${options.grantedByClerkId}:${now}`;
+
+  // balance_after is computed via INSERT...SELECT so addon_tokens and
+  // earned_credits are read at execution time. The UPDATE runs first but does
+  // not touch those columns, so the SELECT reads their correct current values.
+  await queryWithResilience(() =>
+    neonSql.transaction([
+      neonSql`
+        UPDATE users
+        SET tier                = ${newTier},
+            monthly_tokens      = ${allocation},
+            monthly_tokens_used = 0,
+            billing_cycle_start = ${now},
+            banned              = COALESCE(${bannedParam}::int, banned),
+            updated_at          = ${now}
+        WHERE id = ${userId}
+      `,
+      neonSql`
+        INSERT INTO credit_transactions (user_id, transaction_type, amount, balance_after, source, reference_id)
+        SELECT ${userId}, 'adjustment', ${allocation},
+               ${allocation} + addon_tokens + earned_credits,
+               ${source}, ${referenceId}
+        FROM users WHERE id = ${userId}
+        ON CONFLICT (user_id, source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING
+      `,
+    ])
+  );
+}


### PR DESCRIPTION
## Summary

The paid-only alpha comps an approved tester by an admin setting their `tier` via `PATCH /api/admin/users/[id]`. Before this change that PATCH wrote the `tier` column **alone — with no token grant** — so a comped "pro" user held 0 tokens and was blocked at every `/api/generate/*` route. The 5–10 minute "idea → playable game" core journey never started. A tier with no tokens is a tier in name only.

This change makes a genuine tier change **also** grant the new tier's full monthly token allotment and write a `credit_transactions` audit row, atomically.

### What it does
- New `applyAdminTierChange(userId, newTier, opts)` in `web/src/lib/billing/admin-tier-grant.ts`: one atomic `neonSql.transaction([...])` (neon-http — `db.transaction()` throws) that:
  1. `UPDATE users` — sets the new tier, **absolute-sets** `monthly_tokens` to the new tier's allocation, resets `monthly_tokens_used`, stamps a fresh billing cycle, and folds an optional `banned` flag into the same write (`COALESCE(${bannedParam}::int, banned)`).
  2. `INSERT` a `credit_transactions` audit row (type `adjustment`) whose `balance_after` is read from **live** `addon_tokens + earned_credits` via `INSERT...SELECT` (not a stale JS snapshot).
- The route invokes the grant **only on a real tier change**. A banned-only or same-tier edit stays a plain `UPDATE` (re-granting on a no-op would zero accrued spend).
- Absolute-set (not upgrade-diff) is deliberate: a comped-from-zero user would be under-granted by a difference calc, and an absolute set makes a repeated PATCH balance-idempotent.

### Hardening (from the 5-reviewer board)
- **Self-comp blocked**: `403 SELF_MODIFICATION_FORBIDDEN` when an admin targets their own account — before any DB read (privilege-escalation vector: self-grant a higher tier / self-unban).
- **Malformed `[id]`**: non-UUID path segment returns `404` on GET+PATCH before any DB access (avoids a uuid-cast `500` + Sentry noise; 404 not 400 so the id format isn't confirmed to an enumerator).
- **Error-path completeness**: `500` when the post-grant re-read finds no row (instead of `200 { user: undefined }`), and `404` when the plain-update `.returning()` is empty (TOCTOU hard-delete between read and write).

## Test plan
- [x] `adminTierGrant.db.test.ts` — real Postgres (PGlite, schema replayed from `web/drizzle/*.sql`): comped-from-zero grant, live addon/earned `balance_after`, absolute-set on re-comp, banned-fold, banned-preserve, banned-clear, distinct-audit-per-change. Every grant path asserts `transaction_type='adjustment'` + non-null `reference_id` via a shared `expectAdjustment` helper.
- [x] `adminTierGrant.test.ts` — mock unit tests for the grant module.
- [x] `route.test.ts` — handler tests incl. 401/403/404/422, grant-on-tier-change, ban-fold, same-tier no-grant, 429, 404-invalid-UUID, 403-self-comp, 500-grant-throws, 500-empty-reread, 404-plain-update-TOCTOU.
- [x] `vitest` 33/33 on the three suites; `eslint --max-warnings 0` clean; `tsc --noEmit` exit 0.
- [x] Re-reviewed by architect + security + test specialists — all PASS.

Closes #8744 (PF-844)