### PR TITLE
fix(security): filter detail routes to published records (marketplace asset + community game)

### DIFF
--- a/.changeset/fix-status-leak-detail-routes.md
+++ b/.changeset/fix-status-leak-detail-routes.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Stop the marketplace asset detail (`/api/marketplace/assets/[id]`) and community game detail (`/api/community/games/[id]`) endpoints from leaking non-public records. Both detail routes fetched by `id` with no status constraint, so draft/pending/rejected/removed assets and processing/unpublished/removed games were exposed to anyone who knew (or guessed) an id — diverging from the list routes, which already filter to `status = 'published'`. The detail queries now apply the same `status = 'published'` filter and return 404 for anything else, so a record's existence is not disclosed.

--- a/web/src/app/api/community/games/[id]/route.test.ts
+++ b/web/src/app/api/community/games/[id]/route.test.ts
@@ -3,10 +3,11 @@ vi.mock('server-only', () => ({}));
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { getDb } from '@/lib/db/client';
-import { eq } from 'drizzle-orm';
 
-// Spy on drizzle's `eq` so we can assert the route applies the
-// `status = 'published'` visibility filter (the .where() mock is a passthrough).
+// Mock drizzle's `eq`/`and` to return inspectable plain objects so we can assert
+// on the composed predicate the route passes to `.where()`. We inspect the
+// `.where()` call argument directly (not the `eq` spy identity) so the assertion
+// is robust to `vi.resetModules()` re-running this factory on each dynamic import.
 vi.mock('drizzle-orm', async (importOriginal) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return {
@@ -80,7 +81,10 @@ describe('GET /api/community/games/[id]', () => {
 
     // Security: the detail query MUST constrain to published games so
     // processing/unpublished/removed games are never exposed (#8614, #8638).
-    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+    // Assert on the WHERE predicate the route actually composed (status filter),
+    // not the drizzle `eq` spy identity — the latter is unreliable across the
+    // `vi.resetModules()` in beforeEach.
+    expect(JSON.stringify(gameChain.where.mock.calls)).toContain('"__eq":["status","published"]');
   });
 
   it('should not leak a non-published (processing/unpublished/removed) game — returns 404', async () => {
@@ -96,7 +100,8 @@ describe('GET /api/community/games/[id]', () => {
 
     expect(res.status).toBe(404);
     expect(body.error).toBe('Game not found');
-    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+    // The status filter is what makes a processing/unpublished game match no row.
+    expect(JSON.stringify(gameChain.where.mock.calls)).toContain('"__eq":["status","published"]');
   });
 
   it('should return 404 when game not found', async () => {

--- a/web/src/app/api/community/games/[id]/route.test.ts
+++ b/web/src/app/api/community/games/[id]/route.test.ts
@@ -3,6 +3,18 @@ vi.mock('server-only', () => ({}));
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { getDb } from '@/lib/db/client';
+import { eq } from 'drizzle-orm';
+
+// Spy on drizzle's `eq` so we can assert the route applies the
+// `status = 'published'` visibility filter (the .where() mock is a passthrough).
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+    and: vi.fn((...conds: unknown[]) => ({ __and: conds })),
+  };
+});
 
 vi.mock('@/lib/db/client');
 vi.mock('@/lib/db/schema', () => ({
@@ -65,6 +77,26 @@ describe('GET /api/community/games/[id]', () => {
     expect(body.game.tags).toEqual(['puzzle', 'casual']);
     expect(body.game.comments).toHaveLength(1);
     expect(body.game.ratingBreakdown).toHaveLength(5);
+
+    // Security: the detail query MUST constrain to published games so
+    // processing/unpublished/removed games are never exposed (#8614, #8638).
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+  });
+
+  it('should not leak a non-published (processing/unpublished/removed) game — returns 404', async () => {
+    // With the status filter applied, a processing game matches no row → empty result.
+    const gameChain = mockDbChain([]);
+    const mockDb = { select: vi.fn().mockReturnValue(gameChain) };
+    vi.mocked(getDb).mockReturnValue(mockDb as never);
+
+    const { GET } = await import('./route');
+    const req = new NextRequest('http://localhost:3000/api/community/games/processing-game');
+    const res = await GET(req, { params: Promise.resolve({ id: 'processing-game' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Game not found');
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
   });
 
   it('should return 404 when game not found', async () => {

--- a/web/src/app/api/community/games/[id]/route.ts
+++ b/web/src/app/api/community/games/[id]/route.ts
@@ -37,7 +37,10 @@ export async function GET(
       .leftJoin(users, eq(publishedGames.userId, users.id))
       .leftJoin(gameLikes, eq(publishedGames.id, gameLikes.gameId))
       .leftJoin(gameRatings, eq(publishedGames.id, gameRatings.gameId))
-      .where(eq(publishedGames.id, id))
+      // Only published games are publicly visible. Mirrors the list route's
+      // `status = 'published'` filter so processing/unpublished/removed games
+      // are not leaked via the detail endpoint (404, not their existence).
+      .where(and(eq(publishedGames.id, id), eq(publishedGames.status, 'published')))
       .groupBy(
         publishedGames.id,
         publishedGames.title,

--- a/web/src/app/api/marketplace/assets/[id]/route.test.ts
+++ b/web/src/app/api/marketplace/assets/[id]/route.test.ts
@@ -3,6 +3,20 @@ vi.mock('server-only', () => ({}));
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { getDb } from '@/lib/db/client';
+import { eq } from 'drizzle-orm';
+
+// Spy on drizzle's `eq`/`and` so we can assert the route applies the
+// `status = 'published'` visibility filter (the .where() mock is a passthrough
+// and cannot otherwise observe the predicate).
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return {
+    ...actual,
+    eq: vi.fn((col: unknown, val: unknown) => ({ __eq: [col, val] })),
+    and: vi.fn((...conds: unknown[]) => ({ __and: conds })),
+    desc: vi.fn((col: unknown) => ({ __desc: col })),
+  };
+});
 
 vi.mock('@/lib/db/client');
 vi.mock('@/lib/db/schema', () => ({
@@ -11,7 +25,7 @@ vi.mock('@/lib/db/schema', () => ({
     priceTokens: 'priceTokens', license: 'license', previewUrl: 'previewUrl',
     assetFileSize: 'assetFileSize', downloadCount: 'downloadCount', avgRating: 'avgRating',
     ratingCount: 'ratingCount', tags: 'tags', aiGenerated: 'aiGenerated', aiProvider: 'aiProvider',
-    metadataJson: 'metadataJson', createdAt: 'createdAt', sellerId: 'sellerId',
+    metadataJson: 'metadataJson', createdAt: 'createdAt', sellerId: 'sellerId', status: 'status',
   },
   sellerProfiles: { userId: 'userId', displayName: 'displayName', bio: 'bio', portfolioUrl: 'portfolioUrl' },
   assetReviews: { id: 'id', rating: 'rating', content: 'content', createdAt: 'createdAt', assetId: 'assetId', userId: 'userId' },
@@ -88,6 +102,31 @@ describe('GET /api/marketplace/assets/[id]', () => {
     expect(body.asset.aiGenerated).toBe(true);
     expect(body.asset.seller.name).toBe('Seller');
     expect(body.reviews).toHaveLength(1);
+
+    // Security: the detail query MUST constrain to published assets so
+    // draft/pending/rejected/removed assets are never exposed (#8640).
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+  });
+
+  it('should not leak a non-published (draft/pending/rejected/removed) asset — returns 404', async () => {
+    // With the status filter applied, a draft asset matches no row → empty result.
+    const assetChain = {
+      from: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    const mockDb = { select: vi.fn().mockReturnValue(assetChain) };
+    vi.mocked(getDb).mockReturnValue(mockDb as never);
+
+    const { GET } = await import('./route');
+    const req = new NextRequest('http://localhost:3000/api/marketplace/assets/draft-asset');
+    const res = await GET(req, { params: Promise.resolve({ id: 'draft-asset' }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Asset not found');
+    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
   });
 
   it('should return 404 when asset not found', async () => {

--- a/web/src/app/api/marketplace/assets/[id]/route.test.ts
+++ b/web/src/app/api/marketplace/assets/[id]/route.test.ts
@@ -3,11 +3,11 @@ vi.mock('server-only', () => ({}));
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { getDb } from '@/lib/db/client';
-import { eq } from 'drizzle-orm';
 
-// Spy on drizzle's `eq`/`and` so we can assert the route applies the
-// `status = 'published'` visibility filter (the .where() mock is a passthrough
-// and cannot otherwise observe the predicate).
+// Mock drizzle's `eq`/`and`/`desc` to return inspectable plain objects so we can
+// assert on the composed predicate the route passes to `.where()`. We inspect the
+// `.where()` call argument directly (not the `eq` spy identity) so the assertion
+// is robust to `vi.resetModules()` re-running this factory on each dynamic import.
 vi.mock('drizzle-orm', async (importOriginal) => {
   const actual = await importOriginal<typeof import('drizzle-orm')>();
   return {
@@ -105,7 +105,10 @@ describe('GET /api/marketplace/assets/[id]', () => {
 
     // Security: the detail query MUST constrain to published assets so
     // draft/pending/rejected/removed assets are never exposed (#8640).
-    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+    // Assert on the WHERE predicate the route actually composed (status filter),
+    // not the drizzle `eq` spy identity — the latter is unreliable across the
+    // `vi.resetModules()` in beforeEach.
+    expect(JSON.stringify(assetChain.where.mock.calls)).toContain('"__eq":["status","published"]');
   });
 
   it('should not leak a non-published (draft/pending/rejected/removed) asset — returns 404', async () => {
@@ -126,7 +129,8 @@ describe('GET /api/marketplace/assets/[id]', () => {
 
     expect(res.status).toBe(404);
     expect(body.error).toBe('Asset not found');
-    expect(vi.mocked(eq)).toHaveBeenCalledWith('status', 'published');
+    // The status filter is what makes a draft/pending/rejected asset match no row.
+    expect(JSON.stringify(assetChain.where.mock.calls)).toContain('"__eq":["status","published"]');
   });
 
   it('should return 404 when asset not found', async () => {

--- a/web/src/app/api/marketplace/assets/[id]/route.ts
+++ b/web/src/app/api/marketplace/assets/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getDb, queryWithResilience } from '@/lib/db/client';
 import { marketplaceAssets, sellerProfiles, assetReviews, users } from '@/lib/db/schema';
-import { eq, desc } from 'drizzle-orm';
+import { eq, desc, and } from 'drizzle-orm';
 import { rateLimitPublicRoute } from '@/lib/rateLimit';
 import { captureException } from '@/lib/monitoring/sentry-server';
 
@@ -40,7 +40,10 @@ export async function GET(
       })
       .from(marketplaceAssets)
       .leftJoin(sellerProfiles, eq(marketplaceAssets.sellerId, sellerProfiles.userId))
-      .where(eq(marketplaceAssets.id, id))
+      // Only published assets are publicly visible. Mirrors the list route's
+      // `status = 'published'` filter so draft/pending/rejected/removed assets
+      // are not leaked via the detail endpoint (404, not their existence).
+      .where(and(eq(marketplaceAssets.id, id), eq(marketplaceAssets.status, 'published')))
       .limit(1));
 
     if (!asset) {


### PR DESCRIPTION
## Summary
- The marketplace asset detail route (`/api/marketplace/assets/[id]`) and the community game detail route returned records in ANY status, leaking draft/processing/pending/rejected/removed rows that the list routes already hide.
- Both detail handlers now compose `and(eq(id, …), eq(status, 'published'))` in their `.where()`, mirroring the existing list-route filter. A non-published id returns 404 (no existence disclosure).
- The early `if (!record)` gate stops all downstream queries (reviews, tags, comments, ratings), so no secondary data leaks either.

Closes #8640
Closes #8614
Closes #8638

## Test plan
- [x] Added per-route regression tests asserting the composed WHERE predicate includes `status='published'` (fails on the pre-fix `.where(eq(id))`)
- [x] Added a 404 test for a non-published record on each route
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, targeted vitest green