### PR TITLE
ci(smoke): follow redirects so apex 307→www stops failing healthy deploys

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -40,6 +40,11 @@ jobs:
 
     env:
       # Prefer explicit input (workflow_dispatch / workflow_call); then DEPLOY_URL var; then production.
+      # NOTE: the apex (https://spawnforge.ai) 307-redirects to the canonical host
+      # (https://www.spawnforge.ai). Every curl below MUST pass --location so it
+      # follows that hop to the final 200 — otherwise the smoke test sees the 307
+      # and fails on a healthy deploy, masking real outages. --location is a no-op
+      # for targets that don't redirect (www, Vercel preview URLs, DEPLOY_URL).
       TARGET_URL: ${{ inputs.target_url || vars.DEPLOY_URL || 'https://spawnforge.ai' }}
 
     steps:
@@ -50,7 +55,7 @@ jobs:
       - name: Health check (/api/health)
         id: health
         run: |
-          HTTP_CODE=$(curl --silent --output /tmp/health_body.json \
+          HTTP_CODE=$(curl --silent --location --output /tmp/health_body.json \
             --write-out "%{http_code}" \
             --max-time 10 \
             "$TARGET_URL/api/health")
@@ -75,7 +80,7 @@ jobs:
       - name: Homepage loads (/)
         id: homepage
         run: |
-          HTTP_CODE=$(curl --silent --output /tmp/homepage_body.html \
+          HTTP_CODE=$(curl --silent --location --output /tmp/homepage_body.html \
             --write-out "%{http_code}" \
             --max-time 10 \
             "$TARGET_URL/")
@@ -97,7 +102,7 @@ jobs:
       - name: Static asset (/manifest.json)
         id: manifest
         run: |
-          HTTP_CODE=$(curl --silent --output /tmp/manifest_body.json \
+          HTTP_CODE=$(curl --silent --location --output /tmp/manifest_body.json \
             --write-out "%{http_code}" \
             --max-time 10 \
             "$TARGET_URL/manifest.json")
@@ -124,7 +129,7 @@ jobs:
           fi
           WASM_PATH="$WASM_URL"
           echo "Checking WASM at: $WASM_URL"
-          RESPONSE=$(curl --silent --head --output /dev/null \
+          RESPONSE=$(curl --silent --location --head --output /dev/null \
             --write-out "%{http_code}|%{content_type}" \
             --max-time 10 \
             "$WASM_URL")


### PR DESCRIPTION
## Summary

The **Post-Deploy Smoke Tests** workflow has been red on every run against production even when prod is fully healthy — a **broken safety net** that masks real post-deploy outages (the signal is always red, so a genuine failure looks identical to the chronic false one).

**Root cause:** all four checks (`/api/health`, `/` homepage, `/manifest.json`, WASM HEAD) `curl` `TARGET_URL`, which defaults to the **apex** `https://spawnforge.ai`. The apex **307-redirects** to the canonical host `https://www.spawnforge.ai`, and none of the curls passed `--location`, so each captured the `307` and failed its `-ne 200` check.

Verified live (2026-06-14):

| Path | apex (no `-L`) | apex (`-L`) | www |
|------|:---:|:---:|:---:|
| `/api/health` | 307 | 200 | 200 |
| `/` | 307 | 200 | 200 |
| `/manifest.json` | 307 | 200 | 200 |

`307 location: https://www.spawnforge.ai/api/health` confirms the apex→www canonicalization hop.

**Fix:** add `--location` to all four `curl` invocations + a durable comment explaining why the flag must stay.

- `--location` follows the apex→www hop to the final `200`.
- No-op for non-redirecting targets (www, Vercel preview URLs, an explicit `DEPLOY_URL`).
- `%{http_code}` reports the **final** response code under `--location`, so the gate keeps its teeth: a `307→200` chain passes, a `307→5xx` chain still fails on the `5xx`.
- The apex default is intentionally kept, so the redirect chain is now exercised as **live coverage** rather than always failing (a www default would make a broken apex redirect silently invisible).
- All content verification is unchanged (JSON parse on `/api/health`, `SpawnForge` grep on homepage, WASM MIME check) — run against the final response.

## Review board (BEFORE push)

- **code-architect** — PASS (0 findings): `%{http_code}` accurate both directions; `--head --location` safe for WASM; no redirect-loop regression under `--max-time 10`; coverage strictly improved.
- **security-reviewer** — PASS (0 findings): no auth headers to leak across a hop; `TARGET_URL` is env-scoped + double-quoted (no injection); all 3 sources require repo write; SSRF-via-redirect N/A on GitHub runners (no IMDS).
- **dx-guardian** — PASS (0 findings): applied consistently to all four checks; durable comment; matches repo CI conventions.

## Validation

- `actionlint` clean (shellchecks the `run:` blocks)
- YAML parses cleanly
- CI/infra-only change — `skip changeset` (no `web/` source touched)

## Test plan

- [ ] After merge, the next CD-triggered **Post-Deploy Smoke Tests** run goes green against the apex default.
- [ ] Manually dispatch with `target_url=https://www.spawnforge.ai` — also green (no redirect; `--location` no-op).

Closes #8775