### PR TITLE
fix(editor): mount useScriptRunner so entity scripts run in Play mode

### DIFF
--- a/.changeset/mount-script-runner.md
+++ b/.changeset/mount-script-runner.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Mount `useScriptRunner` in the editor canvas so user entity scripts actually run when the game enters Play mode. The hook that registers the per-frame play-tick callback was never mounted by any component, so pressing Play rendered the scene but executed none of the user's scripts. The hook self-gates on `engineMode === 'play'`, so it stays inert in Edit mode.

--- a/web/src/components/editor/CanvasArea.tsx
+++ b/web/src/components/editor/CanvasArea.tsx
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 import { useViewport } from '@/hooks/useViewport';
 import { useEngineEvents } from '@/hooks/useEngineEvents';
+import { useScriptRunner } from '@/lib/scripting/useScriptRunner';
 import { usePointerLock } from '@/hooks/usePointerLock';
 import { getWasmModule } from '@/hooks/useEngine';
 import { useEditorStore } from '@/stores/editorStore';
@@ -53,6 +54,13 @@ export function CanvasArea() {
 
   // Connect engine events to Zustand store
   useEngineEvents({ wasmModule: getWasmModule() });
+
+  // Drive user entity scripts in Play mode. The hook self-gates on
+  // engineMode==='play' (no worker is spawned in Edit mode), so mounting it
+  // unconditionally here is safe — and it is the ONLY place that registers the
+  // per-frame play-tick callback. Without this mount, pressing Play renders the
+  // scene but runs none of the user's scripts (#8751).
+  useScriptRunner({ wasmModule: getWasmModule() });
 
   // Pointer lock for FirstPerson camera mouse look
   usePointerLock(CANVAS_ID);

--- a/web/src/components/editor/__tests__/CanvasArea.test.tsx
+++ b/web/src/components/editor/__tests__/CanvasArea.test.tsx
@@ -28,6 +28,12 @@ vi.mock('@/hooks/useEngineEvents', () => ({
   useEngineEvents: vi.fn(),
 }));
 
+vi.mock('@/lib/scripting/useScriptRunner', () => ({
+  useScriptRunner: vi.fn(),
+  // Preserve the module's other export so any indirect consumer keeps its shape.
+  getScriptCollisionCallback: vi.fn(),
+}));
+
 vi.mock('@/hooks/usePointerLock', () => ({
   usePointerLock: vi.fn(),
 }));
@@ -55,6 +61,7 @@ vi.mock('../ui-builder/UIRuntimeRenderer', () => ({
 
 import { useEditorStore } from '@/stores/editorStore';
 import { useViewport } from '@/hooks/useViewport';
+import { useScriptRunner } from '@/lib/scripting/useScriptRunner';
 
 function mockEditorStore(overrides: Record<string, unknown> = {}) {
   const state: Record<string, unknown> = {
@@ -81,6 +88,25 @@ describe('CanvasArea', () => {
     const canvas = container.querySelector('canvas');
     expect(canvas).toBeInTheDocument();
     expect(canvas?.id).toBe('game-canvas');
+  });
+
+  it('mounts useScriptRunner so user entity scripts run in Play mode (#8751)', () => {
+    // The per-frame play-tick callback that drives user entity scripts is
+    // registered only while useScriptRunner is mounted. If CanvasArea never
+    // mounts it, pressing Play renders the scene but executes none of the
+    // user's scripts — the core journey silently breaks at the Play step. The
+    // hook self-gates on engineMode==='play', so an unconditional mount in the
+    // editor canvas is safe (it no-ops in Edit mode).
+    mockEditorStore();
+    render(<CanvasArea />);
+    expect(useScriptRunner).toHaveBeenCalledWith({
+      wasmModule: { handle_command: mockHandleCommand },
+    });
+    // Exactly once — the play-tick callback must be registered a single time.
+    // CanvasArea is rendered once in the editor (mutually-exclusive compact and
+    // desktop layout branches), so a second call would signal an accidental
+    // double-mount and double registration.
+    expect(useScriptRunner).toHaveBeenCalledTimes(1);
   });
 
   it('does not show dimension indicator when not ready', () => {


### PR DESCRIPTION
## Summary
`useScriptRunner` is the React hook that registers the engine's per-frame play-tick callback (`setPlayTickCallback`) — the single mechanism that executes user-authored **entity scripts** while the game is in Play mode. It was imported by **zero** components (only the sibling export `getScriptCollisionCallback` was consumed, in `physicsEvents.ts`), so `_playTickCallback` stayed `null` and pressing **Play** rendered the scene but ran **none** of the user's scripts. This silently broke the core journey at the Play step.

This mounts the hook in `CanvasArea` directly beside the existing `useEngineEvents({ wasmModule: getWasmModule() })` call — the established home for editor-viewport engine hooks. The hook self-gates on `engineMode === 'play'` (no worker is spawned, no callback registered, in Edit mode) and tears down cleanly on edit/unmount, so the unconditional mount is safe.

## Why CanvasArea
- `useEngineEvents` already lives here and uses the identical `getWasmModule()` wiring — this mirrors it exactly.
- `CanvasArea` renders exactly once in the editor (mutually-exclusive compact and desktop layout branches), so the play-tick callback is registered exactly once. `setPlayTickCallback` has no other caller in the codebase, so there is no double-registration path.
- `getWasmModule()` is an allocation-free module-level singleton getter; calling it twice per render is free.

## Test plan
- [x] TDD: new regression test in `CanvasArea.test.tsx` asserts `useScriptRunner` is mounted with the wasm module **exactly once** (RED before the mount, GREEN after).
- [x] Full `CanvasArea.test.tsx` suite green (24/24) — the added `vi.mock` does not disturb the existing 23 tests.
- [x] `eslint --max-warnings 0` + `tsc --noEmit` clean.
- [x] Review board (code-architect + test-writer): both PASS — confirmed single-mount, leak-free Edit-mode lifecycle, no other registration site, genuine regression guard.

Closes #8751