### PR TITLE
fix(api): route pixel-art / sprite_sheet / tileset jobs to their status endpoints

### DIFF
--- a/.changeset/generation-status-endpoint-parity.md
+++ b/.changeset/generation-status-endpoint-parity.md
@@ -1,0 +1,11 @@
+---
+"web": patch
+---
+
+Fix `get_generation_status` returning a false "Could not find generation job"
+for valid `pixel-art`, `sprite_sheet`, and `tileset` jobs (#8762). The chat
+tool's hand-maintained type→status-route map had drifted from the auto-poller's
+(`useGenerationPolling`), omitting the three types added since. Both now consume
+a single exported `STATUS_ENDPOINTS` source of truth in
+`@/lib/generation/statusEndpoints`, and a unit test pins the type set so any
+future generation type that is added to one consumer but not the map fails CI.

--- a/web/src/hooks/useGenerationPolling.ts
+++ b/web/src/hooks/useGenerationPolling.ts
@@ -19,6 +19,7 @@
 import { useEffect, useRef } from 'react';
 import { useGenerationStore } from '@/stores/generationStore';
 import { useEditorStore } from '@/stores/editorStore';
+import { getStatusEndpoint } from '@/lib/generation/statusEndpoints';
 import { postProcess, inferSfxCategory } from '@/lib/generate/postProcess';
 import { analyzeModelQuality } from '@/lib/generate/modelQuality';
 import { detectGridDimensions, sliceSheet, buildSpriteSheetData } from '@/lib/sprites/sheetImporter';
@@ -156,29 +157,6 @@ export function useGenerationPolling() {
 
     // Immediate first poll
     poll();
-  }
-
-  function getStatusEndpoint(type: string): string {
-    switch (type) {
-      case 'model':
-        return '/api/generate/model/status';
-      case 'texture':
-        return '/api/generate/texture/status';
-      case 'skybox':
-        return '/api/generate/skybox/status';
-      case 'music':
-        return '/api/generate/music/status';
-      case 'sprite':
-        return '/api/generate/sprite/status';
-      case 'sprite_sheet':
-        return '/api/generate/sprite-sheet/status';
-      case 'tileset':
-        return '/api/generate/tileset-gen/status';
-      case 'pixel-art':
-        return '/api/generate/pixel-art/status';
-      default:
-        throw new Error(`Unknown generation type: ${type}`);
-    }
   }
 
   async function handleCompletion(id: string, type: string, data: StatusResponse) {

--- a/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import { createMockStore } from './handlerTestUtils';
 import { generationHandlers } from '../generationHandlers';
+import { STATUS_ENDPOINTS } from '@/lib/generation/statusEndpoints';
 
 // ---------------------------------------------------------------------------
 // Mock generationStore
@@ -666,9 +667,29 @@ describe('generationHandlers', () => {
       expect(result.success).toBe(true);
     });
 
+    it('routes a pixel-art job to its status endpoint (regression for #8762)', async () => {
+      // Before #8762 the chat tool's route map omitted pixel-art, so this
+      // fell through to "Could not find generation job" for a valid in-flight job.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ status: 'processing', progress: 25 }),
+      });
+      const { result } = await invoke('get_generation_status', {
+        jobId: 'px-1',
+        type: 'pixel-art',
+      });
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/generate/pixel-art/status?jobId=px-1'),
+      );
+    });
+
     it('returns error when job not found anywhere', async () => {
-      // Mock all status endpoints to fail
-      for (let i = 0; i < 5; i++) {
+      // Fail every status endpoint. Count is derived from STATUS_ENDPOINTS (the
+      // shared source of truth) so adding a new generation type does not
+      // re-break this test, and `Once` queueing avoids leaking a default mock
+      // into later tests (clearAllMocks does not clear implementations).
+      for (let i = 0; i < Object.keys(STATUS_ENDPOINTS).length; i++) {
         mockFetch.mockResolvedValueOnce({ ok: false, json: () => Promise.resolve({}) });
       }
       const { result } = await invoke('get_generation_status', { jobId: 'bad-id' });

--- a/web/src/lib/chat/handlers/generationHandlers.ts
+++ b/web/src/lib/chat/handlers/generationHandlers.ts
@@ -11,6 +11,7 @@ import type { GenerationType } from '@/stores/generationStore';
 import { enrichPrompt, enrichSfxPrompt, enrichMusicPrompt, enrichVoiceStyle } from '@/lib/generate/promptEnricher';
 import { inferSfxCategory, getSpatialDefaults } from '@/lib/generate/postProcess';
 import { DIRECT_CAPABILITY_PROVIDER } from '@/lib/config/providers';
+import { STATUS_ENDPOINTS, resolveStatusEndpoint } from '@/lib/generation/statusEndpoints';
 
 /** Generate a unique ID for client-side job tracking. */
 export function makeJobId(): string {
@@ -655,29 +656,27 @@ export const generationHandlers: Record<string, ToolHandler> = {
     }), args);
     if (p.error) return p.error;
 
-    // Route to the correct status endpoint based on generation type
-    const statusRoutes: Record<string, string> = {
-      model: '/api/generate/model/status',
-      texture: '/api/generate/texture/status',
-      skybox: '/api/generate/skybox/status',
-      music: '/api/generate/music/status',
-      sprite: '/api/generate/sprite/status',
-    };
+    // Route to the correct status endpoint. STATUS_ENDPOINTS is the single
+    // source of truth shared with the auto-poller (useGenerationPolling) so the
+    // two maps can never drift (#8762) — every pollable type, including
+    // pixel-art / sprite_sheet / tileset, resolves here.
 
     // If type is specified, use it directly
-    if (p.data.type && statusRoutes[p.data.type]) {
-      return queryStatus(statusRoutes[p.data.type], p.data.jobId);
+    if (p.data.type) {
+      const route = resolveStatusEndpoint(p.data.type);
+      if (route) return queryStatus(route, p.data.jobId);
     }
 
     // Try to find the job in the generation store to determine type
     const genStore = useGenerationStore.getState();
     const storeJob = Object.values(genStore.jobs).find((j) => j.jobId === p.data.jobId);
-    if (storeJob && statusRoutes[storeJob.type]) {
-      return queryStatus(statusRoutes[storeJob.type], p.data.jobId);
+    if (storeJob) {
+      const route = resolveStatusEndpoint(storeJob.type);
+      if (route) return queryStatus(route, p.data.jobId);
     }
 
     // Try all status endpoints
-    for (const route of Object.values(statusRoutes)) {
+    for (const route of Object.values(STATUS_ENDPOINTS)) {
       const result = await queryStatus(route, p.data.jobId);
       if (result.success) return result;
     }

--- a/web/src/lib/generation/__tests__/statusEndpoints.test.ts
+++ b/web/src/lib/generation/__tests__/statusEndpoints.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STATUS_ENDPOINTS,
+  resolveStatusEndpoint,
+  getStatusEndpoint,
+} from '@/lib/generation/statusEndpoints';
+
+/**
+ * Regression suite for #8762: `get_generation_status`'s status-route map had
+ * drifted from `useGenerationPolling`'s — `pixel-art`, `sprite_sheet`, and
+ * `tileset` were absent from the chat tool, so `get_generation_status({ type:
+ * 'pixel-art' })` returned a false "Could not find generation job". Both now
+ * consume STATUS_ENDPOINTS; these tests pin the contract so any future
+ * single-sided edit fails CI.
+ */
+describe('STATUS_ENDPOINTS (single source of truth)', () => {
+  it('covers exactly the async-pollable generation types', () => {
+    // Adding a new async generation type? Add it here AND to STATUS_ENDPOINTS.
+    // `sfx` and `voice` are deliberately excluded — they have no /status route.
+    expect(Object.keys(STATUS_ENDPOINTS).sort()).toEqual(
+      ['model', 'music', 'pixel-art', 'skybox', 'sprite', 'sprite_sheet', 'texture', 'tileset'].sort(),
+    );
+  });
+
+  it('maps every type to a /api/generate/*/status route', () => {
+    for (const route of Object.values(STATUS_ENDPOINTS)) {
+      expect(route).toMatch(/^\/api\/generate\/[a-z-]+\/status$/);
+    }
+  });
+
+  it('includes the three types that had drifted out of the chat tool (#8762)', () => {
+    expect(resolveStatusEndpoint('pixel-art')).toBe('/api/generate/pixel-art/status');
+    expect(resolveStatusEndpoint('sprite_sheet')).toBe('/api/generate/sprite-sheet/status');
+    expect(resolveStatusEndpoint('tileset')).toBe('/api/generate/tileset-gen/status');
+  });
+
+  it('resolves the original five types unchanged', () => {
+    expect(resolveStatusEndpoint('model')).toBe('/api/generate/model/status');
+    expect(resolveStatusEndpoint('texture')).toBe('/api/generate/texture/status');
+    expect(resolveStatusEndpoint('skybox')).toBe('/api/generate/skybox/status');
+    expect(resolveStatusEndpoint('music')).toBe('/api/generate/music/status');
+    expect(resolveStatusEndpoint('sprite')).toBe('/api/generate/sprite/status');
+  });
+});
+
+describe('resolveStatusEndpoint', () => {
+  it('returns undefined for non-pollable types (sfx, voice)', () => {
+    expect(resolveStatusEndpoint('sfx')).toBeUndefined();
+    expect(resolveStatusEndpoint('voice')).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown type rather than throwing', () => {
+    expect(resolveStatusEndpoint('not-a-real-type')).toBeUndefined();
+  });
+});
+
+describe('getStatusEndpoint (poller variant)', () => {
+  it('returns the route for a known type', () => {
+    expect(getStatusEndpoint('pixel-art')).toBe('/api/generate/pixel-art/status');
+  });
+
+  it('throws on an unknown/unpollable type', () => {
+    expect(() => getStatusEndpoint('not-a-real-type')).toThrow(/Unknown generation type/);
+    expect(() => getStatusEndpoint('sfx')).toThrow(/Unknown generation type/);
+  });
+});

--- a/web/src/lib/generation/statusEndpoints.ts
+++ b/web/src/lib/generation/statusEndpoints.ts
@@ -1,0 +1,51 @@
+import type { GenerationType } from '@/stores/generationStore';
+
+/**
+ * Single source of truth mapping each async generation type to the API route
+ * that reports its job status. Both the auto-poller
+ * (`useGenerationPolling.getStatusEndpoint`) and the chat tool
+ * (`get_generation_status`) consume this map so the two can never drift apart
+ * again (#8762 — `pixel-art`/`sprite_sheet`/`tileset` had silently fallen out
+ * of the chat tool's copy, making `get_generation_status({ type: 'pixel-art' })`
+ * return a false "Could not find generation job").
+ *
+ * `sfx` and `voice` (members of `GenerationType`) are intentionally absent: they
+ * have no async `/status` route, so they are not pollable. The `satisfies`
+ * clause keeps the keys checked against `GenerationType` — a typo'd or removed
+ * type fails `tsc` here rather than silently producing a dead route string.
+ */
+export const STATUS_ENDPOINTS = {
+  model: '/api/generate/model/status',
+  texture: '/api/generate/texture/status',
+  skybox: '/api/generate/skybox/status',
+  music: '/api/generate/music/status',
+  sprite: '/api/generate/sprite/status',
+  sprite_sheet: '/api/generate/sprite-sheet/status',
+  tileset: '/api/generate/tileset-gen/status',
+  'pixel-art': '/api/generate/pixel-art/status',
+} as const satisfies Partial<Record<GenerationType, string>>;
+
+/** A generation type that has an async status endpoint. */
+export type StatusPollableType = keyof typeof STATUS_ENDPOINTS;
+
+/**
+ * Resolve a generation type to its status route, or `undefined` if the type has
+ * no async status endpoint (e.g. `sfx`, `voice`, or an unknown string).
+ * Used by `get_generation_status`, which branches on presence rather than throwing.
+ */
+export function resolveStatusEndpoint(type: string): string | undefined {
+  return (STATUS_ENDPOINTS as Record<string, string | undefined>)[type];
+}
+
+/**
+ * Resolve a generation type to its status route, throwing on an unknown or
+ * unpollable type. Used by the auto-poller, where an unresolvable type is a
+ * programming error (the job should never have been enqueued for polling).
+ */
+export function getStatusEndpoint(type: string): string {
+  const route = resolveStatusEndpoint(type);
+  if (!route) {
+    throw new Error(`Unknown generation type: ${type}`);
+  }
+  return route;
+}


### PR DESCRIPTION
## Summary
- `get_generation_status` did not map the `pixel_art`, `sprite_sheet`, and `tileset` job types to their status endpoints, so polling those async jobs silently failed.
- Unified the job-type → status-endpoint map so every async generation type resolves correctly.

Closes #8762

## Test plan
- [x] Added regression tests covering each previously-unmapped job type resolving to the correct status endpoint (fails on the pre-fix map)
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, targeted vitest green