### PR TITLE
fix(chat): spawnEntity returns id synchronously, killing phantom-success spawns

### DIFF
--- a/.changeset/spawn-entity-returns-id.md
+++ b/.changeset/spawn-entity-returns-id.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix phantom-success spawns in chat/compound/2D handlers (#8748). `spawnEntity` now returns the new entity's id synchronously instead of relying on the async `primaryId` selection round-trip, so AI-driven "spawn then transform/material" commands target the entity that was actually created — including on a fresh scene where `primaryId` was `null`. Non-spawnable types and a not-yet-loaded engine now surface a real failure rather than reporting success against an undefined id.

--- a/engine/src/core/commands/transform.rs
+++ b/engine/src/core/commands/transform.rs
@@ -87,6 +87,9 @@ struct SpawnEntityPayload {
     entity_type: String,
     name: Option<String>,
     position: Option<[f32; 3]>,
+    /// Optional client-generated id. Lets JS reference the spawned entity
+    /// synchronously instead of waiting for the async SELECTION_CHANGED event.
+    id: Option<String>,
 }
 
 /// Spawn a new entity with the given components.
@@ -101,6 +104,7 @@ fn handle_spawn_entity(payload: serde_json::Value) -> CommandResult {
         entity_type,
         name: data.name,
         position: data.position.map(|p| Vec3::new(p[0], p[1], p[2])),
+        id: data.id,
     };
 
     if queue_spawn_from_bridge(request) {

--- a/engine/src/core/entity_factory.rs
+++ b/engine/src/core/entity_factory.rs
@@ -49,6 +49,24 @@ impl EntityNameCounter {
     }
 }
 
+/// Whether a caller-supplied id may override the engine-generated `EntityId`.
+///
+/// The sole production caller passes `crypto.randomUUID()`, so this is
+/// defense-in-depth against a future or rogue caller, never the normal path. An
+/// id is honored only when it is a plausible identifier: non-empty (the caller
+/// already trims it), at most 64 bytes, and free of control characters. This
+/// rejects the concrete vectors a stricter-than-`trim` check would otherwise
+/// admit — interior NUL bytes (`\0`, not stripped by `str::trim`) and unbounded
+/// blobs — while staying decoupled from any single id format. A rejected id
+/// falls back to the engine-generated UUID, so the spawn still succeeds.
+fn is_valid_override_id(id: &str) -> bool {
+    // `len()` is the UTF-8 byte length on purpose: this is a storage/DoS bound on
+    // the string we copy into the `EntityId`, so bytes (not grapheme count) is the
+    // right unit. Do not swap to `chars().count()`. The control-char check is
+    // per-`char`, which is correct for catching interior NUL/format chars.
+    !id.is_empty() && id.len() <= 64 && !id.chars().any(|c| c.is_control())
+}
+
 /// System that processes pending spawn requests.
 pub fn apply_spawn_requests(
     mut pending: ResMut<PendingCommands>,
@@ -92,6 +110,23 @@ pub fn apply_spawn_requests(
                 // ProceduralMesh entities are created by extrude/lathe/combine systems, not through spawn requests.
                 continue;
             }
+        };
+
+        // If the caller supplied a valid id (see `is_valid_override_id`),
+        // override the engine-generated EntityId so the JS caller can reference
+        // this entity synchronously (before the async SELECTION_CHANGED
+        // round-trip). Bevy's `insert` replaces the EntityId the spawn helper
+        // already attached; a blank/None/malformed id falls back to that
+        // generated UUID, so the spawn still succeeds. `EntityId` is itself a
+        // UUID-v4 String newtype, so a client-supplied id has identical
+        // uniqueness properties. The `continue` arms above never reach here, so
+        // only real spawns are overridden.
+        let entity_id = match request.id.as_deref().map(str::trim) {
+            Some(id) if is_valid_override_id(id) => {
+                commands.entity(entity).insert(EntityId::new(id));
+                id.to_string()
+            }
+            _ => entity_id,
         };
 
         // Material data for mesh entities, light data for light entities
@@ -2191,5 +2226,132 @@ fn execute_redo(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod spawn_id_tests {
+    use super::apply_spawn_requests;
+    use super::HistoryStack;
+    use crate::core::entity_id::EntityId;
+    use crate::core::pending_commands::{EntityType, PendingCommands, SpawnRequest};
+    use bevy::prelude::*;
+
+    /// Build a minimal World with the resources `apply_spawn_requests` reads,
+    /// run the system once through a Schedule (which flushes the deferred
+    /// `Commands`), and return every EntityId string left in the world.
+    fn run_spawn(request: SpawnRequest) -> Vec<String> {
+        let mut world = World::new();
+        let mut pending = PendingCommands::default();
+        pending.spawn_requests.push(request);
+        world.insert_resource(pending);
+        world.insert_resource(Assets::<Mesh>::default());
+        world.insert_resource(Assets::<StandardMaterial>::default());
+        world.insert_resource(HistoryStack::default());
+
+        let mut schedule = Schedule::default();
+        schedule.add_systems(apply_spawn_requests);
+        schedule.run(&mut world);
+
+        let mut query = world.query::<&EntityId>();
+        query.iter(&world).map(|id| id.0.clone()).collect()
+    }
+
+    /// The core fix: a supplied non-blank id becomes the spawned entity's
+    /// EntityId. This is what lets the JS caller reference the entity
+    /// synchronously instead of reading a stale `primaryId` that the async
+    /// SELECTION_CHANGED event has not yet updated.
+    #[test]
+    fn supplied_id_overrides_generated_entity_id() {
+        let ids = run_spawn(SpawnRequest {
+            entity_type: EntityType::Cube,
+            name: Some("Hero".into()),
+            position: None,
+            id: Some("client-uuid-123".into()),
+        });
+        assert_eq!(
+            ids,
+            vec!["client-uuid-123".to_string()],
+            "supplied id must override the engine-generated EntityId",
+        );
+    }
+
+    /// Legacy path: a `None` id falls back to the engine-generated UUID-v4
+    /// (36 chars). Spawns that don't supply an id must keep working.
+    #[test]
+    fn none_id_falls_back_to_generated_uuid() {
+        let ids = run_spawn(SpawnRequest {
+            entity_type: EntityType::Sphere,
+            name: Some("Ball".into()),
+            position: None,
+            id: None,
+        });
+        assert_eq!(ids.len(), 1, "exactly one entity should spawn");
+        assert_eq!(
+            ids[0].len(),
+            36,
+            "fallback EntityId should be a UUID-v4 (36 chars), got {:?}",
+            ids[0],
+        );
+    }
+
+    /// A blank / whitespace-only id is treated as absent and falls back to a
+    /// generated UUID — guards against a client sending "" or "   ".
+    #[test]
+    fn blank_id_falls_back_to_generated_uuid() {
+        let ids = run_spawn(SpawnRequest {
+            entity_type: EntityType::Cube,
+            name: Some("Blank".into()),
+            position: None,
+            id: Some("   ".into()),
+        });
+        assert_eq!(ids.len(), 1, "exactly one entity should spawn");
+        assert_eq!(
+            ids[0].len(),
+            36,
+            "blank id must fall back to a UUID-v4, got {:?}",
+            ids[0],
+        );
+    }
+
+    /// An id containing a control / NUL character (which `str::trim` does NOT
+    /// strip from the interior) is rejected by `is_valid_override_id` and falls
+    /// back to a generated UUID. The spawn still succeeds — a malformed client
+    /// id can never produce a malformed EntityId.
+    #[test]
+    fn control_char_id_falls_back_to_generated_uuid() {
+        let ids = run_spawn(SpawnRequest {
+            entity_type: EntityType::Cube,
+            name: Some("Ctrl".into()),
+            position: None,
+            id: Some("ab\u{0}cd".into()),
+        });
+        assert_eq!(ids.len(), 1, "exactly one entity should spawn");
+        assert_eq!(
+            ids[0].len(),
+            36,
+            "control-char id must fall back to a UUID-v4, got {:?}",
+            ids[0],
+        );
+    }
+
+    /// An oversized id (> 64 chars) is rejected and falls back to a generated
+    /// UUID, bounding the EntityId length against an unbounded client blob.
+    #[test]
+    fn oversized_id_falls_back_to_generated_uuid() {
+        let oversized = "a".repeat(65);
+        let ids = run_spawn(SpawnRequest {
+            entity_type: EntityType::Cube,
+            name: Some("Big".into()),
+            position: None,
+            id: Some(oversized),
+        });
+        assert_eq!(ids.len(), 1, "exactly one entity should spawn");
+        assert_eq!(
+            ids[0].len(),
+            36,
+            "oversized id must fall back to a UUID-v4, got {:?}",
+            ids[0],
+        );
     }
 }

--- a/engine/src/core/pending/transform.rs
+++ b/engine/src/core/pending/transform.rs
@@ -39,6 +39,12 @@ pub struct SpawnRequest {
     pub entity_type: super::EntityType,
     pub name: Option<String>,
     pub position: Option<Vec3>,
+    /// Optional caller-supplied entity id. When present and non-blank, the
+    /// spawned entity's `EntityId` is overridden to this value so the JS caller
+    /// can reference the entity synchronously (before the async
+    /// `SELECTION_CHANGED` round-trip). Blank/`None` falls back to the
+    /// engine-generated UUID. See `apply_spawn_requests`.
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/web/src/__integration__/commands/scene-crud.test.ts
+++ b/web/src/__integration__/commands/scene-crud.test.ts
@@ -55,21 +55,25 @@ describe('scene CRUD integration', () => {
   // -------------------------------------------------------------------------
 
   describe('spawn entity', () => {
-    it('dispatches spawn_entity with entityType and name', () => {
-      h.getState().spawnEntity('cube', 'MyCube');
+    it('dispatches spawn_entity with entityType, name, and the returned id', () => {
+      const returnedId = h.getState().spawnEntity('cube', 'MyCube');
 
+      // #8748: id generated client-side and returned synchronously.
+      expect(typeof returnedId).toBe('string');
       expect(h.dispatch).toHaveBeenCalledWith('spawn_entity', {
         entityType: 'cube',
         name: 'MyCube',
+        id: returnedId,
       });
     });
 
     it('dispatches spawn_entity without a name when omitted', () => {
-      h.getState().spawnEntity('sphere');
+      const returnedId = h.getState().spawnEntity('sphere');
 
       expect(h.dispatch).toHaveBeenCalledWith('spawn_entity', {
         entityType: 'sphere',
         name: undefined,
+        id: returnedId,
       });
     });
 
@@ -104,8 +108,13 @@ describe('scene CRUD integration', () => {
       expect(state.sceneGraph.rootIds).not.toContain('child-1');
     });
 
-    it('dispatches spawn_entity for each supported entity type', () => {
-      const types = ['cube', 'sphere', 'plane', 'cylinder', 'cone', 'empty'] as const;
+    it('dispatches spawn_entity for each engine-spawnable entity type', () => {
+      // Only the primitive mesh / light types are spawned by the engine's
+      // `apply_spawn_requests`. `'empty'` is intentionally excluded here — the
+      // engine `EntityType` enum has no `Empty` variant, so a `spawn_entity`
+      // for it would never deserialize and would create nothing (see the
+      // non-spawnable assertion below). #8748.
+      const types = ['cube', 'sphere', 'plane', 'cylinder', 'cone'] as const;
       for (const type of types) {
         h.getState().spawnEntity(type);
       }
@@ -113,6 +122,16 @@ describe('scene CRUD integration', () => {
       for (const type of types) {
         expect(h.dispatch).toHaveBeenCalledWith('spawn_entity', expect.objectContaining({ entityType: type }));
       }
+    });
+
+    it('does NOT dispatch spawn_entity for a non-spawnable type (empty) and returns undefined', () => {
+      // `'empty'` reaches no spawn arm in `apply_spawn_requests`, so returning a
+      // generated id would be a phantom reference. The guard returns undefined
+      // and suppresses the dispatch so the caller's `if (!id)` surfaces the
+      // failure instead of targeting a missing entity. #8748.
+      const returnedId = h.getState().spawnEntity('empty');
+      expect(returnedId).toBeUndefined();
+      expect(h.dispatch).not.toHaveBeenCalledWith('spawn_entity', expect.anything());
     });
   });
 

--- a/web/src/lib/chat/__tests__/executorIntegration.test.ts
+++ b/web/src/lib/chat/__tests__/executorIntegration.test.ts
@@ -67,7 +67,9 @@ describe('Chat executor integration: executeToolCall → handler → store', () 
   });
 
   it('spawn_entity: calls store.spawnEntity with correct type', async () => {
-    const store = makeStore();
+    // spawnEntity returns the new id synchronously (#8748); a spawn with no id
+    // back is a real failure, so the success path must hand back a concrete id.
+    const store = makeStore({ spawnEntity: vi.fn(() => 'sphere-1') });
     const result: ExecutionResult = await executeToolCall(
       'spawn_entity',
       { entityType: 'sphere', name: 'My Sphere' },

--- a/web/src/lib/chat/__tests__/executorLegacy.test.ts
+++ b/web/src/lib/chat/__tests__/executorLegacy.test.ts
@@ -457,10 +457,10 @@ describe('legacy: arrange_entities', () => {
 describe('legacy: create_scene_from_description', () => {
   it('spawns each entity and calls updateTransform for position', async () => {
     let spawnCallCount = 0;
+    // spawnEntity returns the new id synchronously (#8748); the compound handler
+    // targets that returned id for the follow-up updateTransform, not primaryId.
     const store = makeStore({
-      get primaryId() {
-        return `entity-${++spawnCallCount}`;
-      },
+      spawnEntity: vi.fn(() => `entity-${++spawnCallCount}`),
     });
 
     const result = await executeToolCall('create_scene_from_description', {
@@ -528,12 +528,8 @@ describe('legacy: create_scene_from_description', () => {
   });
 
   it('applies physics when entity physics config provided', async () => {
-    let spawned = false;
     const store = makeStore({
-      get primaryId() {
-        if (!spawned) { spawned = true; return 'cube-id'; }
-        return null;
-      },
+      spawnEntity: vi.fn(() => 'cube-id'),
     });
 
     await executeToolCall('create_scene_from_description', {
@@ -553,7 +549,7 @@ describe('legacy: create_scene_from_description', () => {
 
 describe('legacy: setup_character', () => {
   it('spawns character, sets physics, adds character controller, sets input preset', async () => {
-    const store = makeStore({ primaryId: 'char-1' });
+    const store = makeStore({ spawnEntity: vi.fn(() => 'char-1') });
 
     const result = await executeToolCall('setup_character', {
       name: 'Hero',
@@ -568,7 +564,7 @@ describe('legacy: setup_character', () => {
   });
 
   it('attaches camera follow script when cameraFollow is true (default)', async () => {
-    const store = makeStore({ primaryId: 'char-2' });
+    const store = makeStore({ spawnEntity: vi.fn(() => 'char-2') });
 
     await executeToolCall('setup_character', { name: 'Runner' }, store);
 
@@ -580,7 +576,7 @@ describe('legacy: setup_character', () => {
   });
 
   it('skips camera follow script when cameraFollow is false', async () => {
-    const store = makeStore({ primaryId: 'char-3' });
+    const store = makeStore({ spawnEntity: vi.fn(() => 'char-3') });
 
     await executeToolCall('setup_character', { name: 'NoCam', cameraFollow: false }, store);
 
@@ -588,7 +584,7 @@ describe('legacy: setup_character', () => {
   });
 
   it('skips health component when health is explicitly null', async () => {
-    const store = makeStore({ primaryId: 'char-4' });
+    const store = makeStore({ spawnEntity: vi.fn(() => 'char-4') });
 
     await executeToolCall('setup_character', { name: 'NoHealth', health: null }, store);
 
@@ -599,7 +595,7 @@ describe('legacy: setup_character', () => {
   });
 
   it('applies custom entity type when entityType is provided', async () => {
-    const store = makeStore({ primaryId: 'char-5' });
+    const store = makeStore({ spawnEntity: vi.fn(() => 'char-5') });
 
     await executeToolCall('setup_character', { name: 'Bot', entityType: 'sphere' }, store);
 

--- a/web/src/lib/chat/handlers/__tests__/audioPhysicsGameHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/audioPhysicsGameHandlers.test.ts
@@ -1479,21 +1479,60 @@ describe('gameplayHandlers', () => {
     });
 
     it('instantiates an existing prefab', async () => {
-      const { result, store } = await invokeHandler(gameplayHandlers, 'instantiate_prefab', {
-        prefabId: 'prefab-1',
-      });
+      const { result, store } = await invokeHandler(
+        gameplayHandlers,
+        'instantiate_prefab',
+        { prefabId: 'prefab-1' },
+        { spawnEntity: vi.fn(() => 'prefab-ent-1') },
+      );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'TestPrefab');
       expect((result.result as { message: string }).message).toContain('TestPrefab');
     });
 
     it('uses custom name when provided', async () => {
-      const { result, store } = await invokeHandler(gameplayHandlers, 'instantiate_prefab', {
-        prefabId: 'prefab-1',
-        name: 'CustomName',
-      });
+      const { result, store } = await invokeHandler(
+        gameplayHandlers,
+        'instantiate_prefab',
+        { prefabId: 'prefab-1', name: 'CustomName' },
+        { spawnEntity: vi.fn(() => 'prefab-ent-1') },
+      );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'CustomName');
+    });
+
+    it('targets spawnEntity\'s returned id for material and transform on a fresh scene', async () => {
+      // Fresh scene: primaryId is null. The prefab\'s material + the requested
+      // position must be applied to the synchronously-returned spawn id, not the
+      // stale selection. Proves the stale-primaryId fix end-to-end (#8748).
+      const { result, store } = await invokeHandler(
+        gameplayHandlers,
+        'instantiate_prefab',
+        { prefabId: 'prefab-1', position: [1, 2, 3] },
+        { spawnEntity: vi.fn(() => 'prefab-ent-1') },
+      );
+      expect(result.success).toBe(true);
+      expect(store.primaryId).toBeNull();
+      expect(store.updateMaterial).toHaveBeenCalledWith('prefab-ent-1', { baseColor: [1, 0, 0, 1] });
+      expect(store.updateTransform).toHaveBeenCalledWith('prefab-ent-1', 'position', [1, 2, 3]);
+      expect((result.result as { entityId: string }).entityId).toBe('prefab-ent-1');
+    });
+
+    it('fails (not a phantom success) and applies nothing when no entity is spawned (#8748)', async () => {
+      // spawnEntity returns undefined when the prefab's unvalidated `entityType: string`
+      // is non-spawnable, or when the engine is not loaded yet. The handler must surface
+      // a real failure rather than claim the prefab was instantiated — and must NOT apply
+      // the prefab's material or the requested position to a non-existent entity.
+      const { result, store } = await invokeHandler(
+        gameplayHandlers,
+        'instantiate_prefab',
+        { prefabId: 'prefab-1', position: [1, 2, 3] },
+        { spawnEntity: vi.fn(() => undefined) },
+      );
+      expect(result.success).toBe(false);
+      expect(store.updateMaterial).not.toHaveBeenCalled();
+      expect(store.updateTransform).not.toHaveBeenCalled();
+      expect((result.result as { entityId?: string } | undefined)?.entityId).toBeUndefined();
     });
   });
 

--- a/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
@@ -351,7 +351,7 @@ describe('compoundHandlers', () => {
           { type: 'sphere', name: 'Ball', position: [0, 2, 0] },
         ],
       }, {
-        primaryId: 'spawned-1',
+        spawnEntity: vi.fn((_t: unknown, n: string) => `id-${n}`),
       });
 
       expect(result.success).toBe(true);
@@ -366,7 +366,7 @@ describe('compoundHandlers', () => {
         entities: [],
         clearExisting: true,
       }, {
-        primaryId: 'spawned-1',
+        spawnEntity: vi.fn(() => 'spawned-1'),
       });
 
       expect(store.newScene).toHaveBeenCalled();
@@ -395,7 +395,7 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('create_scene_from_description', {
         entities: [{ type: 'cube', name: 'Red', material: { presetId: 'glossy-red' } }],
       }, {
-        primaryId: 'e1',
+        spawnEntity: vi.fn(() => 'e1'),
       });
 
       expect(mockGetPresetById).toHaveBeenCalledWith('glossy-red');
@@ -406,35 +406,33 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('create_scene_from_description', {
         entities: [{ type: 'cube', name: 'Box', physics: { bodyType: 'dynamic' } }],
       }, {
-        primaryId: 'e1',
+        spawnEntity: vi.fn(() => 'e1'),
       });
 
       expect(store.togglePhysics).toHaveBeenCalledWith('e1', true);
       expect(store.updatePhysics).toHaveBeenCalled();
     });
 
-    it('reparents entities when parentName is specified', async () => {
-      let callCount = 0;
+    it('reparents entities using the distinct ids returned by spawnEntity', async () => {
+      // Each spawn returns a distinct id derived from the name, proving the
+      // name→id map is built from spawnEntity's return value (not stale primaryId).
       const { store } = await invoke('create_scene_from_description', {
         entities: [
           { type: 'cube', name: 'Parent' },
           { type: 'sphere', name: 'Child', parentName: 'Parent' },
         ],
       }, {
-        get primaryId() {
-          callCount++;
-          return `e${callCount}`;
-        },
+        spawnEntity: vi.fn((_t: unknown, n: string) => `id-${n}`),
       });
 
-      expect(store.reparentEntity).toHaveBeenCalled();
+      expect(store.reparentEntity).toHaveBeenCalledWith('id-Child', 'id-Parent');
     });
 
     it('handles spawn failure gracefully', async () => {
       const { result } = await invoke('create_scene_from_description', {
         entities: [{ type: 'cube', name: 'Broken' }],
       }, {
-        primaryId: null,
+        spawnEntity: vi.fn(() => null),
       });
 
       expect(result.success).toBe(true);
@@ -453,7 +451,7 @@ describe('compoundHandlers', () => {
       const { result, store } = await invoke('create_level_layout', {
         levelName: 'Level1',
       }, {
-        primaryId: 'root-1',
+        spawnEntity: vi.fn(() => 'root-1'),
       });
 
       expect(result.success).toBe(true);
@@ -462,9 +460,9 @@ describe('compoundHandlers', () => {
       expect(data.entityIds).toHaveProperty('Level1', 'root-1');
     });
 
-    it('returns error when root spawn fails', async () => {
+    it('returns error when root spawn returns no id', async () => {
       const { result } = await invoke('create_level_layout', {}, {
-        primaryId: null,
+        spawnEntity: vi.fn(() => null),
       });
 
       expect(result.success).toBe(false);
@@ -473,7 +471,7 @@ describe('compoundHandlers', () => {
 
     it('uses default level name "Level"', async () => {
       const { store } = await invoke('create_level_layout', {}, {
-        primaryId: 'root',
+        spawnEntity: vi.fn(() => 'root'),
       });
 
       expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'Level');
@@ -483,10 +481,39 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('create_level_layout', {
         inputPreset: 'platformer',
       }, {
-        primaryId: 'root',
+        spawnEntity: vi.fn(() => 'root'),
       });
 
       expect(store.setInputPreset).toHaveBeenCalledWith('platformer');
+    });
+
+    it('reports the terrain ground as an explicit failure when its id is unavailable (#8749 boundary)', async () => {
+      // The terrain path still reads the stale `primaryId` (#8749). On a fresh
+      // scene that is null, so the ground cannot be parented. The handler must
+      // surface that as a failed operation — never silently drop it and imply
+      // the ground exists.
+      const { result, store } = await invoke('create_level_layout', {
+        levelName: 'TerrainLevel',
+        ground: { useTerrain: true, terrainConfig: { size: 64 } },
+      }, {
+        spawnEntity: vi.fn(() => 'root-1'),
+        // primaryId left at its default null; spawnTerrain does not set it (#8749)
+      });
+
+      expect(store.spawnTerrain).toHaveBeenCalled();
+      const data = result.result as {
+        success: boolean;
+        operations: Array<{ action: string; success: boolean; error?: string }>;
+        partialSuccess: boolean;
+      };
+      const groundOp = data.operations.find((op) => op.action === 'create terrain ground');
+      expect(groundOp).toBeDefined();
+      expect(groundOp?.success).toBe(false);
+      expect(groundOp?.error).toContain('#8749');
+      // Root succeeded, ground failed → the compound result reports partial
+      // success, not a clean success that would imply the ground exists.
+      expect(data.success).toBe(false);
+      expect(data.partialSuccess).toBe(true);
     });
   });
 
@@ -497,11 +524,13 @@ describe('compoundHandlers', () => {
   describe('setup_character', () => {
     it('spawns a character with default settings', async () => {
       const { result, store } = await invoke('setup_character', {}, {
-        primaryId: 'char-1',
+        spawnEntity: vi.fn(() => 'char-1'),
       });
 
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('capsule', 'Player');
+      // primaryId stays null on a fresh scene — all follow-ups target the returned id.
+      expect(store.primaryId).toBeNull();
       expect(store.updateTransform).toHaveBeenCalledWith('char-1', 'position', [0, 1, 0]);
       expect(store.togglePhysics).toHaveBeenCalledWith('char-1', true);
       expect(store.updatePhysics).toHaveBeenCalled();
@@ -515,7 +544,7 @@ describe('compoundHandlers', () => {
         position: [5, 0, 3],
         entityType: 'sphere',
       }, {
-        primaryId: 'char-2',
+        spawnEntity: vi.fn(() => 'char-2'),
       });
 
       expect(store.spawnEntity).toHaveBeenCalledWith('sphere', 'Hero');
@@ -526,7 +555,7 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('setup_character', {
         material: { baseColor: [1, 0, 0, 1] },
       }, {
-        primaryId: 'char-3',
+        spawnEntity: vi.fn(() => 'char-3'),
       });
 
       expect(store.updateMaterial).toHaveBeenCalled();
@@ -536,7 +565,7 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('setup_character', {
         health: null,
       }, {
-        primaryId: 'char-4',
+        spawnEntity: vi.fn(() => 'char-4'),
       });
 
       // addGameComponent should be called once for character_controller only
@@ -547,7 +576,7 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('setup_character', {
         cameraFollow: true,
       }, {
-        primaryId: 'char-5',
+        spawnEntity: vi.fn(() => 'char-5'),
       });
 
       expect(store.setScript).toHaveBeenCalled();
@@ -560,15 +589,15 @@ describe('compoundHandlers', () => {
       const { store } = await invoke('setup_character', {
         cameraFollow: false,
       }, {
-        primaryId: 'char-6',
+        spawnEntity: vi.fn(() => 'char-6'),
       });
 
       expect(store.setScript).not.toHaveBeenCalled();
     });
 
-    it('handles spawn failure gracefully', async () => {
+    it('handles spawn failure gracefully (spawnEntity returns no id)', async () => {
       const { result } = await invoke('setup_character', {}, {
-        primaryId: null,
+        spawnEntity: vi.fn(() => null),
       });
 
       expect(result.success).toBe(true);

--- a/web/src/lib/chat/handlers/__tests__/entityHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/entityHandlers.test.ts
@@ -53,9 +53,12 @@ describe('spawn_entity', () => {
   });
 
   it('spawns cube and calls store.spawnEntity', async () => {
-    const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', {
-      entityType: 'cube',
-    });
+    const { result, store } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'cube' },
+      { spawnEntity: vi.fn(() => 'cube-1') },
+    );
     expect(result.success).toBe(true);
     expect(store.spawnEntity).toHaveBeenCalledWith('cube', undefined);
   });
@@ -68,21 +71,44 @@ describe('spawn_entity', () => {
     expect(store.spawnEntity).toHaveBeenCalledWith('sphere', 'MyBall');
   });
 
-  it('accepts all valid entity types', async () => {
+  it('spawns every engine-spawnable primitive/light type', async () => {
+    // Exactly the types the engine's apply_spawn_requests creates via the
+    // spawn_entity command (SPAWNABLE_ENTITY_TYPES). Non-spawnable EntityTypes
+    // are covered by the rejection test below (#8748).
     const types = [
-      'cube', 'sphere', 'cylinder', 'capsule', 'torus', 'plane', 'cone', 'icosphere',
-      'point_light', 'directional_light', 'spot_light', 'gltf_model', 'empty',
+      'cube', 'sphere', 'cylinder', 'capsule', 'torus', 'plane', 'cone',
+      'point_light', 'directional_light', 'spot_light',
     ];
     for (const entityType of types) {
-      const { result } = await invokeHandler(transformHandlers, 'spawn_entity', { entityType });
+      const { result } = await invokeHandler(
+        transformHandlers,
+        'spawn_entity',
+        { entityType },
+        { spawnEntity: vi.fn(() => `${entityType}-1`) },
+      );
       expect(result.success).toBe(true);
     }
   });
 
+  it('rejects non-spawnable entity types instead of reporting phantom success (#8748)', async () => {
+    // icosphere/gltf_model/empty/sprite/terrain are valid EntityType values but are
+    // NOT created by the engine's spawn_entity path — the schema rejects them before
+    // any dispatch, so the tool returns a real failure rather than an undefined id.
+    const nonSpawnable = ['icosphere', 'gltf_model', 'empty', 'sprite', 'terrain'];
+    for (const entityType of nonSpawnable) {
+      const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', { entityType });
+      expect(result.success).toBe(false);
+      expect(store.spawnEntity).not.toHaveBeenCalled();
+    }
+  });
+
   it('result message includes entityType', async () => {
-    const { result } = await invokeHandler(transformHandlers, 'spawn_entity', {
-      entityType: 'torus',
-    });
+    const { result } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'torus' },
+      { spawnEntity: vi.fn(() => 'torus-1') },
+    );
     const data = result.result as { message: string };
     expect(data.message).toContain('torus');
   });

--- a/web/src/lib/chat/handlers/__tests__/entityMaterialHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/entityMaterialHandlers.test.ts
@@ -96,34 +96,49 @@ describe('entityHandlers', () => {
   // -----------------------------------------------------------------------
   describe('spawn_entity', () => {
     it('calls spawnEntity with type and name', async () => {
-      const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', {
-        entityType: 'cube',
-        name: 'MyCube',
-      });
+      const { result, store } = await invokeHandler(
+        transformHandlers,
+        'spawn_entity',
+        { entityType: 'cube', name: 'MyCube' },
+        { spawnEntity: vi.fn(() => 'cube-1') },
+      );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'MyCube');
     });
 
     it('calls spawnEntity with type only (no name)', async () => {
-      const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', {
-        entityType: 'sphere',
-      });
+      const { result, store } = await invokeHandler(
+        transformHandlers,
+        'spawn_entity',
+        { entityType: 'sphere' },
+        { spawnEntity: vi.fn(() => 'sphere-1') },
+      );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('sphere', undefined);
     });
 
     it('returns a message containing the entity type', async () => {
-      const { result } = await invokeHandler(transformHandlers, 'spawn_entity', {
-        entityType: 'cylinder',
-      });
+      const { result } = await invokeHandler(
+        transformHandlers,
+        'spawn_entity',
+        { entityType: 'cylinder' },
+        { spawnEntity: vi.fn(() => 'cylinder-1') },
+      );
       expect(result.success).toBe(true);
       expect((result.result as { message: string }).message).toContain('cylinder');
     });
 
     it('supports different entity types', async () => {
-      const types = ['cube', 'sphere', 'plane', 'capsule', 'torus', 'cone', 'point_light', 'directional_light', 'spot_light', 'empty'];
+      // The full set of engine-spawnable types (SPAWNABLE_ENTITY_TYPES). 'empty' is
+      // intentionally excluded — it is not spawnable via spawn_entity (#8748).
+      const types = ['cube', 'sphere', 'plane', 'cylinder', 'capsule', 'torus', 'cone', 'point_light', 'directional_light', 'spot_light'];
       for (const entityType of types) {
-        const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', { entityType });
+        const { result, store } = await invokeHandler(
+          transformHandlers,
+          'spawn_entity',
+          { entityType },
+          { spawnEntity: vi.fn(() => `${entityType}-1`) },
+        );
         expect(result.success).toBe(true);
         expect(store.spawnEntity).toHaveBeenCalledWith(entityType, undefined);
       }

--- a/web/src/lib/chat/handlers/__tests__/exportAsset2dHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/exportAsset2dHandlers.test.ts
@@ -671,12 +671,13 @@ describe('handlers2d sprite commands', () => {
   describe('create_sprite', () => {
     it('spawns a plane entity and sets default sprite data', async () => {
       const { result, store } = await invoke2d('create_sprite', {}, {
-        primaryId: 'new-ent-1',
-        spawnEntity: vi.fn(),
+        spawnEntity: vi.fn(() => 'new-ent-1'),
         setSpriteData: vi.fn(),
         updateTransform: vi.fn(),
       });
       expect(result.success).toBe(true);
+      // Fresh-scene path: primaryId is null; the handler targets spawnEntity's returned id.
+      expect(store.primaryId).toBeNull();
       expect(store.spawnEntity).toHaveBeenCalledWith('plane', undefined);
       expect(store.setSpriteData).toHaveBeenCalledWith('new-ent-1', expect.objectContaining({
         sortingLayer: 'Default',
@@ -689,7 +690,7 @@ describe('handlers2d sprite commands', () => {
       const { result, store } = await invoke2d(
         'create_sprite',
         { entityType: 'cube', name: 'Hero', sortingLayer: 'Foreground', sortingOrder: 5 },
-        { primaryId: 'ent-hero', spawnEntity: vi.fn(), setSpriteData: vi.fn(), updateTransform: vi.fn() },
+        { spawnEntity: vi.fn(() => 'ent-hero'), setSpriteData: vi.fn(), updateTransform: vi.fn() },
       );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'Hero');
@@ -703,15 +704,14 @@ describe('handlers2d sprite commands', () => {
       const { store } = await invoke2d(
         'create_sprite',
         { position: [1, 2, 3] },
-        { primaryId: 'ent-pos', spawnEntity: vi.fn(), setSpriteData: vi.fn(), updateTransform: vi.fn() },
+        { spawnEntity: vi.fn(() => 'ent-pos'), setSpriteData: vi.fn(), updateTransform: vi.fn() },
       );
       expect(store.updateTransform).toHaveBeenCalledWith('ent-pos', 'position', { x: 1, y: 2, z: 3 });
     });
 
-    it('returns error when entity spawn returns null primaryId', async () => {
+    it('returns error when spawnEntity returns no id (engine spawn failed)', async () => {
       const { result } = await invoke2d('create_sprite', {}, {
-        primaryId: null,
-        spawnEntity: vi.fn(),
+        spawnEntity: vi.fn(() => null),
         setSpriteData: vi.fn(),
         updateTransform: vi.fn(),
       });
@@ -1360,9 +1360,11 @@ describe('handlers2d tilemap commands', () => {
       const { result, store } = await invoke2d(
         'create_tilemap',
         { tilesetAssetId: 'tiles-1' },
-        { primaryId: 'ent-tile', spawnEntity: vi.fn(), setTilemapData: vi.fn() },
+        { spawnEntity: vi.fn(() => 'ent-tile'), setTilemapData: vi.fn() },
       );
       expect(result.success).toBe(true);
+      // Fresh-scene path: primaryId is null; the handler targets spawnEntity's returned id.
+      expect(store.primaryId).toBeNull();
       expect(store.spawnEntity).toHaveBeenCalledWith('plane', 'Tilemap');
       expect(store.setTilemapData).toHaveBeenCalledWith('ent-tile', expect.objectContaining({
         tilesetAssetId: 'tiles-1',
@@ -1376,7 +1378,7 @@ describe('handlers2d tilemap commands', () => {
       const { store } = await invoke2d(
         'create_tilemap',
         { name: 'World', tilesetAssetId: 'tiles-1', tileSize: [16, 16], mapSize: [30, 20], origin: 'Center' },
-        { primaryId: 'ent-tile2', spawnEntity: vi.fn(), setTilemapData: vi.fn() },
+        { spawnEntity: vi.fn(() => 'ent-tile2'), setTilemapData: vi.fn() },
       );
       expect(store.spawnEntity).toHaveBeenCalledWith('plane', 'World');
       expect(store.setTilemapData).toHaveBeenCalledWith('ent-tile2', expect.objectContaining({
@@ -1391,11 +1393,11 @@ describe('handlers2d tilemap commands', () => {
       expect(result.success).toBe(false);
     });
 
-    it('returns error when spawn returns null primaryId', async () => {
+    it('returns error when spawnEntity returns no id (engine spawn failed)', async () => {
       const { result } = await invoke2d(
         'create_tilemap',
         { tilesetAssetId: 'tiles-1' },
-        { primaryId: null, spawnEntity: vi.fn(), setTilemapData: vi.fn() },
+        { spawnEntity: vi.fn(() => null), setTilemapData: vi.fn() },
       );
       expect(result.success).toBe(false);
     });

--- a/web/src/lib/chat/handlers/__tests__/handlers2d.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/handlers2d.test.ts
@@ -103,6 +103,17 @@ describe('handlers2d sprite edge cases', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Invalid arguments');
     });
+
+    it('rejects non-spawnable entityType "empty" at the schema boundary, not as a phantom spawn failure (#8748)', async () => {
+      // 'empty' is not engine-spawnable (spawnEntity returns undefined for it), so
+      // accepting it in the schema guaranteed a "Failed to get entity ID" runtime
+      // failure for a request the API claimed to accept. It must be rejected up front
+      // like any other unsupported type, and spawnEntity must never be reached.
+      const { result, store } = await invoke('create_sprite', { entityType: 'empty' });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(store.spawnEntity).not.toHaveBeenCalled();
+    });
   });
 
   describe('set_sprite_texture', () => {

--- a/web/src/lib/chat/handlers/__tests__/handlers2d.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/handlers2d.test.ts
@@ -53,10 +53,13 @@ async function invoke(
 
 describe('handlers2d sprite edge cases', () => {
   describe('create_sprite', () => {
-    it('creates with default entity type when none specified', async () => {
-      const { result, store } = await invoke('create_sprite', {}, { primaryId: 'ent-1' });
+    it('creates on a fresh scene (primaryId null) using the id returned by spawnEntity', async () => {
+      const { result, store } = await invoke('create_sprite', {}, { spawnEntity: vi.fn(() => 'ent-1') });
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalled();
+      // primaryId is NOT consulted — it stays null until the async SELECTION_CHANGED
+      // round-trip. Follow-up writes must target the synchronously-returned id.
+      expect(store.primaryId).toBeNull();
       expect(store.setSpriteData).toHaveBeenCalledWith(
         'ent-1',
         expect.objectContaining({ sortingLayer: 'Default', sortingOrder: 0 }),
@@ -74,7 +77,7 @@ describe('handlers2d sprite edge cases', () => {
           sortingLayer: 'Foreground',
           sortingOrder: 5,
         },
-        { primaryId: 'ent-2' },
+        { spawnEntity: vi.fn(() => 'ent-2') },
       );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('sphere', 'MySprite');
@@ -89,8 +92,8 @@ describe('handlers2d sprite edge cases', () => {
       );
     });
 
-    it('fails when primaryId is null after spawn', async () => {
-      const { result } = await invoke('create_sprite', {}, { primaryId: null });
+    it('fails when spawnEntity returns no id (engine spawn failed)', async () => {
+      const { result } = await invoke('create_sprite', {}, { spawnEntity: vi.fn(() => undefined) });
       expect(result.success).toBe(false);
       expect(result.error).toContain('Failed to get entity ID');
     });
@@ -296,14 +299,16 @@ describe('handlers2d tilemap edge cases', () => {
   };
 
   describe('create_tilemap', () => {
-    it('creates tilemap with required params', async () => {
+    it('creates tilemap on a fresh scene using the id returned by spawnEntity', async () => {
       const { result, store } = await invoke(
         'create_tilemap',
         { tilesetAssetId: 'ts-1' },
-        { primaryId: 'tm-1' },
+        { spawnEntity: vi.fn(() => 'tm-1') },
       );
       expect(result.success).toBe(true);
       expect(store.spawnEntity).toHaveBeenCalledWith('plane', expect.any(String));
+      // primaryId stays null on a fresh scene — the returned id is what targets the write.
+      expect(store.primaryId).toBeNull();
       expect(store.setTilemapData).toHaveBeenCalledWith(
         'tm-1',
         expect.objectContaining({ tilesetAssetId: 'ts-1' }),
@@ -314,7 +319,7 @@ describe('handlers2d tilemap edge cases', () => {
       const { result, store } = await invoke(
         'create_tilemap',
         { tilesetAssetId: 'ts-1', tileSize: [16, 16], mapSize: [30, 20], name: 'Ground' },
-        { primaryId: 'tm-2' },
+        { spawnEntity: vi.fn(() => 'tm-2') },
       );
       expect(result.success).toBe(true);
       expect(store.setTilemapData).toHaveBeenCalledWith(
@@ -323,11 +328,11 @@ describe('handlers2d tilemap edge cases', () => {
       );
     });
 
-    it('fails when primaryId is null', async () => {
+    it('fails when spawnEntity returns no id (engine spawn failed)', async () => {
       const { result } = await invoke(
         'create_tilemap',
         { tilesetAssetId: 'ts-1' },
-        { primaryId: null },
+        { spawnEntity: vi.fn(() => undefined) },
       );
       expect(result.success).toBe(false);
     });

--- a/web/src/lib/chat/handlers/__tests__/transformHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/transformHandlers.test.ts
@@ -1,15 +1,59 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { invokeHandler } from './handlerTestUtils';
 import { transformHandlers } from '../transformHandlers';
 
 describe('transformHandlers', () => {
-  it('spawn_entity calls spawnEntity', async () => {
-    const { result, store } = await invokeHandler(transformHandlers, 'spawn_entity', {
-      entityType: 'cube',
-      name: 'MyCube',
-    });
+  it('spawn_entity calls spawnEntity and surfaces the returned id', async () => {
+    const { result, store } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'cube', name: 'MyCube' },
+      { spawnEntity: vi.fn(() => 'cube-1') },
+    );
     expect(result.success).toBe(true);
     expect(store.spawnEntity).toHaveBeenCalledWith('cube', 'MyCube');
+    expect((result.result as { entityId?: string }).entityId).toBe('cube-1');
+  });
+
+  it('spawn_entity returns the id from spawnEntity (not the stale primaryId)', async () => {
+    // #8748: the handler must surface the synchronously-returned id so the
+    // caller can target the new entity. With primaryId left at its default
+    // (null on a fresh scene), the only correct source is spawnEntity's return.
+    const { result } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'cube', name: 'MyCube' },
+      { spawnEntity: vi.fn(() => 'spawned-uuid'), primaryId: null },
+    );
+    expect(result.success).toBe(true);
+    expect((result.result as { entityId?: string }).entityId).toBe('spawned-uuid');
+  });
+
+  it('spawn_entity rejects a non-spawnable type instead of reporting a phantom success (#8748)', async () => {
+    // icosphere/empty/gltf_model are JS-only union members the engine never spawns via
+    // spawn_entity. The schema (derived from SPAWNABLE_ENTITY_TYPES) must reject them
+    // rather than return success with an undefined entityId that follow-up commands
+    // would target in vain.
+    const { result } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'icosphere', name: 'Nope' },
+      { spawnEntity: vi.fn(() => undefined) },
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('spawn_entity fails (not a phantom success) when the engine returns no id', async () => {
+    // A spawnable type whose dispatch produced no entity (engine not loaded yet) must
+    // not report success with an undefined entityId.
+    const { result } = await invokeHandler(
+      transformHandlers,
+      'spawn_entity',
+      { entityType: 'cube', name: 'MyCube' },
+      { spawnEntity: vi.fn(() => undefined) },
+    );
+    expect(result.success).toBe(false);
+    expect((result.result as { entityId?: string } | undefined)?.entityId).toBeUndefined();
   });
 
   it('despawn_entity calls setSelection and deleteSelectedEntities with entityIds array', async () => {

--- a/web/src/lib/chat/handlers/compoundHandlers.ts
+++ b/web/src/lib/chat/handlers/compoundHandlers.ts
@@ -664,8 +664,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         const entType = ent.type as string;
         const entName = ent.name as string;
 
-        ctx.store.spawnEntity(entType as EntityType, entName);
-        const entityId = ctx.store.primaryId;
+        const entityId = ctx.store.spawnEntity(entType as EntityType, entName);
         if (!entityId) throw new Error('spawn failed');
         nameToId[entName] = entityId;
 
@@ -730,8 +729,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
     const results: Array<{ action: string; success: boolean; entityId?: string; error?: string }> = [];
     const nameToId: Record<string, string> = {};
 
-    ctx.store.spawnEntity('cube', levelName);
-    const rootId = ctx.store.primaryId;
+    const rootId = ctx.store.spawnEntity('cube', levelName);
     if (!rootId) return { success: false, error: 'Failed to create level root' };
     nameToId[levelName] = rootId;
     ctx.store.updateTransform(rootId, 'scale', [1, 1, 1]);
@@ -746,15 +744,31 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         if (useTerrain) {
           const terrainConfig = (ground.terrainConfig as Record<string, unknown>) ?? {};
           ctx.store.spawnTerrain(terrainConfig);
+          // KNOWN BUG (#8749): terrain goes through the separate `spawn_terrain`
+          // engine pipeline, not `spawn_entity`/`apply_spawn_requests`, so
+          // `spawnTerrain` does not yet return an id and this `primaryId` read is
+          // the same stale-read defect #8748 fixed for the primitive path — on a
+          // fresh scene `groundId` is null and the terrain ground is silently
+          // dropped. Tracked + scoped in #8749 (extend `spawnTerrain` to return an
+          // id + add the engine-side EntityId override to the terrain path).
           const groundId = ctx.store.primaryId;
           if (groundId) {
             nameToId['Ground'] = groundId;
             ctx.store.reparentEntity(groundId, rootId);
             results.push({ action: 'create terrain ground', success: true, entityId: groundId });
+          } else {
+            // Until #8749 lands, the stale primaryId read above yields null on a
+            // fresh scene. Surface that as an explicit failure instead of
+            // silently omitting the ground op — otherwise the caller sees a
+            // compound result that falsely implies the terrain ground exists.
+            results.push({
+              action: 'create terrain ground',
+              success: false,
+              error: 'terrain spawn id unavailable before #8749 — ground not parented',
+            });
           }
         } else {
-          ctx.store.spawnEntity('plane', 'Ground');
-          const groundId = ctx.store.primaryId;
+          const groundId = ctx.store.spawnEntity('plane', 'Ground');
           if (groundId) {
             nameToId['Ground'] = groundId;
             ctx.store.updateTransform(groundId, 'scale', [width / 2, 1, depth / 2]);
@@ -785,8 +799,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
 
         const geom = wallFromStartEnd(start, end, height, thickness);
 
-        ctx.store.spawnEntity('cube', name);
-        const wallId = ctx.store.primaryId;
+        const wallId = ctx.store.spawnEntity('cube', name);
         if (wallId) {
           nameToId[name] = wallId;
           ctx.store.updateTransform(wallId, 'position', geom.position);
@@ -817,8 +830,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         const position = obstacle.position as [number, number, number];
         const scale = obstacle.scale as [number, number, number] | undefined;
 
-        ctx.store.spawnEntity(obstType as EntityType, obstName);
-        const obstId = ctx.store.primaryId;
+        const obstId = ctx.store.spawnEntity(obstType as EntityType, obstName);
         if (obstId) {
           nameToId[obstName] = obstId;
           ctx.store.updateTransform(obstId, 'position', position);
@@ -856,8 +868,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         const spName = (sp.name as string) ?? (isPlayerSpawn ? 'PlayerSpawn' : `SpawnPoint_${i}`);
         const position = sp.position as [number, number, number];
 
-        ctx.store.spawnEntity('sphere', spName);
-        const spId = ctx.store.primaryId;
+        const spId = ctx.store.spawnEntity('sphere', spName);
         if (spId) {
           nameToId[spName] = spId;
           ctx.store.updateTransform(spId, 'position', position);
@@ -882,8 +893,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         const position = goal.position as [number, number, number];
         const goalType = (goal.type as string) ?? 'reach';
 
-        ctx.store.spawnEntity('sphere', goalName);
-        const goalId = ctx.store.primaryId;
+        const goalId = ctx.store.spawnEntity('sphere', goalName);
         if (goalId) {
           nameToId[goalName] = goalId;
           ctx.store.updateTransform(goalId, 'position', position);
@@ -938,8 +948,7 @@ export const compoundHandlers: Record<string, ToolHandler> = {
     const nameToId: Record<string, string> = {};
 
     try {
-      ctx.store.spawnEntity(entityType as EntityType, charName);
-      const charId = ctx.store.primaryId;
+      const charId = ctx.store.spawnEntity(entityType as EntityType, charName);
       if (!charId) throw new Error('Character spawn failed');
       nameToId[charName] = charId;
 

--- a/web/src/lib/chat/handlers/gameplayHandlers.ts
+++ b/web/src/lib/chat/handlers/gameplayHandlers.ts
@@ -327,17 +327,27 @@ export const gameplayHandlers: Record<string, ToolHandler> = {
     const prefab = getPrefab(p.data.prefabId);
     if (!prefab) return { success: false, error: `Prefab not found: ${p.data.prefabId}` };
 
-    ctx.store.spawnEntity(prefab.snapshot.entityType as EntityType, p.data.name || prefab.snapshot.name);
-
-    if (prefab.snapshot.material && ctx.store.primaryId) {
-      ctx.store.updateMaterial(ctx.store.primaryId, prefab.snapshot.material);
+    const entityId = ctx.store.spawnEntity(prefab.snapshot.entityType as EntityType, p.data.name || prefab.snapshot.name);
+    if (!entityId) {
+      // spawnEntity returns undefined for a non-spawnable entityType (imported prefabs
+      // carry an unvalidated `entityType: string`) or when the engine isn't loaded yet.
+      // Report a real failure rather than a phantom success that claims the prefab was
+      // instantiated while no entity was created and no material/transform applied (#8748).
+      return {
+        success: false,
+        error: `Cannot instantiate prefab "${prefab.name}": '${prefab.snapshot.entityType}' is not a spawnable type or the engine is not ready`,
+      };
     }
 
-    if (p.data.position && ctx.store.primaryId) {
-      ctx.store.updateTransform(ctx.store.primaryId, 'position', p.data.position);
+    if (prefab.snapshot.material) {
+      ctx.store.updateMaterial(entityId, prefab.snapshot.material);
     }
 
-    return { success: true, result: { message: `Instantiated prefab "${prefab.name}"` } };
+    if (p.data.position) {
+      ctx.store.updateTransform(entityId, 'position', p.data.position);
+    }
+
+    return { success: true, result: { message: `Instantiated prefab "${prefab.name}"`, entityId } };
   },
 
   list_prefabs: async (args, _ctx) => {

--- a/web/src/lib/chat/handlers/handlers2d.ts
+++ b/web/src/lib/chat/handlers/handlers2d.ts
@@ -147,7 +147,11 @@ const zBone2dDef = z.object({
 // Sprite Commands
 // ---------------------------------------------------------------------------
 
-const ENTITY_TYPES_2D = ['plane', 'cube', 'sphere', 'cylinder', 'capsule', 'empty'] as const;
+// Only engine-spawnable carrier meshes for a 2D sprite. 'empty' was accepted here
+// but is not spawnable (spawnEntity returns undefined for it), so create_sprite with
+// entityType:'empty' was a guaranteed "Failed to get entity ID" failure for a request
+// the schema claimed to accept (#8748). Keep this list a subset of SPAWNABLE_ENTITY_TYPES.
+const ENTITY_TYPES_2D = ['plane', 'cube', 'sphere', 'cylinder', 'capsule'] as const;
 
 const spriteHandlers: Record<string, ToolHandler> = {
   create_sprite: async (args, ctx): Promise<ExecutionResult> => {

--- a/web/src/lib/chat/handlers/handlers2d.ts
+++ b/web/src/lib/chat/handlers/handlers2d.ts
@@ -167,9 +167,7 @@ const spriteHandlers: Record<string, ToolHandler> = {
 
       const { entityType = 'plane', name, position, textureAssetId, sortingLayer, sortingOrder } = p.data;
 
-      ctx.store.spawnEntity(entityType as Parameters<typeof ctx.store.spawnEntity>[0], name);
-
-      const entityId = ctx.store.primaryId;
+      const entityId = ctx.store.spawnEntity(entityType as Parameters<typeof ctx.store.spawnEntity>[0], name);
       if (!entityId) {
         return { success: false, error: 'Failed to get entity ID after spawn' };
       }
@@ -657,8 +655,7 @@ const tilemapHandlers: Record<string, ToolHandler> = {
 
       const { name, tilesetAssetId, tileSize, mapSize, origin = 'TopLeft' } = p.data;
 
-      ctx.store.spawnEntity('plane', name ?? 'Tilemap');
-      const entityId = ctx.store.primaryId;
+      const entityId = ctx.store.spawnEntity('plane', name ?? 'Tilemap');
       if (!entityId) {
         return { success: false, error: 'Failed to get entity ID after spawn' };
       }

--- a/web/src/lib/chat/handlers/transformHandlers.ts
+++ b/web/src/lib/chat/handlers/transformHandlers.ts
@@ -7,22 +7,33 @@ import type { ToolHandler } from './types';
 import { zEntityId, zXYZ, zSelectionMode, zGizmoMode, zCameraPreset, parseArgs } from './types';
 import { parseHandlerArgs } from '@/lib/validation/parseArgs';
 import { entityId, enumValue, boundedString } from '@/lib/validation/validators';
+import { SPAWNABLE_ENTITY_TYPES } from '@/stores/slices/sceneGraphSlice';
 
-const ENTITY_TYPES = [
-  'cube', 'sphere', 'cylinder', 'capsule', 'torus', 'plane', 'cone', 'icosphere',
-  'point_light', 'directional_light', 'spot_light', 'gltf_model', 'empty',
-] as const;
+// The accepted entity types for `spawn_entity` are derived from the single source of
+// truth — SPAWNABLE_ENTITY_TYPES — so this tool's schema can never drift from what the
+// engine's `apply_spawn_requests` actually spawns. JS-only union members like
+// icosphere/empty/gltf_model are created through other pipelines and hit a `continue`
+// arm in the engine, so accepting them here would report a phantom success for an
+// entity that was never created (#8748).
+const SPAWNABLE_TYPES = [...SPAWNABLE_ENTITY_TYPES];
 
 export const transformHandlers: Record<string, ToolHandler> = {
   // Uses shared validation framework (parseHandlerArgs) instead of Zod
   spawn_entity: async (args, { store }) => {
     const p = parseHandlerArgs(args, {
-      entityType: { validate: enumValue(ENTITY_TYPES) },
+      entityType: { validate: enumValue(SPAWNABLE_TYPES) },
       name: { validate: boundedString(1, 128), optional: true },
     });
     if (p.error) return p.error;
-    store.spawnEntity(p.data.entityType, p.data.name);
-    return { success: true, result: { message: `Spawned ${p.data.entityType}` } };
+    const newId = store.spawnEntity(p.data.entityType, p.data.name);
+    if (!newId) {
+      // The schema already rejects non-spawnable types, so a falsy id here means the
+      // engine has not finished loading (no dispatcher yet). Surface a real failure
+      // rather than a phantom success with an undefined entityId that follow-up
+      // commands would target in vain (#8748).
+      return { success: false, error: `Cannot spawn '${p.data.entityType}': the engine is not ready yet` };
+    }
+    return { success: true, result: { message: `Spawned ${p.data.entityType}`, entityId: newId } };
   },
 
   despawn_entity: async (args, { store }) => {

--- a/web/src/stores/editorStore.test.ts
+++ b/web/src/stores/editorStore.test.ts
@@ -634,13 +634,17 @@ describe('editorStore', () => {
   });
 
   describe('Entity CRUD', () => {
-    it('spawnEntity dispatches spawn_entity', () => {
+    it('spawnEntity dispatches spawn_entity with a generated id and returns it', () => {
       const state = useEditorStore.getState();
-      state.spawnEntity('cube', 'MyCube');
+      const returnedId = state.spawnEntity('cube', 'MyCube');
 
+      // #8748: the id is generated client-side, passed into the command, and
+      // returned synchronously so callers never read the async-updated primaryId.
+      expect(typeof returnedId).toBe('string');
       expect(mockDispatch).toHaveBeenCalledWith('spawn_entity', {
         entityType: 'cube',
         name: 'MyCube',
+        id: returnedId,
       });
     });
 

--- a/web/src/stores/slices/__tests__/sceneGraphSlice.spawnableParity.test.ts
+++ b/web/src/stores/slices/__tests__/sceneGraphSlice.spawnableParity.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { SPAWNABLE_ENTITY_TYPES } from '../sceneGraphSlice';
+
+/**
+ * Parity guard for #8748.
+ *
+ * `spawnEntity` only dispatches `spawn_entity` (and returns a usable id) for the
+ * entity types the engine's `apply_spawn_requests` actually spawns. That JS
+ * allow-list, `SPAWNABLE_ENTITY_TYPES`, is hand-maintained in `sceneGraphSlice.ts`
+ * and a comment claims it is "kept in sync" with the Rust match arms — but nothing
+ * enforced that. A future engineer adding (or removing) a `spawn_*_with_id` arm in
+ * Rust without touching the TS set would silently desync the two: either a newly
+ * spawnable type returns `undefined` (spawns the caller can't reference) or a
+ * removed type returns a phantom id (follow-up commands target a non-existent
+ * entity). This test mirrors the Rust arms and fails on any diff, turning a silent
+ * desync into a red build.
+ */
+describe('SPAWNABLE_ENTITY_TYPES ↔ engine apply_spawn_requests parity', () => {
+  // web/ is the vitest cwd; the engine source lives at the repo/worktree root.
+  const entityFactoryPath = resolve(process.cwd(), '..', 'engine', 'src', 'core', 'entity_factory.rs');
+
+  function pascalToSnake(variant: string): string {
+    return variant
+      .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2') // ABCFoo -> ABC_Foo (acronym boundary)
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2') // fooBar -> foo_Bar
+      .toLowerCase();
+  }
+
+  it('the engine source file exists where this test expects it', () => {
+    expect(
+      existsSync(entityFactoryPath),
+      `Expected engine source at ${entityFactoryPath}. If the engine moved, update this parity test ` +
+        `so it keeps guarding the SPAWNABLE_ENTITY_TYPES ↔ apply_spawn_requests contract (#8748).`,
+    ).toBe(true);
+  });
+
+  it('the JS spawnable set exactly equals the engine spawn arms (no silent desync)', () => {
+    const src = readFileSync(entityFactoryPath, 'utf8');
+
+    // Every spawnable arm has the shape `EntityType::Variant => spawn_<x>_with_id(`.
+    // The `continue` arms (Sprite, GltfModel|GltfMesh, CsgResult, Terrain,
+    // ProceduralMesh) have no `spawn_*_with_id` call and are correctly excluded.
+    const matches = [...src.matchAll(/EntityType::(\w+)\s*=>\s*spawn_\w+_with_id\b/g)];
+    const engineSpawnable = new Set(matches.map((m) => pascalToSnake(m[1])));
+
+    // Guard against a regex that silently matches nothing (which would otherwise
+    // make a shrunk JS set falsely "pass" against an empty engine set).
+    expect(engineSpawnable.size).toBeGreaterThan(0);
+
+    const jsSpawnable = new Set(SPAWNABLE_ENTITY_TYPES);
+
+    // Deterministic, diff-friendly comparison.
+    const sorted = (s: Set<string>) => [...s].sort();
+    expect(
+      sorted(jsSpawnable),
+      'SPAWNABLE_ENTITY_TYPES in web/src/stores/slices/sceneGraphSlice.ts is out of sync ' +
+        'with the spawn_*_with_id arms in engine/src/core/entity_factory.rs (#8748). ' +
+        'Add/remove the listed type(s) in SPAWNABLE_ENTITY_TYPES to match the engine.',
+    ).toEqual(sorted(engineSpawnable));
+  });
+});

--- a/web/src/stores/slices/__tests__/sceneGraphSlice.test.ts
+++ b/web/src/stores/slices/__tests__/sceneGraphSlice.test.ts
@@ -141,15 +141,52 @@ describe('sceneGraphSlice', () => {
   });
 
   describe('spawnEntity', () => {
-    it('should dispatch spawn_entity for non-terrain types', () => {
-      store.getState().spawnEntity('cube', 'MyCube');
-      expect(mockDispatch).toHaveBeenCalledWith('spawn_entity', { entityType: 'cube', name: 'MyCube' });
+    it('should dispatch spawn_entity with a generated id and return it synchronously', () => {
+      // The fresh-scene stale-primaryId bug (#8748) is fixed by generating the
+      // entity id client-side, passing it into the command, AND returning it so
+      // callers never have to read the async-updated primaryId.
+      const returnedId = store.getState().spawnEntity('cube', 'MyCube');
+      expect(typeof returnedId).toBe('string');
+      // RFC-4122 v4 UUID shape
+      expect(returnedId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+      expect(mockDispatch).toHaveBeenCalledWith('spawn_entity', {
+        entityType: 'cube',
+        name: 'MyCube',
+        id: returnedId,
+      });
     });
 
-    it('should call spawnTerrain for terrain type', () => {
-      store.getState().spawnEntity('terrain');
+    it('should call spawnTerrain for terrain type and return undefined', () => {
+      const returnedId = store.getState().spawnEntity('terrain');
       expect(spawnTerrainMock).toHaveBeenCalled();
+      expect(returnedId).toBeUndefined();
       expect(mockDispatch).not.toHaveBeenCalledWith('spawn_entity', expect.anything());
+    });
+
+    // The engine's apply_spawn_requests only spawns primitive mesh/light types
+    // via the spawn_entity command; sprite/gltf/csg/procedural/empty/icosphere
+    // are created through other pipelines and would be silently dropped (a
+    // `continue` arm), leaving a phantom id. spawnEntity must return undefined
+    // for those so a caller's `if (!entityId)` guard surfaces a real failure
+    // instead of dispatching follow-up commands against a non-existent entity.
+    it.each(['sprite', 'gltf_model', 'csg_result', 'procedural_mesh', 'empty', 'icosphere'] as const)(
+      'should NOT dispatch and should return undefined for non-spawnable type %s',
+      (type) => {
+        const returnedId = store.getState().spawnEntity(type);
+        expect(returnedId).toBeUndefined();
+        expect(mockDispatch).not.toHaveBeenCalledWith('spawn_entity', expect.anything());
+      },
+    );
+
+    it('should return undefined (not a phantom id) when the engine dispatcher is not yet set', () => {
+      // During the engine-loading window `dispatchCommand` is null. Returning a
+      // freshly-minted UUID there would be a phantom reference — the command was
+      // never sent, so no entity exists, yet a caller's `if (!entityId)` guard
+      // would see a truthy id and queue follow-up commands against nothing.
+      // spawnEntity must return undefined so callers treat it as a real failure.
+      setSceneGraphDispatcher(null as unknown as (command: string, payload: unknown) => void);
+      const returnedId = store.getState().spawnEntity('cube', 'MyCube');
+      expect(returnedId).toBeUndefined();
     });
   });
 

--- a/web/src/stores/slices/sceneGraphSlice.ts
+++ b/web/src/stores/slices/sceneGraphSlice.ts
@@ -40,7 +40,17 @@ export interface SceneGraphSlice {
 
   toggleVisibility: (entityId: string) => void;
   renameEntity: (entityId: string, newName: string) => void;
-  spawnEntity: (type: EntityType, name?: string) => void;
+  /**
+   * Spawn a new entity. Returns the new entity's id **synchronously** so callers
+   * can immediately target it (transform/material/physics/reparent) without
+   * waiting for the async SELECTION_CHANGED round-trip. Returns `undefined` when
+   * no entity was spawned: the terrain path (handled by `spawnTerrain`), an
+   * entity type the engine does not spawn (see `SPAWNABLE_ENTITY_TYPES`), or when
+   * the engine isn't loaded yet (`dispatchCommand` is null). Callers MUST guard on
+   * the result. Do NOT read `primaryId` after calling this — it is not updated
+   * until the engine emits SELECTION_CHANGED.
+   */
+  spawnEntity: (type: EntityType, name?: string) => string | undefined;
   deleteSelectedEntities: () => void;
   duplicateSelectedEntity: () => void;
   reparentEntity: (
@@ -49,6 +59,30 @@ export interface SceneGraphSlice {
     insertIndex?: number
   ) => void;
 }
+
+/**
+ * Entity types the engine's `apply_spawn_requests` actually spawns in response
+ * to a `spawn_entity` command. Every other `EntityType` (sprite, gltf, csg,
+ * procedural, empty, icosphere, terrain) is created through a different
+ * pipeline and is silently dropped by that system, so dispatching a
+ * `spawn_entity` for one and returning a generated id would yield a phantom
+ * reference. Kept in sync with the spawn arms in
+ * `engine/src/core/entity_factory.rs`. Enforced by
+ * `__tests__/sceneGraphSlice.spawnableParity.test.ts`, which fails the build on
+ * any desync — update both sides together.
+ */
+export const SPAWNABLE_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>([
+  'cube',
+  'sphere',
+  'plane',
+  'cylinder',
+  'cone',
+  'torus',
+  'capsule',
+  'point_light',
+  'directional_light',
+  'spot_light',
+]);
 
 // Internal dispatcher reference
 let dispatchCommand: ((command: string, payload: unknown) => void) | null = null;
@@ -226,11 +260,35 @@ export const createSceneGraphSlice: StateCreator<
   spawnEntity: (type, name) => {
     if (type === 'terrain') {
       get().spawnTerrain();
-      return;
+      return undefined;
     }
+    // The engine's `apply_spawn_requests` only spawns the primitive mesh/light
+    // types in SPAWNABLE_ENTITY_TYPES via the spawn_entity command. Every other
+    // EntityType (sprite, gltf, csg, procedural, empty, icosphere) is created
+    // through a different pipeline and hits a `continue` arm there — the command
+    // is silently dropped and no entity is created. Returning a generated id for
+    // one of those would be a phantom reference that follow-up commands target
+    // in vain, so return undefined and let the caller's `if (!entityId)` guard
+    // surface a real failure instead of dispatching against a missing entity.
+    if (!SPAWNABLE_ENTITY_TYPES.has(type)) {
+      return undefined;
+    }
+    // Generate the id client-side and pass it to the engine, which overrides
+    // the spawned entity's EntityId to match. This lets the caller reference
+    // the entity synchronously — `primaryId` is only set later by the async
+    // SELECTION_CHANGED event, so reading it right after spawn is stale.
+    //
+    // Only return the id when we actually dispatched the command. When the
+    // engine isn't loaded yet `dispatchCommand` is null — returning a fresh id
+    // there would be a phantom reference (no entity was created), defeating
+    // every caller's `if (!entityId)` guard. Return undefined so callers treat
+    // it as a real failure, matching the pre-fix `void` contract.
     if (dispatchCommand) {
-      dispatchCommand('spawn_entity', { entityType: type, name });
+      const id = crypto.randomUUID();
+      dispatchCommand('spawn_entity', { entityType: type, name, id });
+      return id;
     }
+    return undefined;
   },
 
   deleteSelectedEntities: () => {


### PR DESCRIPTION
## Summary

AI-driven "spawn then transform/material" commands silently failed on a fresh scene and mis-targeted otherwise. Chat/compound/2D handlers called `store.spawnEntity()` (which returned `void`) then synchronously read `store.primaryId` to target the new entity — but `primaryId` is only set later by the async, microtask-batched `SELECTION_CHANGED` event, which is **never emitted on spawn**. So on a fresh scene `primaryId` was `null` (every spawn reported a **phantom success** against an `undefined` id), and otherwise the follow-up command targeted the *previously selected* entity.

This is a core-journey blocker for the AI game-creation flow (milestone E1): "make a red cube and move it up" could not work from an empty scene.

## Fix (root cause + every call site)

- **JS `spawnEntity` now returns `string | undefined` synchronously.** It generates `crypto.randomUUID()`, passes it as the optional `id` on the `spawn_entity` command, and returns it — only when a dispatcher actually exists. Returns `undefined` for terrain (handled by `spawnTerrain`), non-spawnable types, or a null dispatcher.
- **Engine `apply_spawn_requests` overrides the spawned `EntityId`** to the provided id when `is_valid_override_id` passes (trimmed, non-empty, ≤64 bytes, no control chars); otherwise it keeps its own generated UUID. (`SpawnEntityPayload`/`SpawnRequest` gained `id: Option<String>`.)
- **Every call site guards the falsy return** and reports a real failure instead of `{ success: true, entityId: undefined }`. This eliminates the phantom-success defect class across `transformHandlers`, `compoundHandlers`, `handlers2d`, and `gameplayHandlers` (`instantiate_prefab`).
- **`SPAWNABLE_ENTITY_TYPES`** is the single source of truth for the 10 spawnable engine types; `spawn_entity`'s schema is derived from it, and a new parity test (`sceneGraphSlice.spawnableParity.test.ts`) fails the build on any desync with the engine's spawn arms.

Terrain spawn-id follow-up is tracked separately as #8749 (the terrain branch reports an explicit failure referencing it rather than a phantom success).

## Test plan

- [x] `transformHandlers` / `audioPhysicsGameHandlers` / `sceneGraphSlice` / parity / `compoundHandlers` / `handlers2d` / `exportAsset2dHandlers` / `editorStore` / `scene-crud` vitest suites — all green (fresh-scene null-`primaryId` path, non-spawnable rejection, null-dispatcher failure, and `instantiate_prefab` no-partial-mutation failure path all asserted)
- [x] `eslint --max-warnings 0` on all touched files — clean
- [x] `tsc --noEmit` — clean
- [x] Native engine `spawn_id_tests` (5) cover the id-override + validation boundary (CI rebuilds WASM)
- [x] 5-reviewer board (architect, security, dx, test-writer; ux N/A — no UI) — all PASS

Closes #8748