### PR TITLE
fix(security): order CSP route rules so /play + content overrides actually win

### DIFF
--- a/.changeset/fix-csp-eval-scoping.md
+++ b/.changeset/fix-csp-eval-scoping.md
@@ -2,8 +2,8 @@
 "web": patch
 ---
 
-Scope `'unsafe-eval'` out of the public content routes' Content-Security-Policy
-(#8612, #8634).
+Scope `'unsafe-eval'` out of the public content routes' and `/play`'s
+Content-Security-Policy (#8612, #8634).
 
 The global `script-src` previously granted `'unsafe-eval'` to every route. It is
 genuinely required only on the editor surface (`/dev`, `/editor/:path*`), where
@@ -12,12 +12,23 @@ constructor inside a same-origin worker that inherits the document CSP —
 `'wasm-unsafe-eval'` does not cover `eval`/`Function`. The CSP builder is now
 extracted to `src/lib/security/csp.ts`, and the script-free public content routes
 (`/community`, `/blog`, `/about`, `/pricing`, `/docs`, … — the user-generated
--content surface the findings call out) receive a tightened policy with
-`'unsafe-eval'` removed, emitted alongside the global policy so browsers enforce
-the most-restrictive intersection (the same mechanism `/play` already uses).
+-content surface the findings call out) plus the published-game surface (`/play`)
+receive tightened, eval-free policies.
 
-`'unsafe-inline'` is retained: it is required by Clerk and Next.js inline
-framework scripts, and a nonce-based migration would break this app's statically
-rendered pages (the same failure mode that forced SRI removal). Fully dropping
-`'unsafe-eval'` everywhere would require re-architecting the script sandbox onto
-a cross-origin/blob worker with its own CSP — tracked separately.
+The route scoping had to be corrected to actually take effect. Next.js applies
+every matching `headers()` rule and the **last** writer of a duplicate header key
+wins — it is not a browser-style intersection of multiple CSP headers. The
+tightened overrides were previously listed *before* the permissive global
+`/:path*` rule, so the global rule silently overrode them and `'unsafe-eval'`
+stayed live on both the content routes and `/play`. The ordered rule list is now
+the single source of truth in `src/lib/security/csp.ts` (global first, overrides
+after) with the ordering + per-route effective policy unit-tested, so a future
+reordering fails CI instead of silently reopening the hole.
+
+`'unsafe-inline'` is retained on the editor/content routes: it is required by
+Clerk and Next.js inline framework scripts, and a nonce-based migration would
+break this app's statically rendered pages (the same failure mode that forced SRI
+removal). `/play` carries neither `'unsafe-eval'` nor `'unsafe-inline'` since a
+played game runs only first-party code + WASM. Fully dropping `'unsafe-eval'`
+everywhere would require re-architecting the editor script sandbox onto a
+cross-origin/blob worker with its own CSP — tracked separately.

--- a/.changeset/fix-csp-eval-scoping.md
+++ b/.changeset/fix-csp-eval-scoping.md
@@ -1,0 +1,23 @@
+---
+"web": patch
+---
+
+Scope `'unsafe-eval'` out of the public content routes' Content-Security-Policy
+(#8612, #8634).
+
+The global `script-src` previously granted `'unsafe-eval'` to every route. It is
+genuinely required only on the editor surface (`/dev`, `/editor/:path*`), where
+the in-editor script sandbox compiles user scripts with the `Function()`
+constructor inside a same-origin worker that inherits the document CSP —
+`'wasm-unsafe-eval'` does not cover `eval`/`Function`. The CSP builder is now
+extracted to `src/lib/security/csp.ts`, and the script-free public content routes
+(`/community`, `/blog`, `/about`, `/pricing`, `/docs`, … — the user-generated
+-content surface the findings call out) receive a tightened policy with
+`'unsafe-eval'` removed, emitted alongside the global policy so browsers enforce
+the most-restrictive intersection (the same mechanism `/play` already uses).
+
+`'unsafe-inline'` is retained: it is required by Clerk and Next.js inline
+framework scripts, and a nonce-based migration would break this app's statically
+rendered pages (the same failure mode that forced SRI removal). Fully dropping
+`'unsafe-eval'` everywhere would require re-architecting the script sandbox onto
+a cross-origin/blob worker with its own CSP — tracked separately.

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 import createNextIntlPlugin from "next-intl/plugin";
+import {
+  buildContentSecurityPolicy,
+  EVAL_FREE_ROUTE_SOURCES,
+} from "./src/lib/security/csp";
 
 const analyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -12,22 +16,15 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 const engineCdn = process.env.NEXT_PUBLIC_ENGINE_CDN_URL || "";
 const cdnDirective = engineCdn ? ` ${engineCdn}` : "";
 
-const cspDirectives = [
-  "default-src 'self'",
-  // 'unsafe-inline' is required for Clerk's sign-in/sign-up inline scripts in production.
-  // Since 'unsafe-eval' is already allowed (for WASM), 'unsafe-inline' does not
-  // meaningfully reduce CSP security. The /play/:path* route keeps a strict CSP.
-  `script-src 'self' 'unsafe-eval' 'unsafe-inline' 'wasm-unsafe-eval' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://challenges.cloudflare.com${cdnDirective}`,
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: https://img.clerk.com https://clerk.spawnforge.ai",
-  "font-src 'self' data:",
-  `connect-src 'self' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://api.anthropic.com https://api.meshy.ai https://api.elevenlabs.io https://studio-api.suno.ai https://api.hyper3d.ai${cdnDirective}`,
-  "frame-src 'self' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://challenges.cloudflare.com",
-  "worker-src 'self' blob:",
-  "media-src 'self' blob:",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-];
+// Global CSP. 'unsafe-eval' is retained because the in-editor script sandbox
+// compiles user scripts with Function() inside a same-origin worker that inherits
+// this policy (see src/lib/security/csp.ts). It is scoped OUT of script-free public
+// routes via EVAL_FREE_ROUTE_SOURCES below (#8612, #8634).
+const globalCsp = buildContentSecurityPolicy({ allowUnsafeEval: true, engineCdn });
+// Tightened CSP (no 'unsafe-eval') applied to public content routes that never
+// mount the script sandbox. Emitted alongside the global policy; browsers enforce
+// the intersection, so these routes effectively lose 'unsafe-eval'.
+const evalFreeCsp = buildContentSecurityPolicy({ allowUnsafeEval: false, engineCdn });
 
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
@@ -40,7 +37,7 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: cspDirectives.join("; "),
+    value: globalCsp,
   },
 ];
 
@@ -102,6 +99,14 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // Tighten 'unsafe-eval' out of public content routes that never run the
+      // editor script sandbox. Listed BEFORE the global /:path* rule; the
+      // tightened CSP is emitted alongside the global one and browsers enforce
+      // the most-restrictive intersection (#8612, #8634).
+      ...EVAL_FREE_ROUTE_SOURCES.map((source) => ({
+        source,
+        headers: [{ key: "Content-Security-Policy", value: evalFreeCsp }],
+      })),
       {
         source: "/:path*",
         headers: securityHeaders,

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,10 +2,7 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import withBundleAnalyzer from "@next/bundle-analyzer";
 import createNextIntlPlugin from "next-intl/plugin";
-import {
-  buildContentSecurityPolicy,
-  EVAL_FREE_ROUTE_SOURCES,
-} from "./src/lib/security/csp";
+import { buildCspRouteRules } from "./src/lib/security/csp";
 
 const analyzer = withBundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -14,18 +11,19 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 // CDN origin for WASM engine files (e.g. "https://cdn.spawnforge.ai")
 const engineCdn = process.env.NEXT_PUBLIC_ENGINE_CDN_URL || "";
-const cdnDirective = engineCdn ? ` ${engineCdn}` : "";
 
-// Global CSP. 'unsafe-eval' is retained because the in-editor script sandbox
-// compiles user scripts with Function() inside a same-origin worker that inherits
-// this policy (see src/lib/security/csp.ts). It is scoped OUT of script-free public
-// routes via EVAL_FREE_ROUTE_SOURCES below (#8612, #8634).
-const globalCsp = buildContentSecurityPolicy({ allowUnsafeEval: true, engineCdn });
-// Tightened CSP (no 'unsafe-eval') applied to public content routes that never
-// mount the script sandbox. Emitted alongside the global policy; browsers enforce
-// the intersection, so these routes effectively lose 'unsafe-eval'.
-const evalFreeCsp = buildContentSecurityPolicy({ allowUnsafeEval: false, engineCdn });
+// Per-route Content-Security-Policy rules. ORDER IS LOAD-BEARING: Next.js applies
+// every matching headers() rule and the LAST writer of a duplicate key wins (it
+// is NOT a browser-style intersection). buildCspRouteRules() therefore emits the
+// permissive global /:path* rule FIRST and the tightened /play + content-route
+// overrides AFTER it, so each override is the last writer for its paths and
+// 'unsafe-eval' is actually dropped there (#8612, #8634). Single source of truth
+// + ordering contract live in src/lib/security/csp.ts and are unit-tested.
+const cspRouteRules = buildCspRouteRules({ engineCdn });
 
+// Non-CSP security headers applied to every route. CSP is intentionally NOT here
+// — it comes from cspRouteRules so the last-writer-wins ordering is explicit and
+// testable. These keys never collide with the CSP rules, so their order is moot.
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
@@ -34,10 +32,6 @@ const securityHeaders = [
   {
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=()",
-  },
-  {
-    key: "Content-Security-Policy",
-    value: globalCsp,
   },
 ];
 
@@ -89,28 +83,17 @@ const nextConfig: NextConfig = {
   },
   async headers() {
     return [
-      {
-        // Restrictive CSP for published/played games — no unsafe-eval needed
-        source: "/play/:path*",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: `default-src 'self'; script-src 'self' 'wasm-unsafe-eval'${cdnDirective}; connect-src 'self'${cdnDirective}; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; frame-ancestors 'none'`,
-          },
-        ],
-      },
-      // Tighten 'unsafe-eval' out of public content routes that never run the
-      // editor script sandbox. Listed BEFORE the global /:path* rule; the
-      // tightened CSP is emitted alongside the global one and browsers enforce
-      // the most-restrictive intersection (#8612, #8634).
-      ...EVAL_FREE_ROUTE_SOURCES.map((source) => ({
-        source,
-        headers: [{ key: "Content-Security-Policy", value: evalFreeCsp }],
-      })),
+      // Non-CSP security headers for every route. CSP is supplied separately by
+      // cspRouteRules (below) so the last-writer-wins ordering is explicit.
       {
         source: "/:path*",
         headers: securityHeaders,
       },
+      // Content-Security-Policy rules, already ordered global-first so the
+      // tightened /play + content-route overrides win under Next's
+      // last-writer-wins semantics (#8612, #8634). Do NOT reorder by hand — the
+      // ordering contract is owned and tested in src/lib/security/csp.ts.
+      ...cspRouteRules,
       {
         source: "/engine-pkg-webgl2/:path*",
         headers: [

--- a/web/src/lib/security/__tests__/csp.test.ts
+++ b/web/src/lib/security/__tests__/csp.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildContentSecurityPolicy,
+  EVAL_FREE_ROUTE_SOURCES,
+} from '../csp';
+
+/** Pull the `script-src` directive out of a full CSP header value. */
+function scriptSrc(csp: string): string {
+  const directive = csp.split(';').map((d) => d.trim()).find((d) => d.startsWith('script-src '));
+  if (!directive) throw new Error('no script-src directive in CSP');
+  return directive;
+}
+
+describe('buildContentSecurityPolicy (#8612, #8634)', () => {
+  describe('eval scoping', () => {
+    it("includes 'unsafe-eval' only when allowUnsafeEval is true (editor/sandbox routes)", () => {
+      const permissive = buildContentSecurityPolicy({ allowUnsafeEval: true });
+      expect(scriptSrc(permissive)).toContain("'unsafe-eval'");
+    });
+
+    it("omits 'unsafe-eval' when allowUnsafeEval is false (public content routes)", () => {
+      const strict = buildContentSecurityPolicy({ allowUnsafeEval: false });
+      // Must NOT contain the standalone eval token...
+      expect(scriptSrc(strict)).not.toContain("'unsafe-eval'");
+      // ...but MUST retain 'wasm-unsafe-eval' (it is a distinct token, and even
+      // content routes may lazy-load WASM-backed widgets).
+      expect(scriptSrc(strict)).toContain("'wasm-unsafe-eval'");
+    });
+
+    it("substring of 'wasm-unsafe-eval' is not mistaken for 'unsafe-eval' removal", () => {
+      // Regression guard: the only delta between the two policies is the
+      // standalone "'unsafe-eval'" token, NOT the 'wasm-unsafe-eval' substring.
+      const permissive = buildContentSecurityPolicy({ allowUnsafeEval: true });
+      const strict = buildContentSecurityPolicy({ allowUnsafeEval: false });
+      expect(permissive.replace(" 'unsafe-eval'", '')).toBe(strict);
+    });
+  });
+
+  describe('unchanged hardening guarantees', () => {
+    it("retains 'unsafe-inline' in both modes (required by Clerk + Next framework scripts)", () => {
+      expect(scriptSrc(buildContentSecurityPolicy({ allowUnsafeEval: true }))).toContain("'unsafe-inline'");
+      expect(scriptSrc(buildContentSecurityPolicy({ allowUnsafeEval: false }))).toContain("'unsafe-inline'");
+    });
+
+    it("keeps default-src 'self' and frame-ancestors 'none' regardless of eval scope", () => {
+      for (const allowUnsafeEval of [true, false]) {
+        const csp = buildContentSecurityPolicy({ allowUnsafeEval });
+        expect(csp).toContain("default-src 'self'");
+        expect(csp).toContain("frame-ancestors 'none'");
+      }
+    });
+
+    it('appends the engine CDN origin to script-src and connect-src when provided', () => {
+      const cdn = 'https://cdn.spawnforge.test';
+      const csp = buildContentSecurityPolicy({ allowUnsafeEval: false, engineCdn: cdn });
+      expect(scriptSrc(csp)).toContain(cdn);
+      const connect = csp.split(';').map((d) => d.trim()).find((d) => d.startsWith('connect-src '));
+      expect(connect).toContain(cdn);
+    });
+
+    it('does not append a CDN origin when none is configured', () => {
+      const csp = buildContentSecurityPolicy({ allowUnsafeEval: false });
+      expect(csp).not.toContain('undefined');
+      // No trailing/double spaces from an empty CDN directive.
+      expect(csp).not.toMatch(/\s{2,}/);
+    });
+  });
+
+  describe('EVAL_FREE_ROUTE_SOURCES', () => {
+    it('covers the user-content surface named in the findings (community) but excludes editor routes', () => {
+      expect(EVAL_FREE_ROUTE_SOURCES).toContain('/community/:path*');
+      // Editor routes must NOT be tightened — they need 'unsafe-eval' for the
+      // Function()-based script sandbox. A tightening entry would break scripting.
+      expect(EVAL_FREE_ROUTE_SOURCES).not.toContain('/editor/:path*');
+      expect(EVAL_FREE_ROUTE_SOURCES).not.toContain('/dev/:path*');
+      expect(EVAL_FREE_ROUTE_SOURCES).not.toContain('/dev');
+    });
+
+    it('lists only well-formed Next.js route source patterns', () => {
+      for (const source of EVAL_FREE_ROUTE_SOURCES) {
+        expect(source.startsWith('/')).toBe(true);
+        expect(source).not.toContain('//');
+      }
+    });
+  });
+});

--- a/web/src/lib/security/__tests__/csp.test.ts
+++ b/web/src/lib/security/__tests__/csp.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildContentSecurityPolicy,
+  buildCspRouteRules,
+  buildPlayContentSecurityPolicy,
+  cspSourceToRegExp,
+  effectiveCspForPath,
   EVAL_FREE_ROUTE_SOURCES,
 } from '../csp';
 
@@ -82,5 +86,110 @@ describe('buildContentSecurityPolicy (#8612, #8634)', () => {
         expect(source).not.toContain('//');
       }
     });
+  });
+});
+
+describe('buildPlayContentSecurityPolicy', () => {
+  it('locks script-src to first-party + WASM only (no eval, no inline)', () => {
+    const csp = buildPlayContentSecurityPolicy();
+    expect(scriptSrc(csp)).toBe("script-src 'self' 'wasm-unsafe-eval'");
+    expect(scriptSrc(csp)).not.toContain("'unsafe-eval'"); // standalone token absent
+    expect(scriptSrc(csp)).not.toContain("'unsafe-inline'");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+  });
+
+  it('appends the engine CDN origin to script-src and connect-src when provided', () => {
+    const cdn = 'https://cdn.spawnforge.test';
+    const csp = buildPlayContentSecurityPolicy(cdn);
+    expect(scriptSrc(csp)).toContain(cdn);
+    const connect = csp.split(';').map((d) => d.trim()).find((d) => d.startsWith('connect-src '));
+    expect(connect).toContain(cdn);
+  });
+});
+
+describe('cspSourceToRegExp (Next.js source pattern matching)', () => {
+  it('treats /:path* as a catch-all that matches every route incl. the root', () => {
+    const re = cspSourceToRegExp('/:path*');
+    expect(re.test('/')).toBe(true);
+    expect(re.test('/anything')).toBe(true);
+    expect(re.test('/a/b/c')).toBe(true);
+    expect(re.test('/play/game-1')).toBe(true);
+  });
+
+  it('matches a prefixed wildcard against the prefix and its descendants only', () => {
+    const re = cspSourceToRegExp('/play/:path*');
+    expect(re.test('/play')).toBe(true);
+    expect(re.test('/play/game-1')).toBe(true);
+    expect(re.test('/play/a/b')).toBe(true);
+    // A sibling prefix that merely starts with the same letters must NOT match.
+    expect(re.test('/playground')).toBe(false);
+    expect(re.test('/community/x')).toBe(false);
+  });
+});
+
+describe('buildCspRouteRules — ordering contract (#8612, #8634)', () => {
+  // This is the regression guard for the live bug: Next.js applies every matching
+  // headers() rule and the LAST writer of a duplicate key wins (NOT a browser
+  // intersection). The permissive global rule must therefore be emitted BEFORE the
+  // tightened overrides, or it silently overrides them and 'unsafe-eval' leaks back
+  // onto /play and the public content routes. The prior code ordered them the wrong
+  // way around; these assertions fail on that ordering.
+  it('emits the global /:path* rule BEFORE the /play and content-route overrides', () => {
+    const rules = buildCspRouteRules({ engineCdn: '' });
+    const sources = rules.map((r) => r.source);
+    const globalIdx = sources.indexOf('/:path*');
+    const playIdx = sources.indexOf('/play/:path*');
+    const communityIdx = sources.indexOf('/community/:path*');
+
+    expect(globalIdx).toBe(0);
+    expect(playIdx).toBeGreaterThan(globalIdx);
+    expect(communityIdx).toBeGreaterThan(globalIdx);
+    // Every eval-free content source must appear after the global rule.
+    for (const source of EVAL_FREE_ROUTE_SOURCES) {
+      expect(sources.indexOf(source)).toBeGreaterThan(globalIdx);
+    }
+  });
+
+  it('every rule sets exactly the Content-Security-Policy header', () => {
+    for (const rule of buildCspRouteRules()) {
+      expect(rule.headers).toHaveLength(1);
+      expect(rule.headers[0].key).toBe('Content-Security-Policy');
+      expect(rule.headers[0].value.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('effectiveCspForPath — resolves last-writer-wins per route (#8612, #8634)', () => {
+  const rules = buildCspRouteRules({ engineCdn: '' });
+  const evalOf = (path: string) => {
+    const csp = effectiveCspForPath(rules, path);
+    if (!csp) throw new Error(`no CSP resolved for ${path}`);
+    return scriptSrc(csp);
+  };
+
+  it("KEEPS 'unsafe-eval' on editor + default routes (Function() script sandbox needs it)", () => {
+    expect(evalOf('/dev')).toContain("'unsafe-eval'");
+    expect(evalOf('/editor/scene-1')).toContain("'unsafe-eval'");
+    expect(evalOf('/')).toContain("'unsafe-eval'");
+    expect(evalOf('/some/marketing/page')).toContain("'unsafe-eval'");
+  });
+
+  it("DROPS 'unsafe-eval' on public content routes (the override must actually win)", () => {
+    // Regression: under the old (broken) ordering the global rule overrode these,
+    // so 'unsafe-eval' stayed present here. The override now wins.
+    expect(evalOf('/community/games/123')).not.toContain("'unsafe-eval'");
+    expect(evalOf('/pricing')).not.toContain("'unsafe-eval'");
+    expect(evalOf('/docs/getting-started')).not.toContain("'unsafe-eval'");
+    // 'wasm-unsafe-eval' (a distinct token) is retained on content routes.
+    expect(evalOf('/community/games/123')).toContain("'wasm-unsafe-eval'");
+  });
+
+  it('applies the locked-down game policy to /play (no eval, no inline, no Clerk)', () => {
+    const playScript = evalOf('/play/game-1');
+    expect(playScript).toBe("script-src 'self' 'wasm-unsafe-eval'");
+    expect(playScript).not.toContain("'unsafe-eval'");
+    expect(playScript).not.toContain("'unsafe-inline'");
+    expect(playScript).not.toContain('clerk');
   });
 });

--- a/web/src/lib/security/csp.ts
+++ b/web/src/lib/security/csp.ts
@@ -80,13 +80,11 @@ export function buildContentSecurityPolicy({ allowUnsafeEval, engineCdn = '' }: 
 
 /**
  * Public/content route prefixes that never mount the editor script sandbox and
- * therefore receive the eval-free (tightened) CSP. Browsers enforce every CSP
- * header present on a response as an intersection, so emitting the tightened
- * policy alongside the permissive global policy yields the most-restrictive
- * (eval-free) result on these routes — the same mechanism `/play` relies on.
+ * therefore receive the eval-free (tightened) CSP.
  *
  * Editor routes (`/dev`, `/editor/:path*`) are deliberately absent so they keep
- * the global policy's `'unsafe-eval'`.
+ * the global policy's `'unsafe-eval'`, which their `Function()`-based script
+ * sandbox requires.
  */
 export const EVAL_FREE_ROUTE_SOURCES: string[] = [
   '/community/:path*',
@@ -102,3 +100,92 @@ export const EVAL_FREE_ROUTE_SOURCES: string[] = [
   '/docs/:path*',
   '/api-docs/:path*',
 ];
+
+/**
+ * Locked-down policy for published/played games (`/play/:path*`). A played game
+ * runs only first-party code + WASM, so script-src carries neither
+ * `'unsafe-eval'` nor `'unsafe-inline'` (it does not mount Clerk or the editor).
+ * Kept independent of {@link EVAL_FREE_ROUTE_SOURCES} because the game surface
+ * needs a strictly smaller allowlist than the marketing/content routes.
+ */
+export function buildPlayContentSecurityPolicy(engineCdn = ''): string {
+  const cdn = engineCdn ? ` ${engineCdn}` : '';
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'wasm-unsafe-eval'${cdn}`,
+    `connect-src 'self'${cdn}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}
+
+export interface CspRouteRule {
+  source: string;
+  headers: Array<{ key: 'Content-Security-Policy'; value: string }>;
+}
+
+/**
+ * Build the ORDERED list of Content-Security-Policy route rules consumed by
+ * `next.config.ts#headers()`. This is the single source of truth for CSP route
+ * scoping so the ordering contract below can be unit-tested.
+ *
+ * ## Ordering is load-bearing (#8634, #8612)
+ *
+ * Next.js applies EVERY matching `headers()` rule, and when two matching rules
+ * set the same header key the LAST one in the returned array wins (documented
+ * "Header Overriding Behavior"). It is NOT a browser-style intersection of
+ * multiple CSP headers — Next emits exactly one CSP header, the last writer's.
+ *
+ * Therefore the permissive global (`/:path*`) rule MUST come FIRST and the
+ * tightened per-route overrides (`/play`, the content routes) MUST come AFTER
+ * it, so each override is the last writer for its own paths and actually takes
+ * effect. The previous ordering (overrides before the global rule) was silently
+ * a no-op: the global rule overrode every tightened policy, leaving
+ * `'unsafe-eval'` live on the public content routes AND on `/play`.
+ */
+export function buildCspRouteRules({ engineCdn = '' }: { engineCdn?: string } = {}): CspRouteRule[] {
+  const globalCsp = buildContentSecurityPolicy({ allowUnsafeEval: true, engineCdn });
+  const evalFreeCsp = buildContentSecurityPolicy({ allowUnsafeEval: false, engineCdn });
+  const playCsp = buildPlayContentSecurityPolicy(engineCdn);
+  const csp = (value: string): CspRouteRule['headers'] => [
+    { key: 'Content-Security-Policy', value },
+  ];
+  return [
+    // Global FIRST — see the ordering note above. Last-writer-wins means a rule
+    // listed here can only be overridden by a more-specific rule BELOW it.
+    { source: '/:path*', headers: csp(globalCsp) },
+    // Overrides AFTER the global rule so they are the last writer for their paths.
+    { source: '/play/:path*', headers: csp(playCsp) },
+    ...EVAL_FREE_ROUTE_SOURCES.map((source) => ({ source, headers: csp(evalFreeCsp) })),
+  ];
+}
+
+/**
+ * Convert a Next.js header `source` pattern to a RegExp, mirroring the subset of
+ * path-to-regexp semantics this app uses: `/:name*` wildcard segments and
+ * `:name` single segments. This documents (and lets tests assert) the matching
+ * Next performs at runtime; it is NOT used in the request path (Next compiles
+ * the `source` patterns itself).
+ */
+export function cspSourceToRegExp(source: string): RegExp {
+  const body = source
+    .replace(/\/:[A-Za-z0-9_]+\*/g, '(?:/.*)?') // "/:path*" → optional trailing segments
+    .replace(/:[A-Za-z0-9_]+/g, '[^/]+'); // ":name" → exactly one path segment
+  return new RegExp(`^${body}/?$`);
+}
+
+/**
+ * Resolve the CSP that actually applies to `path`, simulating Next.js
+ * last-writer-wins over the ordered {@link buildCspRouteRules} output. Returns
+ * `undefined` when no rule matches.
+ */
+export function effectiveCspForPath(rules: CspRouteRule[], path: string): string | undefined {
+  let value: string | undefined;
+  for (const rule of rules) {
+    if (!cspSourceToRegExp(rule.source).test(path)) continue;
+    const header = rule.headers.find((h) => h.key === 'Content-Security-Policy');
+    if (header) value = header.value; // last writer wins — mirrors Next.js
+  }
+  return value;
+}

--- a/web/src/lib/security/csp.ts
+++ b/web/src/lib/security/csp.ts
@@ -1,0 +1,104 @@
+/**
+ * Content-Security-Policy construction for the SpawnForge web app.
+ *
+ * Extracted from `next.config.ts` so the policy can be unit-tested and so the
+ * per-route scoping logic has a single source of truth.
+ *
+ * ## Why `'unsafe-eval'` cannot simply be removed (#8612, #8634)
+ *
+ * The in-editor scripting feature compiles user-authored game scripts with the
+ * `Function(...)` constructor inside a **same-origin** Web Worker
+ * (`scriptWorker.ts` → `compileScript()`). A same-origin worker inherits the
+ * owner document's CSP, and `'wasm-unsafe-eval'` permits **only** WebAssembly
+ * compilation — it does NOT cover `eval` / `Function`. So the routes that mount
+ * the editor (`/dev`, `/editor/:path*`) genuinely require `'unsafe-eval'`;
+ * dropping it there silently breaks all in-editor scripting. The audit findings
+ * assumed `'unsafe-eval'` was only needed for WASM — it is not.
+ *
+ * ## Why `'unsafe-inline'` cannot simply be removed
+ *
+ * Clerk's sign-in/sign-up widgets and Next.js's framework bootstrap scripts emit
+ * inline `<script>` tags. The standard mitigation is a per-request nonce, but
+ * this app statically renders its public/marketing pages (and the landing page
+ * is intentionally cached), and a nonce-based policy breaks static inline
+ * scripts — the same class of failure that forced SRI to be removed
+ * (see `next.config.ts`). Until the sandbox is re-architected onto a
+ * cross-origin/blob worker with its own CSP, `'unsafe-inline'` is retained.
+ *
+ * ## What we CAN do, and do here
+ *
+ * Scope `'unsafe-eval'` down to only the editor routes. The script sandbox runs
+ * on `/dev` and `/editor/:path*` only; every other route — including the
+ * user-generated-content surfaces the findings call out (e.g. `/community`) —
+ * never compiles scripts and therefore does not need `'unsafe-eval'`. Removing
+ * it there shrinks the string-to-code attack surface as defense-in-depth, with
+ * no impact on functionality. The `/play` route already runs a strict,
+ * eval-free policy (see `next.config.ts`).
+ */
+
+export interface CspOptions {
+  /**
+   * Whether to include `'unsafe-eval'` in `script-src`. Required ONLY on routes
+   * that mount the editor's `Function()`-based script sandbox.
+   */
+  allowUnsafeEval: boolean;
+  /** Optional engine CDN origin to allow for `script-src` / `connect-src`. */
+  engineCdn?: string;
+}
+
+/**
+ * Build the application Content-Security-Policy header value.
+ *
+ * The returned policy is identical regardless of `allowUnsafeEval` EXCEPT for
+ * the presence of the `'unsafe-eval'` token in `script-src` — keeping the delta
+ * to a single token minimizes the blast radius of per-route scoping.
+ */
+export function buildContentSecurityPolicy({ allowUnsafeEval, engineCdn = '' }: CspOptions): string {
+  const cdnDirective = engineCdn ? ` ${engineCdn}` : '';
+  const evalToken = allowUnsafeEval ? " 'unsafe-eval'" : '';
+
+  const directives = [
+    "default-src 'self'",
+    // 'unsafe-eval' is gated by allowUnsafeEval — see module docstring: it is
+    // required by the same-origin script-sandbox worker's Function() compiler on
+    // editor routes, NOT by WASM (WASM uses 'wasm-unsafe-eval'). 'unsafe-inline'
+    // is required by Clerk + Next.js inline framework scripts.
+    `script-src 'self'${evalToken} 'unsafe-inline' 'wasm-unsafe-eval' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://challenges.cloudflare.com${cdnDirective}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https://img.clerk.com https://clerk.spawnforge.ai",
+    "font-src 'self' data:",
+    `connect-src 'self' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://api.anthropic.com https://api.meshy.ai https://api.elevenlabs.io https://studio-api.suno.ai https://api.hyper3d.ai${cdnDirective}`,
+    "frame-src 'self' https://*.clerk.accounts.dev https://clerk.spawnforge.ai https://challenges.cloudflare.com",
+    "worker-src 'self' blob:",
+    "media-src 'self' blob:",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ];
+
+  return directives.join('; ');
+}
+
+/**
+ * Public/content route prefixes that never mount the editor script sandbox and
+ * therefore receive the eval-free (tightened) CSP. Browsers enforce every CSP
+ * header present on a response as an intersection, so emitting the tightened
+ * policy alongside the permissive global policy yields the most-restrictive
+ * (eval-free) result on these routes — the same mechanism `/play` relies on.
+ *
+ * Editor routes (`/dev`, `/editor/:path*`) are deliberately absent so they keep
+ * the global policy's `'unsafe-eval'`.
+ */
+export const EVAL_FREE_ROUTE_SOURCES: string[] = [
+  '/community/:path*',
+  '/blog/:path*',
+  '/about/:path*',
+  '/pricing/:path*',
+  '/faq/:path*',
+  '/compare/:path*',
+  '/use-cases/:path*',
+  '/changelog/:path*',
+  '/terms/:path*',
+  '/privacy/:path*',
+  '/docs/:path*',
+  '/api-docs/:path*',
+];


### PR DESCRIPTION
## Summary
- Next.js `headers()` is **last-writer-wins**, not a browser-style CSP intersection — it emits exactly one CSP header per path, the last matching rule's. The permissive global `/:path*` rule (with `'unsafe-eval'`) was declared LAST, silently overriding both the strict `/play` CSP and the `EVAL_FREE_ROUTE_SOURCES` tightened rules. The eval-scoping was a no-op AND `/play`'s strict CSP was regressed.
- Made the ordered CSP rule list a single source of truth in `src/lib/security/csp.ts` (`buildCspRouteRules`): global catch-all FIRST, per-route overrides (`/play`, content routes) AFTER so they are the last writer for their paths.
- `next.config.ts` now consumes `buildCspRouteRules({ engineCdn })` instead of inlining ordering.
- `'unsafe-inline'` is retained on editor/content routes (Clerk requirement); `/play` carries neither `'unsafe-eval'` nor `'unsafe-inline'`.

Closes #8634
Closes #8612

## Test plan
- [x] Added header-level regression tests in `csp.test.ts` that fail on the old global-last ordering: `effectiveCspForPath` keeps `'unsafe-eval'` on editor/marketing paths, drops it on content paths, and pins `/play` to `script-src 'self' 'wasm-unsafe-eval'`
- [x] Ordering contract test asserts global `/:path*` precedes every override
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, vitest green (18 csp tests)