### PR TITLE
chore(sentry): migrate sendDefaultPii → exhaustive dataCollection + regression guard (#8778)

### DIFF
--- a/.changeset/sentry-datacollection-migration.md
+++ b/.changeset/sentry-datacollection-migration.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Migrate Sentry off the deprecated `sendDefaultPii: false` to the `dataCollection` framework (bump `@sentry/nextjs` 10.55→10.57; `sendDefaultPii` is `@deprecated` in 10.57 and removed in v11). The replacement object is **exhaustive** in all three configs (server, edge, client) — once any `dataCollection` key is set, Sentry falls back to permissive DEFAULTS for every omitted field, so a partial object would silently re-enable PII. Every field is opted out, which is equivalent-or-stricter than the legacy false path (cookies/queryParams/headers go from PII deny-list to fully off; `stackFrameVariables` goes `true`→`false`, finally expressing the F04 "no stack-frame locals" intent in a first-class control). Preserves the F03/F04 audit posture; `scrubSentryEvent` remains as defence-in-depth.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4051,9 +4051,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4265,12 +4265,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
-      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
+      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4388,13 +4388,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
-      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
+      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/resources": "2.8.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6031,50 +6031,62 @@
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.55.0.tgz",
-      "integrity": "sha512-zUvyBr13EK0evKsSTzwSimRzZ3P9kugS32dLCj3ea5gNN+/DFtU/GsMTdcIQDhusEDraIlH17AGgqJH5gUAv5w==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.57.0.tgz",
+      "integrity": "sha512-tXObp954rMTSYKlbftjVXHtNl4t/6ssks3jkqyzmKb+PDPWzabGQO7sWwqVuTjT8Kx/8A3FmriS1bGmqxiJy3A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.55.0"
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.55.0.tgz",
-      "integrity": "sha512-32X9WW1xs5DjCRlp89QJ/PLw4kbTIX6MsBDXN2RBN1nWBjm/2WcwXqO/v/WoIS4W2kTWXcZnQwalLSI22Fp33A==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.57.0.tgz",
+      "integrity": "sha512-ZcF4QhkqGX3iiQSXB2N0N3Awp+j5iqnDRu6PA/qyLFrWqH5ZiiAAgu59OLD9E6XAdg6iFtLYw19MAMZVK8qNOQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.55.0"
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.55.0.tgz",
-      "integrity": "sha512-OkQpANGwYU5UKfwLk6Y+NpESRC8nrLBjawRDLwF6cJ8HpNScOuNNJDEJEGwXHVkJPH0pcIixsH8y0Qfcltq6Xw==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.57.0.tgz",
+      "integrity": "sha512-Wmnx/6ABynVH1iwuoNUqJNyjIUqsqoGML7qsyivBRKb5Wo2YQtPOQlQYfxfZSvWzGpcoSVdInkRjDssUQxQEQg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.55.0",
-        "@sentry/core": "10.55.0"
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.55.0.tgz",
-      "integrity": "sha512-lu/y7k9cK7FZ/qJpL0fBX4WqK6IFa/+bTPhedEaC5UpzjUNP7BfXt0H+R7q9CHWmp20Ffh/wGfO3j7O+Tv2MAA==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.57.0.tgz",
+      "integrity": "sha512-zsfa4JcfV0AEc9YhNxNabd5lSZL2Av84saAyexGAqcHs+67m9Gd0cGStOzMb/nCl7UAtmdP0aI+G7a3rcxxN/A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.55.0",
-        "@sentry/core": "10.55.0"
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry/core": "10.57.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.57.0.tgz",
+      "integrity": "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -6090,16 +6102,16 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.55.0.tgz",
-      "integrity": "sha512-5n1kxmW1m4j16ZDV9kt+Zo5uafFnKTy7s5YyEcGnC45KnOiO1Gy+QFd3woXns1K5GNxpjF7oOOc6tXgZLuXnQQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.57.0.tgz",
+      "integrity": "sha512-s36AQy/CKXTfyY9Z+qUhzNomntZXgfs0rbaK7q9ffnFkqcPwzE8qQtVs58y3Suut56u+AhwSztgQtERcuZ5VIA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.55.0",
-        "@sentry-internal/feedback": "10.55.0",
-        "@sentry-internal/replay": "10.55.0",
-        "@sentry-internal/replay-canvas": "10.55.0",
-        "@sentry/core": "10.55.0"
+        "@sentry-internal/browser-utils": "10.57.0",
+        "@sentry-internal/feedback": "10.57.0",
+        "@sentry-internal/replay": "10.57.0",
+        "@sentry-internal/replay-canvas": "10.57.0",
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -6362,30 +6374,30 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.55.0.tgz",
-      "integrity": "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.57.0.tgz",
+      "integrity": "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.55.0.tgz",
-      "integrity": "sha512-ODiv6hy7+gmINFvbWAVaCqtxT2ceFW7AW65amy34z3fCgld9+LHTP2++p4g2LmQb/mYQPIbJrVEfJoqGASK4EQ==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.57.0.tgz",
+      "integrity": "sha512-jRsyc387+YoOpYoxtJaL8VLzCq4I0KrIsVcZW4j3gA4LHG2nolKV4IDGrYWxEygc41Sgrtm1ZYbZAvjHMd9phQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry-internal/browser-utils": "10.55.0",
+        "@sentry-internal/browser-utils": "10.57.0",
         "@sentry/bundler-plugin-core": "^5.3.0",
-        "@sentry/core": "10.55.0",
-        "@sentry/node": "10.55.0",
-        "@sentry/opentelemetry": "10.55.0",
-        "@sentry/react": "10.55.0",
-        "@sentry/vercel-edge": "10.55.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/node": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
+        "@sentry/react": "10.57.0",
+        "@sentry/vercel-edge": "10.57.0",
         "@sentry/webpack-plugin": "^5.3.0",
         "rollup": "^4.60.3",
         "stacktrace-parser": "^0.1.11"
@@ -6767,9 +6779,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.55.0.tgz",
-      "integrity": "sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.57.0.tgz",
+      "integrity": "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
@@ -6777,9 +6789,10 @@
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.55.0",
-        "@sentry/node-core": "10.55.0",
-        "@sentry/opentelemetry": "10.55.0",
+        "@sentry-internal/server-utils": "10.57.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/node-core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6787,13 +6800,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.55.0.tgz",
-      "integrity": "sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.57.0.tgz",
+      "integrity": "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.55.0",
-        "@sentry/opentelemetry": "10.55.0",
+        "@sentry/core": "10.57.0",
+        "@sentry/opentelemetry": "10.57.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6829,12 +6842,12 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.55.0.tgz",
-      "integrity": "sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.57.0.tgz",
+      "integrity": "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.55.0"
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -6847,13 +6860,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.55.0.tgz",
-      "integrity": "sha512-cf6wI0W1FdrL/7d5FTHXUdTN5k5uRZ9AQu5QZxUujnxWN+DBxUWtow1HDD1zTEonQsCFyYuhXVu3w+qmBBW11A==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.57.0.tgz",
+      "integrity": "sha512-6QThwQ4XWQ2rwKZEVQ9P9WKl7JlowC7S5LpAvmMdrwlfJBpLDFOsM7tycnIvbXTXf0ZOOuLFPa4L4YYbdyNGmA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.55.0",
-        "@sentry/core": "10.55.0"
+        "@sentry/browser": "10.57.0",
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -6863,14 +6876,14 @@
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "10.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.55.0.tgz",
-      "integrity": "sha512-IB8MBTdCHnuUtxHWh39Ecr9/TvMqSYW9BOO7ExnByDjHhfXOzQnEs6VJvEEIwSyUEl1yIz1Y3WdOlY9I6lqeMA==",
+      "version": "10.57.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.57.0.tgz",
+      "integrity": "sha512-8liagiXIWfyG0xGMmZQPCNOvqfzJcL7djB2jjNCaF5y7C+X/NTUHr4sqUHfAHqpQFUUXqmBT/mZv9HB5FDLhyQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/resources": "^2.6.1",
-        "@sentry/core": "10.55.0"
+        "@sentry/core": "10.57.0"
       },
       "engines": {
         "node": ">=18"
@@ -14688,9 +14701,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
-      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.2.tgz",
+      "integrity": "sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -21917,7 +21930,7 @@
         "@google/generative-ai": "^0.24.1",
         "@monaco-editor/react": "^4.7.0",
         "@neondatabase/serverless": "^1.1.0",
-        "@sentry/nextjs": "^10.55.0",
+        "@sentry/nextjs": "^10.57.0",
         "@spawnforge/ui": "*",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -21,8 +21,19 @@ if (DSN) {
 
     // SECURITY (audit 2026-05-30, F03/F04): no default PII; scrub residual
     // secrets/PII from every event before transmission. Session-replay text is
-    // already masked (maskAllText, #8001).
-    sendDefaultPii: false,
+    // already masked (maskAllText, #8001). Migrated off the deprecated
+    // `sendDefaultPii: false` to the exhaustive `dataCollection` opt-out (any
+    // partial object re-enables PII via Sentry's permissive defaults; see
+    // sentry.server.config.ts for the full rationale).
+    dataCollection: {
+      userInfo: false,
+      cookies: false,
+      queryParams: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+    },
     enableLogs: true,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,

--- a/web/package.json
+++ b/web/package.json
@@ -59,7 +59,7 @@
     "@google/generative-ai": "^0.24.1",
     "@monaco-editor/react": "^4.7.0",
     "@neondatabase/serverless": "^1.1.0",
-    "@sentry/nextjs": "^10.55.0",
+    "@sentry/nextjs": "^10.57.0",
     "@spawnforge/ui": "*",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",

--- a/web/sentry.edge.config.ts
+++ b/web/sentry.edge.config.ts
@@ -18,8 +18,20 @@ if (DSN) {
     },
 
     // SECURITY (audit 2026-05-30, F03/F04): no default PII; scrub residual
-    // secrets/PII from every event before transmission.
-    sendDefaultPii: false,
+    // secrets/PII from every event before transmission. Migrated off the
+    // deprecated `sendDefaultPii: false` to the `dataCollection` framework — the
+    // object MUST stay exhaustive (any partial object re-enables PII via Sentry's
+    // permissive defaults). Every field is opted out (see sentry.server.config.ts
+    // for the full rationale).
+    dataCollection: {
+      userInfo: false,
+      cookies: false,
+      queryParams: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+    },
     enableLogs: true,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -21,7 +21,23 @@ if (DSN) {
     // (they can hold decrypted BYOK provider keys and prompts) and do NOT send
     // default PII (IPs, cookies, headers, user data). scrubSentryEvent provides
     // defence-in-depth, redacting any residual secrets/PII before transmission.
-    sendDefaultPii: false,
+    //
+    // Migrated off the deprecated `sendDefaultPii: false` (removed in @sentry v11)
+    // to the `dataCollection` framework. This object MUST stay exhaustive: as soon
+    // as ANY `dataCollection` key is present, every OMITTED field falls back to
+    // Sentry's permissive DEFAULTS (cookies/queryParams/headers/genAI all on), so a
+    // partial object would silently re-enable PII. Every field below is opted out —
+    // equivalent-or-stricter than the legacy false path, notably
+    // `stackFrameVariables: false`, which the legacy path resolved to `true`.
+    dataCollection: {
+      userInfo: false,
+      cookies: false,
+      queryParams: false,
+      httpHeaders: { request: false, response: false },
+      httpBodies: [],
+      genAI: { inputs: false, outputs: false },
+      stackFrameVariables: false,
+    },
     enableLogs: true,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,

--- a/web/src/lib/__tests__/sentry-regressions.test.ts
+++ b/web/src/lib/__tests__/sentry-regressions.test.ts
@@ -349,3 +349,119 @@ describe('PF-892: Sentry client config must not include server-only AI integrati
     expect(content).toContain('anthropicAIIntegration');
   });
 });
+
+// ---------------------------------------------------------------------------
+// F03/F04 (#8778): Sentry dataCollection opt-out must stay exhaustive
+// ---------------------------------------------------------------------------
+
+describe('F03/F04 (#8778): Sentry dataCollection opt-out must stay exhaustive', () => {
+  /**
+   * The migration off the deprecated `sendDefaultPii: false` to the
+   * `dataCollection` framework introduced a silent footgun: once ANY
+   * `dataCollection` key is set, Sentry resolves every OMITTED field to its
+   * permissive DEFAULT (cookies / queryParams / httpHeaders / genAI /
+   * stackFrameVariables all ON). A future edit that drops a single field — or
+   * flips one to `true` — would re-enable PII capture while still passing tsc
+   * and every existing test. These guards fail on that regression, preserving
+   * the F03/F04 audit posture (no default PII, no stack-frame locals) across all
+   * three Sentry init sites.
+   *
+   * See web/src/lib/monitoring/sentryConfig.ts and the three init configs.
+   */
+  const CONFIG_FILES = [
+    'sentry.server.config.ts',
+    'sentry.edge.config.ts',
+    'instrumentation-client.ts',
+  ] as const;
+
+  // Every privacy-relevant dataCollection field with its required opt-out
+  // literal. Missing any of these → Sentry's permissive default silently
+  // re-enables that data class.
+  const REQUIRED_OPT_OUTS = [
+    'userInfo: false',
+    'cookies: false',
+    'queryParams: false',
+    'httpHeaders: { request: false, response: false }',
+    'httpBodies: []',
+    'genAI: { inputs: false, outputs: false }',
+    'stackFrameVariables: false',
+  ] as const;
+
+  // Any of these literals inside a config means a field was flipped back ON.
+  // (None collide with unrelated config: the AI integration uses
+  // `recordInputs`/`recordOutputs`, not `inputs:`/`outputs:`.)
+  const FORBIDDEN_OPT_INS = [
+    'userInfo: true',
+    'cookies: true',
+    'queryParams: true',
+    'stackFrameVariables: true',
+    'request: true',
+    'response: true',
+    'inputs: true',
+    'outputs: true',
+  ] as const;
+
+  // Strip block + line comments so the guards inspect ACTIVE config only. The
+  // configs intentionally DOCUMENT the migration in prose (e.g. "Migrated off
+  // the deprecated `sendDefaultPii: false`"), so a raw-text scan would conflate
+  // explanatory comments with real Sentry.init options.
+  function stripComments(src: string): string {
+    return src
+      .replace(/\/\*[\s\S]*?\*\//g, '') // block comments (incl. JSDoc)
+      .replace(/\/\/.*$/gm, ''); // line comments
+  }
+
+  async function readConfig(file: string): Promise<string> {
+    const fs = await import('fs');
+    const path = await import('path');
+    const raw = fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8');
+    return stripComments(raw);
+  }
+
+  it.each(CONFIG_FILES)('%s declares a dataCollection block', async (file) => {
+    const content = await readConfig(file);
+    expect(content).toContain('dataCollection: {');
+  });
+
+  it.each(CONFIG_FILES)(
+    '%s opts out of every PII-relevant dataCollection field',
+    async (file) => {
+      const content = await readConfig(file);
+      for (const field of REQUIRED_OPT_OUTS) {
+        expect(
+          content,
+          `${file} is missing an exhaustive opt-out: "${field}" — a dropped field re-enables PII via Sentry defaults`,
+        ).toContain(field);
+      }
+    },
+  );
+
+  it.each(CONFIG_FILES)(
+    '%s never flips a dataCollection field back on',
+    async (file) => {
+      const content = await readConfig(file);
+      for (const optIn of FORBIDDEN_OPT_INS) {
+        expect(
+          content,
+          `${file} re-enables PII via "${optIn}"`,
+        ).not.toContain(optIn);
+      }
+    },
+  );
+
+  it.each(CONFIG_FILES)(
+    '%s no longer uses the deprecated sendDefaultPii flag',
+    async (file) => {
+      const content = await readConfig(file);
+      expect(content).not.toContain('sendDefaultPii');
+    },
+  );
+
+  it.each(CONFIG_FILES)(
+    '%s keeps scrubSentryEvent as defence-in-depth on beforeSend',
+    async (file) => {
+      const content = await readConfig(file);
+      expect(content).toContain('beforeSend: scrubSentryEvent');
+    },
+  );
+});

--- a/web/src/lib/monitoring/sentryConfig.ts
+++ b/web/src/lib/monitoring/sentryConfig.ts
@@ -153,12 +153,15 @@ function fingerprintEvent(event: Event): Event {
 //
 // Defence-in-depth for two High-severity audit findings (2026-05-30):
 //   - F04: stack-frame local variables can hold decrypted BYOK provider keys and
-//          prompts. We removed `includeLocalVariables` from the server init, and
-//          additionally strip `frame.vars` here in case it is ever re-enabled or
-//          populated by an integration.
-//   - F03: `sendDefaultPii` is now false, but breadcrumbs, exception messages,
-//          request bodies, and structured context can still embed emails, IPs,
-//          cookies, auth headers, and API keys. This hook redacts them.
+//          prompts. We removed `includeLocalVariables` from the server init and
+//          set `dataCollection.stackFrameVariables: false`, and additionally strip
+//          `frame.vars` here in case it is ever re-enabled or populated by an
+//          integration.
+//   - F03: default PII collection is disabled via the exhaustive `dataCollection`
+//          opt-out (migrated from `sendDefaultPii: false`), but breadcrumbs,
+//          exception messages, request bodies, and structured context can still
+//          embed emails, IPs, cookies, auth headers, and API keys. This hook
+//          redacts them.
 //
 // `scrubEvent` is wired as both `beforeSend` and `beforeSendTransaction` in every
 // Sentry.init (server, edge, client). It always returns the (mutated) event — the


### PR DESCRIPTION
## Summary

`sendDefaultPii` is deprecated in `@sentry/nextjs` 10.57 and removed in v11. This migrates all three Sentry init sites off it to the new `dataCollection` framework, bumping `@sentry/nextjs` 10.55.0 → 10.57.0, and adds a regression guard. **The F03/F04 audit posture is preserved: no default PII.**

### The exhaustive-default trap (why this needs a test)

In the new SDK, once **any** `dataCollection` key is set, every **omitted** field falls back to Sentry's *permissive* defaults (cookies, queryParams, httpHeaders, genAI inputs/outputs, stackFrameVariables all default **ON**). A single dropped field would silently re-enable PII capture while passing every existing gate. So the opt-out object must be exhaustive, and that exhaustiveness must be tested.

### Changes

- `web/sentry.server.config.ts`, `web/sentry.edge.config.ts`, `web/instrumentation-client.ts` — replace `sendDefaultPii: false` with the full 7-field opt-out (`userInfo`, `cookies`, `queryParams`, `httpHeaders {request,response}`, `httpBodies: []`, `genAI {inputs,outputs}`, `stackFrameVariables`), identical across all three. `beforeSend`/`beforeSendTransaction: scrubSentryEvent` defence-in-depth retained.
- `web/src/lib/__tests__/sentry-regressions.test.ts` — new `it.each` block over all three configs asserting the block is present, all 7 surfaces are opted out, none is flipped on, and `scrubSentryEvent` stays wired. Comments are stripped before scanning so the migration-documenting prose isn't mistaken for active config.
- `@sentry/nextjs` 10.55.0 → 10.57.0 + lockfile.

## Validation

- `tsc --noEmit` — 0 errors against the installed `@sentry/nextjs@10.57.0` (`dataCollection` is in its `@sentry/core` types, so the option is genuinely type-checked, not a silent excess property)
- `eslint --max-warnings 0` on the test — clean
- `sentry-regressions.test.ts` — 44/44 pass; mutation-traced (removing a `cookies: false` line fails the test)
- **Lockfile Sync** gate dry-run — zero diff
- Security / test / architecture reviews — all PASS. `vercelAIIntegration` confirmed **not** recording prompts/responses because `genAI.inputs/outputs` are `false`.

## Follow-up (non-blocking, pre-existing on `origin/main` — NOT addressed here)

`enableLogs: true` with no `beforeSendLog` hook means `Sentry.logger.*` events route through `beforeSendLog` and bypass `scrubSentryEvent`. Dormant today (no `Sentry.logger.*` call sites log secrets), but structural. Recommend a separate ticket to add `beforeSendLog: scrubSentryEvent` to all three init calls.

## Test plan

- [ ] CI green (lint, tsc, vitest, Lockfile Sync)

Closes #8778