### PR TITLE
refactor(export): extract shared game-loop fragment so exporters can't drift

### DIFF
--- a/.changeset/dedup-export-game-loop.md
+++ b/.changeset/dedup-export-game-loop.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Extract the exported-game per-frame loop into a single shared helper (`generateGameLoopFragment`) consumed by both the single-HTML and ZIP exporters, so the two paths can no longer silently drift (the cause of the #8754 touch-input ordering defect re-appearing in the sibling generator).

--- a/web/src/lib/export/__tests__/gameLoopFragment.test.ts
+++ b/web/src/lib/export/__tests__/gameLoopFragment.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { generateGameLoopFragment } from '../gameLoopFragment';
+
+/**
+ * Single source-of-truth test for the exported game loop (#8761). Previously the
+ * single-HTML and ZIP exporters each carried a near-duplicate structural test;
+ * the loop now lives in one helper, so its invariants are pinned here once.
+ */
+describe('generateGameLoopFragment', () => {
+  const frag = generateGameLoopFragment({ handleCommand: 'handle_command' });
+
+  it('emits the loop scaffold from lastTime capture through the rAF kickoff', () => {
+    expect(frag).toContain('var lastTime = performance.now();');
+    expect(frag).toContain('function gameLoop() {');
+    expect(frag).toContain('var dt = (now - lastTime) / 1000;');
+    // rAF appears twice: the in-loop re-enqueue and the initial kickoff.
+    expect(frag.match(/requestAnimationFrame\(gameLoop\)/g)).toHaveLength(2);
+  });
+
+  it('merges touch input BEFORE the script update every frame (#8754 ordering invariant)', () => {
+    const touchMerge = frag.indexOf('window.__forgeTouchFlush()');
+    const scriptUpdate = frag.indexOf('window.__forgeScriptUpdate(dt)');
+    expect(touchMerge).toBeGreaterThan(-1);
+    expect(scriptUpdate).toBeGreaterThan(-1);
+    // If this ever flips, an intervening PLAY_TICK wipes touch state before any
+    // script reads it and touch controls go dead in exported mobile games.
+    expect(touchMerge).toBeLessThan(scriptUpdate);
+  });
+
+  it('re-applies the full touch surface (pressed / justPressed / justReleased / axes) on top of PLAY_TICK', () => {
+    expect(frag).toContain('for (var k in ti.pressed)');
+    expect(frag).toContain('for (var k2 in ti.justPressed)');
+    expect(frag).toContain('for (var k3 in ti.justReleased)');
+    expect(frag).toContain('for (var k4 in ti.axes)');
+  });
+
+  it('flushes queued script commands through the provided command sink, verbatim', () => {
+    expect(frag).toContain('var cmds = window.__forgeFlushCommands();');
+    // Default (single-HTML) sink: the global handle_command.
+    expect(frag).toContain('handle_command(cmds[ci].cmd, JSON.stringify(cmds[ci]));');
+  });
+
+  it('parameterizes the command sink (ZIP build uses the wasm module local)', () => {
+    const zipFrag = generateGameLoopFragment({ handleCommand: 'wasm.handle_command' });
+    expect(zipFrag).toContain('wasm.handle_command(cmds[ci].cmd, JSON.stringify(cmds[ci]));');
+    // The two builds must differ ONLY in the sink reference — same loop otherwise.
+    expect(zipFrag.replace(/wasm\.handle_command/g, 'handle_command')).toBe(frag);
+  });
+
+  it('applies the indent prefix to every non-blank line and leaves blank lines bare', () => {
+    const indented = generateGameLoopFragment({ handleCommand: 'handle_command', indent: '    ' });
+    const lines = indented.split('\n');
+    for (const line of lines) {
+      if (line.length === 0) continue;
+      expect(line.startsWith('    ')).toBe(true);
+    }
+    // Blank separator lines stay genuinely empty (no trailing whitespace).
+    expect(indented).toContain('\n\n');
+  });
+});

--- a/web/src/lib/export/gameLoopFragment.ts
+++ b/web/src/lib/export/gameLoopFragment.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared inline game-loop fragment for exported games.
+ *
+ * The single-HTML exporter (`gameTemplate.ts` → `generateGameHTML`) and the ZIP
+ * exporter (`zipExporter.ts` → `generateZipIndexHtml`) both embed a functionally
+ * identical per-frame loop: merge touch input, run script `onUpdate`, flush
+ * queued script commands to the engine, then re-enqueue via
+ * `requestAnimationFrame`. Keeping two copies caused #8754 — the "merge touch
+ * before the script reads it" ordering fix had to be applied to the single-HTML
+ * path first, then re-applied to the ZIP path after Sentry re-found the same
+ * defect in the sibling generator. This module is the single source of truth so
+ * the two paths can never silently diverge again (#8761).
+ *
+ * The ONLY thing that differs between the two hosts is how the engine's command
+ * entry point is referenced: the single-HTML build calls a global
+ * `handle_command`, while the ZIP build holds the WASM module in a `wasm` local
+ * and calls `wasm.handle_command`. That reference is the lone parameter.
+ */
+export interface GameLoopFragmentOptions {
+  /**
+   * How to reference the engine command sink inside the generated loop, e.g.
+   * `'handle_command'` (single-HTML, global) or `'wasm.handle_command'` (ZIP,
+   * module local).
+   *
+   * SECURITY: this string is emitted VERBATIM into the generated game script. It
+   * MUST be a trusted compile-time literal — never derive it from user input,
+   * scene data, or any external value.
+   */
+  handleCommand: string;
+  /**
+   * Indentation prefix applied to every non-blank emitted line so the fragment
+   * slots cleanly into each host's surrounding script block. Cosmetic only.
+   */
+  indent?: string;
+}
+
+/**
+ * Returns the JS source for the exported game loop, from the initial
+ * `lastTime` capture through the kickoff `requestAnimationFrame(gameLoop)`.
+ *
+ * Invariant pinned by `gameLoopFragment.test.ts`: the touch-input merge runs
+ * BEFORE `__forgeScriptUpdate` every frame (#8754).
+ */
+export function generateGameLoopFragment({ handleCommand, indent = '' }: GameLoopFragmentOptions): string {
+  const body = `var lastTime = performance.now();
+function gameLoop() {
+  var now = performance.now();
+  var dt = (now - lastTime) / 1000;
+  lastTime = now;
+
+  // Merge touch input BEFORE the frame's script update. PLAY_TICK overwrites
+  // __forgeInputState wholesale every engine frame with keyboard/gamepad state
+  // only (the engine has no knowledge of JS touch input), so the touch layer
+  // must be re-applied on top within the same synchronous gameLoop tick the
+  // scripts read. JS is single-threaded, so no PLAY_TICK can interleave between
+  // this merge and __forgeScriptUpdate below. Merging AFTER the script read let
+  // an intervening PLAY_TICK obliterate touch input before scripts ever saw it —
+  // touch controls were dead in exported mobile games (#8754, #8761).
+  if (window.__forgeTouchInput) {
+    if (!window.__forgeInputState) window.__forgeInputState = { pressed: {}, justPressed: {}, justReleased: {}, axes: {} };
+    var ti = window.__forgeTouchInput;
+    for (var k in ti.pressed) { if (ti.pressed[k]) window.__forgeInputState.pressed[k] = true; }
+    for (var k2 in ti.justPressed) { if (ti.justPressed[k2]) window.__forgeInputState.justPressed[k2] = true; }
+    for (var k3 in ti.justReleased) { if (ti.justReleased[k3]) window.__forgeInputState.justReleased[k3] = true; }
+    for (var k4 in ti.axes) { window.__forgeInputState.axes[k4] = ti.axes[k4]; }
+    if (window.__forgeTouchFlush) window.__forgeTouchFlush();
+  }
+
+  if (window.__forgeScriptUpdate) window.__forgeScriptUpdate(dt);
+
+  // Flush script commands to the engine
+  if (window.__forgeFlushCommands) {
+    var cmds = window.__forgeFlushCommands();
+    for (var ci = 0; ci < cmds.length; ci++) {
+      ${handleCommand}(cmds[ci].cmd, JSON.stringify(cmds[ci]));
+    }
+  }
+
+  requestAnimationFrame(gameLoop);
+}
+requestAnimationFrame(gameLoop);`;
+
+  if (!indent) return body;
+  return body
+    .split('\n')
+    .map((line) => (line.length > 0 ? indent + line : line))
+    .join('\n');
+}

--- a/web/src/lib/export/gameTemplate.test.ts
+++ b/web/src/lib/export/gameTemplate.test.ts
@@ -130,18 +130,18 @@ describe('gameTemplate', () => {
       expect(html).toContain('if (window.__forgeScriptStart) window.__forgeScriptStart()');
     });
 
-    it('includes script update loop', () => {
+    // The loop's internal structure + ordering invariant are pinned once in
+    // gameLoopFragment.test.ts. Here we only assert the single-HTML path
+    // CONSUMES the shared fragment and wires it to the GLOBAL handle_command
+    // sink (not wasm.handle_command, which is the ZIP build's).
+    it('consumes the shared game loop wired to the global handle_command sink', () => {
       const html = generateGameHTML(baseOptions);
       expect(html).toContain('function gameLoop()');
       expect(html).toContain('if (window.__forgeScriptUpdate) window.__forgeScriptUpdate(dt)');
       expect(html).toContain('requestAnimationFrame(gameLoop)');
-    });
-
-    it('includes command flush logic', () => {
-      const html = generateGameHTML(baseOptions);
-      expect(html).toContain('if (window.__forgeFlushCommands)');
-      expect(html).toContain('const cmds = window.__forgeFlushCommands()');
-      expect(html).toContain('handle_command(cmd.cmd, JSON.stringify(cmd))');
+      expect(html).toContain('var cmds = window.__forgeFlushCommands()');
+      expect(html).toContain('handle_command(cmds[ci].cmd, JSON.stringify(cmds[ci]))');
+      expect(html).not.toContain('wasm.handle_command(cmds[ci]');
     });
 
     it('includes event callback setup', () => {

--- a/web/src/lib/export/gameTemplate.ts
+++ b/web/src/lib/export/gameTemplate.ts
@@ -2,6 +2,7 @@ import { generateUIRuntimeCode } from './uiRuntime';
 import { generateTouchCSS, generateTouchJS } from './touchControls';
 import type { MobileTouchConfig } from './touchControls';
 import { escapeHtml, escapeScriptContent, validateCssColor } from './exportUtils';
+import { generateGameLoopFragment } from './gameLoopFragment';
 
 export interface EmbeddedWasmData {
   jsBase64: string;     // JS glue code, base64-encoded
@@ -165,46 +166,8 @@ export function generateGameHTML(options: GameTemplateOptions): string {
           handle_command('play', '{}');
           if (window.__forgeScriptStart) window.__forgeScriptStart();
 
-          // Script update loop
-          let lastTime = performance.now();
-          function gameLoop() {
-            const now = performance.now();
-            const dt = (now - lastTime) / 1000;
-            lastTime = now;
-
-            // Merge touch input BEFORE the frame's script update. PLAY_TICK
-            // overwrites __forgeInputState wholesale every engine frame with
-            // keyboard/gamepad state only (the engine has no knowledge of JS
-            // touch input), so the touch layer must be re-applied on top within
-            // the same synchronous gameLoop tick that the scripts read — JS is
-            // single-threaded, so no PLAY_TICK can interleave between this merge
-            // and __forgeScriptUpdate below. Merging after the script read (the
-            // prior order) let an intervening PLAY_TICK obliterate touch input
-            // before scripts ever saw it — touch controls were dead in exported
-            // mobile games (#8754).
-            if (window.__forgeTouchInput) {
-              if (!window.__forgeInputState) window.__forgeInputState = { pressed: {}, justPressed: {}, justReleased: {}, axes: {} };
-              var ti = window.__forgeTouchInput;
-              for (var k in ti.pressed) { if (ti.pressed[k]) window.__forgeInputState.pressed[k] = true; }
-              for (var k2 in ti.justPressed) { if (ti.justPressed[k2]) window.__forgeInputState.justPressed[k2] = true; }
-              for (var k3 in ti.justReleased) { if (ti.justReleased[k3]) window.__forgeInputState.justReleased[k3] = true; }
-              for (var k4 in ti.axes) { window.__forgeInputState.axes[k4] = ti.axes[k4]; }
-              if (window.__forgeTouchFlush) window.__forgeTouchFlush();
-            }
-
-            if (window.__forgeScriptUpdate) window.__forgeScriptUpdate(dt);
-
-            // Flush script commands to engine
-            if (window.__forgeFlushCommands) {
-              const cmds = window.__forgeFlushCommands();
-              for (const cmd of cmds) {
-                handle_command(cmd.cmd, JSON.stringify(cmd));
-              }
-            }
-
-            requestAnimationFrame(gameLoop);
-          }
-          requestAnimationFrame(gameLoop);
+          // Script update loop (shared with the ZIP exporter — see gameLoopFragment.ts)
+${generateGameLoopFragment({ handleCommand: 'handle_command', indent: '          ' })}
 
           // Hide loading screen
           document.getElementById('loading').classList.add('hidden');

--- a/web/src/lib/export/zipExporter.test.ts
+++ b/web/src/lib/export/zipExporter.test.ts
@@ -296,14 +296,22 @@ describe('zipExporter', () => {
       expect(text).toContain('__forgeScriptUpdate');
     });
 
-    it('includes game loop with command flush', async () => {
+    it('includes game loop with command flush wired to the wasm.handle_command sink', async () => {
       const blob = await exportAsZip(mockSceneData, mockScripts, defaultOptions);
       const buffer = await blob.arrayBuffer();
       const bytes = new Uint8Array(buffer);
       const text = new TextDecoder().decode(bytes);
+      // Structure + ordering invariant live in gameLoopFragment.test.ts; here we
+      // assert the ZIP path CONSUMES the shared fragment with the module-local
+      // wasm.handle_command sink (the ZIP build holds the engine in a `wasm` var).
       expect(text).toContain('gameLoop');
       expect(text).toContain('__forgeFlushCommands');
       expect(text).toContain('requestAnimationFrame');
+      expect(text).toContain('wasm.handle_command(cmds[ci].cmd, JSON.stringify(cmds[ci]))');
+      // ...and NOT the bare global sink (the single-HTML build's). The leading
+      // space disambiguates a bare `handle_command(` from `wasm.handle_command(`,
+      // which is preceded by a dot — symmetric to gameTemplate.test.ts's guard.
+      expect(text).not.toContain(' handle_command(cmds[ci]');
     });
 
     it('wires the event callback to the engine single-arg PLAY_TICK input contract (#8752)', async () => {

--- a/web/src/lib/export/zipExporter.ts
+++ b/web/src/lib/export/zipExporter.ts
@@ -13,6 +13,7 @@ import type { ExportFormat } from './presets';
 import type { ScriptData } from '@/stores/editorStore';
 import { compressTexture, COMPRESSION_PRESETS, type CompressionConfig } from './textureCompression';
 import { escapeHtml, escapeScriptContent, validateCssColor } from './exportUtils';
+import { generateGameLoopFragment } from './gameLoopFragment';
 
 export interface ZipExportOptions {
   format: ExportFormat;
@@ -400,42 +401,8 @@ export function generateZipIndexHtml(options: {
       // Run script onStart hooks
       if (window.__forgeScriptStart) window.__forgeScriptStart();
 
-      // Main game loop
-      var lastTime = performance.now();
-      function gameLoop() {
-        var now = performance.now();
-        var dt = (now - lastTime) / 1000;
-        lastTime = now;
-
-        // Merge touch input BEFORE the script reads it. The engine's PLAY_TICK
-        // callback overwrites __forgeInputState wholesale with keyboard/gamepad
-        // state only, so the touch layer must be re-merged each frame before
-        // __forgeScriptUpdate runs — otherwise an intervening PLAY_TICK drops
-        // touch state before any script sees it and touch controls go dead (#8754).
-        if (window.__forgeTouchInput) {
-          if (!window.__forgeInputState) window.__forgeInputState = { pressed: {}, justPressed: {}, justReleased: {}, axes: {} };
-          var ti = window.__forgeTouchInput;
-          for (var k in ti.pressed) { if (ti.pressed[k]) window.__forgeInputState.pressed[k] = true; }
-          for (var k2 in ti.justPressed) { if (ti.justPressed[k2]) window.__forgeInputState.justPressed[k2] = true; }
-          for (var k3 in ti.justReleased) { if (ti.justReleased[k3]) window.__forgeInputState.justReleased[k3] = true; }
-          for (var k4 in ti.axes) { window.__forgeInputState.axes[k4] = ti.axes[k4]; }
-          if (window.__forgeTouchFlush) window.__forgeTouchFlush();
-        }
-
-        // Run script onUpdate hooks
-        if (window.__forgeScriptUpdate) window.__forgeScriptUpdate(dt);
-
-        // Flush script commands to WASM engine
-        if (window.__forgeFlushCommands) {
-          var cmds = window.__forgeFlushCommands();
-          for (var i = 0; i < cmds.length; i++) {
-            wasm.handle_command(cmds[i].cmd, JSON.stringify(cmds[i]));
-          }
-        }
-
-        requestAnimationFrame(gameLoop);
-      }
-      requestAnimationFrame(gameLoop);
+      // Main game loop (shared with the single-HTML exporter — see gameLoopFragment.ts)
+${generateGameLoopFragment({ handleCommand: 'wasm.handle_command', indent: '      ' })}
 
       // Signal engine ready (for loading screen)
       window.dispatchEvent(new CustomEvent('forge:engine-ready'));


### PR DESCRIPTION
## Summary

The exported-game per-frame loop — merge touch input → run script `onUpdate` → flush queued script commands to the engine → `requestAnimationFrame` — was duplicated in two generators:

- `web/src/lib/export/gameTemplate.ts` → `generateGameHTML` (single-HTML export, global `handle_command` sink)
- `web/src/lib/export/zipExporter.ts` → `generateZipIndexHtml` (ZIP export, `wasm.handle_command` module-local sink)

That duplication is exactly what caused **#8754**: the "merge touch input *before* the script reads it" ordering fix was applied to one copy, then Sentry re-found the identical defect in the sibling generator. Touch controls were dead in exported mobile games until both copies were fixed.

This PR extracts the loop into a single source of truth:

- **New** `web/src/lib/export/gameLoopFragment.ts` → `generateGameLoopFragment({ handleCommand, indent })`. Parameterized **only** on the engine command-sink reference (the lone real difference between the two hosts) plus a cosmetic `indent`. The `handleCommand` arg is documented as a trusted compile-time literal — never user-derived.
- Both generators now consume it. The #8754 ordering invariant lives in exactly one place and the two paths can never silently diverge again.

## Test plan

- `gameLoopFragment.test.ts` (new) pins the loop structure **once**: the #8754 ordering invariant (touch merge strictly before script update), the full touch surface re-application (pressed/justPressed/justReleased/axes), the sink parameterization (the two builds differ *only* in the sink token), and indent behavior.
- Consumer tests narrowed to each host's **unique** wiring — `gameTemplate.test.ts` asserts the global `handle_command` sink (and not the wasm form); `zipExporter.test.ts` asserts the `wasm.handle_command` sink (and not a bare global one). No structural assertions were weakened — removals were relocated to `gameLoopFragment.test.ts` with equal-or-stronger coverage.
- `npx vitest run src/lib/export/__tests__/gameLoopFragment.test.ts src/lib/export/gameTemplate.test.ts src/lib/export/zipExporter.test.ts` → all green.
- ESLint `--max-warnings 0` clean on all touched files.

Review board: code-architect PASS, security-reviewer PASS (sink is a trusted literal at both call sites; no escaping regression; loop body carries no user data), test-writer PASS (no weakening; symmetric negative-sink guard added to the ZIP consumer per review).

Pure string-templating refactor — no runtime/data-flow change to the exported artifact, no engine rebuild required.

Closes #8761