### PR TITLE
fix(generate): sprite status route returns failed on succeeded-empty (no 5-min hang)

### DIFF
--- a/.changeset/sprite-status-succeeded-empty.md
+++ b/.changeset/sprite-status-succeeded-empty.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Fix sprite generation status route hanging for 5 minutes on an empty Replicate result. When Replicate reports `succeeded` with no output image, the route now returns `failed` with a clear "produced no image" message so the client refunds immediately instead of polling to the timeout cap.

--- a/web/src/app/api/generate/sprite/status/route.test.ts
+++ b/web/src/app/api/generate/sprite/status/route.test.ts
@@ -92,9 +92,11 @@ describe('GET /api/generate/sprite/status', () => {
     const data = await res.json();
 
     expect(res.status).toBe(200);
+    expect(data.jobId).toBe('pred_abc123');
     expect(data.status).toBe('completed');
     expect(data.resultUrl).toBe('https://replicate.delivery/result.png');
     expect(data.progress).toBe(100);
+    expect(data.error).toBeUndefined();
   });
 
   it('returns failed status when prediction failed', async () => {
@@ -107,8 +109,68 @@ describe('GET /api/generate/sprite/status', () => {
     const data = await res.json();
 
     expect(res.status).toBe(200);
+    expect(data.jobId).toBe('pred_abc123');
     expect(data.status).toBe('failed');
-    expect(data.error).toBeDefined();
+    expect(data.error).toBe('Sprite generation failed');
+    expect(data.resultUrl).toBeUndefined();
+    expect(data.progress).toBe(10);
+  });
+
+  it('maps canceled predictions to failed', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
+    vi.mocked(resolveApiKey).mockResolvedValue({ type: 'platform', key: 'rp_key', metered: true });
+    mockGetReplicateStatus.mockResolvedValue({ status: 'canceled', output: undefined });
+
+    const res = await GET(makeRequest({ jobId: 'pred_abc123' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe('failed');
+    expect(data.error).toBe('Sprite generation failed');
+    expect(data.progress).toBe(10);
+  });
+
+  it('maps succeeded-with-no-output to failed (so the poller refunds, not hangs)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
+    vi.mocked(resolveApiKey).mockResolvedValue({ type: 'platform', key: 'rp_key', metered: true });
+    // Replicate reports success but produced no image URL. Mapping this to
+    // `completed` hands the client a completed job with no resultUrl, which throws
+    // an uncaught "No result URL" in useGenerationPolling — the job then sticks in
+    // `downloading` for the full 5-minute poll cap before refunding with a generic
+    // timeout (#8757). The route must surface it as `failed` so the poller refunds
+    // immediately with a meaningful error.
+    mockGetReplicateStatus.mockResolvedValue({ status: 'succeeded', output: [] });
+
+    const res = await GET(makeRequest({ jobId: 'pred_abc123' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe('failed');
+    expect(data.resultUrl).toBeUndefined();
+    expect(data.progress).toBe(10);
+    expect(data.error).toBe('Sprite generation produced no image');
+  });
+
+  it('does not leak a resultUrl while still processing', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
+    vi.mocked(resolveApiKey).mockResolvedValue({ type: 'platform', key: 'rp_key', metered: true });
+    // Replicate can populate `output` before status flips to succeeded; the route
+    // must gate resultUrl on completion so the client doesn't import a partial image.
+    mockGetReplicateStatus.mockResolvedValue({
+      status: 'processing',
+      output: ['https://replicate.delivery/partial.png'],
+    });
+
+    const res = await GET(makeRequest({ jobId: 'pred_abc123' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.status).toBe('processing');
+    expect(data.resultUrl).toBeUndefined();
+    expect(data.error).toBeUndefined();
   });
 
   it('returns processing status for in-progress prediction', async () => {

--- a/web/src/app/api/generate/sprite/status/route.test.ts
+++ b/web/src/app/api/generate/sprite/status/route.test.ts
@@ -187,6 +187,27 @@ describe('GET /api/generate/sprite/status', () => {
     expect(data.progress).toBe(50);
   });
 
+  it('returns pending status for a freshly-started prediction', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
+    vi.mocked(resolveApiKey).mockResolvedValue({ type: 'platform', key: 'rp_key', metered: true });
+    // Replicate predictions begin in `starting` (and may sit in `queued`) before
+    // flipping to `processing`. Both fall through to the else branch → `pending`
+    // at progress 10. Guards against a regression that mis-buckets `starting`
+    // into the `processing` branch (progress 50).
+    mockGetReplicateStatus.mockResolvedValue({ status: 'starting', output: undefined });
+
+    const res = await GET(makeRequest({ jobId: 'pred_abc123' }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.jobId).toBe('pred_abc123');
+    expect(data.status).toBe('pending');
+    expect(data.progress).toBe(10);
+    expect(data.resultUrl).toBeUndefined();
+    expect(data.error).toBeUndefined();
+  });
+
   it('returns 500 if client throws unexpectedly', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });

--- a/web/src/app/api/generate/sprite/status/route.ts
+++ b/web/src/app/api/generate/sprite/status/route.ts
@@ -55,8 +55,20 @@ export async function GET(request: NextRequest) {
     const result = await client.getReplicateStatus(jobId);
 
     let mappedStatus: 'pending' | 'processing' | 'completed' | 'failed';
+    let succeededButEmpty = false;
     if (result.status === 'succeeded') {
-      mappedStatus = 'completed';
+      // Replicate can report `succeeded` with an empty output array. Mapping that
+      // to `completed` hands useGenerationPolling a completed job with no
+      // resultUrl, which throws an uncaught "No result URL" — the job then sticks
+      // in `downloading` for the full 5-minute poll cap before refunding with a
+      // generic timeout (#8757). Surface it as `failed` so the poller refunds
+      // immediately with a meaningful error. Mirrors the pixel-art status route.
+      if (result.output?.length) {
+        mappedStatus = 'completed';
+      } else {
+        mappedStatus = 'failed';
+        succeededButEmpty = true;
+      }
     } else if (result.status === 'failed' || result.status === 'canceled') {
       mappedStatus = 'failed';
     } else if (result.status === 'processing') {
@@ -74,7 +86,9 @@ export async function GET(request: NextRequest) {
       status: mappedStatus,
       progress: mappedStatus === 'completed' ? 100 : mappedStatus === 'processing' ? 50 : 10,
       resultUrl,
-      error: mappedStatus === 'failed' ? 'Sprite generation failed' : undefined,
+      error: mappedStatus === 'failed'
+        ? (succeededButEmpty ? 'Sprite generation produced no image' : 'Sprite generation failed')
+        : undefined,
     });
   } catch (err) {
     captureException(err, { route: '/api/generate/sprite/status', jobId });


### PR DESCRIPTION
## Summary

The sprite generation status route polls Replicate. Replicate can report a prediction as `succeeded` with an **empty `output` array**. The route mapped `succeeded` → `completed` unconditionally while gating `resultUrl` on `result.output?.length`, producing `{ status: 'completed', resultUrl: undefined }`.

Downstream, `useGenerationPolling` enters its completed branch, throws an uncaught `'No result URL'`, and sticks the job in `downloading` until the 5-minute poll cap — then refunds with a generic `'Generation timed out'`. Net user experience: a ~5-minute hang on the sprite generation panel followed by an unhelpful error, despite the refund eventually landing.

This fix maps succeeded-with-empty-output → `failed` with a distinct `'Sprite generation produced no image'` message, so the poller takes its `failed` branch and refunds **immediately** with an accurate message. It mirrors the already-shipped pixel-art status route fix (#8756).

Route-mapping change only — `SpriteClient.getReplicateStatus` is already SSRF-safe (validates + percent-encodes + anchored URL), so no client change was needed.

## Changes
- `succeeded` + non-empty output → `completed` (unchanged)
- `succeeded` + empty/absent output → `failed`, error `'Sprite generation produced no image'` (new)
- `failed`/`canceled` → `failed`, error `'Sprite generation failed'` (unchanged)
- `resultUrl` remains gated on completion (no partial-image leak)
- `dalle3:` synchronous-completion prefix branch preserved untouched

## Test plan
- [x] TDD: added succeeded-empty→failed (the regression), canceled→failed, no-resultUrl-leak-while-processing, and starting→pending cases
- [x] `vitest run src/app/api/generate/sprite/status/route.test.ts` — 12/12 green
- [x] ESLint clean on changed files
- [x] Review board: code-architect PASS, test-writer PASS (after adding the starting→pending parity case)

Closes #8757