### PR TITLE
fix(security): redact hyphenated provider keys, validate master-key hex, stop health branch leak

### DIFF
--- a/.changeset/fix-secrets-redaction-key-validation.md
+++ b/.changeset/fix-secrets-redaction-key-validation.md
@@ -1,0 +1,21 @@
+---
+"web": patch
+---
+
+Harden secret handling and unauthenticated metadata exposure:
+
+- **Structured logger redaction (#8642):** `logger.*` now redacts values under
+  sensitive key names (apiKey, token, secret, password, authorization,
+  encryptedKey, …) and scrubs secret-shaped substrings (Bearer tokens, Stripe
+  `sk_/pk_/whsec_`, OpenAI `sk-`, `forge_`, JWTs) from log messages and nested
+  context/Error objects before they reach stdout or aggregation. Depth- and
+  cycle-bounded so a pathological context object can never hang the logger.
+- **Encryption master key validation (#8641):** `ENCRYPTION_MASTER_KEY` is now
+  validated as a 64-character hex string both at startup
+  (`validateEnvironment()`) and in `getMasterKey()`, surfacing a clear error
+  instead of a cryptic "Invalid key length" on the first BYOK encrypt/decrypt
+  (`Buffer.from(hex)` silently truncates at the first non-hex char).
+- **Health endpoint metadata (#8648):** the unauthenticated `/api/health`
+  response no longer exposes the git branch ref (`VERCEL_GIT_COMMIT_REF`), which
+  leaked internal branch naming and in-flight feature work. The short commit SHA
+  is still returned for build identification.

--- a/web/e2e/tests/api-routes.spec.ts
+++ b/web/e2e/tests/api-routes.spec.ts
@@ -21,7 +21,10 @@ test.describe('API Routes @ui', () => {
       expect(body).toHaveProperty('status', 'ok');
       expect(body).toHaveProperty('environment');
       expect(body).toHaveProperty('commit');
-      expect(body).toHaveProperty('branch');
+      // `branch` is intentionally NOT exposed — the git branch ref leaked
+      // internal/in-flight feature names from the public endpoint (#8648).
+      // Assert its absence so the leak can never silently return.
+      expect(body).not.toHaveProperty('branch');
       expect(body).toHaveProperty('database');
       expect(body).toHaveProperty('timestamp');
     });

--- a/web/src/app/api/__tests__/contracts.test.ts
+++ b/web/src/app/api/__tests__/contracts.test.ts
@@ -184,7 +184,7 @@ describe('GET /api/health — response shape contract', () => {
     expect(body.timestamp).not.toBe('');
   });
 
-  it('returns environment, commit, branch, and version fields', async () => {
+  it('returns environment, commit, and version fields (but not branch)', async () => {
     const { GET, resetHealthCache } = await import('@/app/api/health/route');
     resetHealthCache();
     const res = await GET(makeGetRequest('http://localhost/api/health'));
@@ -192,8 +192,11 @@ describe('GET /api/health — response shape contract', () => {
 
     expect(typeof body.environment).toBe('string');
     expect(typeof body.commit).toBe('string');
-    expect(typeof body.branch).toBe('string');
     expect(typeof body.version).toBe('string');
+    // The git branch ref (VERCEL_GIT_COMMIT_REF) is intentionally NOT exposed on
+    // the public health endpoint — it leaks internal branch naming / in-flight
+    // feature work (#8648). Keep this contract in lockstep with the route.
+    expect(body).not.toHaveProperty('branch');
   });
 
   it('each service entry has name and status fields', async () => {

--- a/web/src/app/api/health/__tests__/route.test.ts
+++ b/web/src/app/api/health/__tests__/route.test.ts
@@ -46,14 +46,13 @@ describe('GET /api/health', () => {
       expect(body.status).toBe('ok');
     });
 
-    it('includes required fields: status, environment, commit, branch, database, timestamp, services', async () => {
+    it('includes required fields: status, environment, commit, database, timestamp, services', async () => {
       const res = await GET(makeReq());
       const body = await res.json();
 
       expect(body).toHaveProperty('status');
       expect(body).toHaveProperty('environment');
       expect(body).toHaveProperty('commit');
-      expect(body).toHaveProperty('branch');
       expect(body).toHaveProperty('database');
       expect(body).toHaveProperty('timestamp');
       expect(body).toHaveProperty('services');
@@ -126,22 +125,18 @@ describe('GET /api/health', () => {
       expect(typeof body.commit).toBe('string');
     });
 
-    it('branch comes from VERCEL_GIT_COMMIT_REF', async () => {
+    it('never exposes the git branch, even when VERCEL_GIT_COMMIT_REF is set (regression for #8648)', async () => {
+      // The full branch ref leaks internal branch naming. The health payload must
+      // omit `branch` entirely regardless of the deploy env, so a probe cannot
+      // recover the branch name from the public endpoint.
       vi.stubEnv('VERCEL_GIT_COMMIT_REF', 'main');
 
       const mod = await import('../route');
       const res = await mod.GET(makeReq());
       const body = await res.json();
 
-      expect(body.branch).toBe('main');
-    });
-
-    it('branch is a string (from env or defaulting to "unknown")', async () => {
-      const res = await GET(makeReq());
-      const body = await res.json();
-
-      // Branch is always a string
-      expect(typeof body.branch).toBe('string');
+      expect(body).not.toHaveProperty('branch');
+      expect(JSON.stringify(body)).not.toContain('main');
     });
   });
 

--- a/web/src/app/api/health/route.test.ts
+++ b/web/src/app/api/health/route.test.ts
@@ -35,7 +35,10 @@ describe('GET /api/health', () => {
     expect(res.status).toBeLessThan(600); // any valid HTTP status
     expect(body.environment).toBe('test');
     expect(body.commit).toBe('abc12345');
-    expect(body.branch).toBe('main');
+    // Git branch ref must NOT be exposed on the public endpoint — it leaks
+    // internal branch naming / in-flight feature work (#8648).
+    expect(body).not.toHaveProperty('branch');
+    expect(JSON.stringify(body)).not.toContain('main');
     expect(body.timestamp).toBeDefined();
   });
 
@@ -45,7 +48,8 @@ describe('GET /api/health', () => {
     const body = await res.json();
 
     expect(body.commit).toBe('local');
-    expect(body.branch).toBe('unknown');
+    // branch is intentionally omitted from the public payload (#8648)
+    expect(body).not.toHaveProperty('branch');
   });
 
   it('should include services array with 12 entries', async () => {

--- a/web/src/app/api/health/route.ts
+++ b/web/src/app/api/health/route.ts
@@ -84,8 +84,11 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const criticalStatus = computeCriticalStatus(report.services);
   const httpStatus = criticalStatus === 'down' ? 503 : 200;
 
+  // Commit SHA prefix is acceptable to expose for build identification, but the
+  // full git branch ref (VERCEL_GIT_COMMIT_REF) leaks internal branch naming and
+  // in-flight feature work to anyone hitting this unauthenticated endpoint, so it
+  // is deliberately omitted from the public payload (#8648).
   const commit = process.env.VERCEL_GIT_COMMIT_SHA ?? 'local';
-  const branch = process.env.VERCEL_GIT_COMMIT_REF ?? 'unknown';
 
   const dbService = report.services.find((s) => s.name === 'Database (Neon)');
   const dbStatus =
@@ -120,7 +123,6 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     status: criticalStatus === 'down' ? 'error' : 'ok',
     environment: report.environment,
     commit: commit.slice(0, 8),
-    branch,
     database: dbStatus,
     timestamp: report.timestamp,
     overall: report.overall,

--- a/web/src/lib/config/__tests__/validateEnv.test.ts
+++ b/web/src/lib/config/__tests__/validateEnv.test.ts
@@ -179,6 +179,54 @@ describe('validateEnv', () => {
     });
   });
 
+  describe('Encryption master key format validation (#8641)', () => {
+    it('flags a 64-char non-hex ENCRYPTION_MASTER_KEY as missing/invalid', async () => {
+      stubAllRequired();
+      vi.stubEnv('ENCRYPTION_MASTER_KEY', 'z'.repeat(64)); // right length, non-hex
+
+      const { validateEnvironment } = await import('../validateEnv');
+      const result = validateEnvironment();
+
+      expect(result.valid).toBe(false);
+      expect(result.missing).toContain('ENCRYPTION_MASTER_KEY');
+    });
+
+    it('does not double-count an absent key already flagged as missing', async () => {
+      stubAllRequired();
+      vi.stubEnv('ENCRYPTION_MASTER_KEY', '');
+
+      const { validateEnvironment } = await import('../validateEnv');
+      const result = validateEnvironment();
+
+      const occurrences = result.missing.filter((k) => k === 'ENCRYPTION_MASTER_KEY');
+      expect(occurrences).toHaveLength(1);
+    });
+
+    it('accepts a valid 64-char hex key (upper and lower case)', async () => {
+      stubAllRequired();
+      vi.stubEnv('ENCRYPTION_MASTER_KEY', 'A1b2'.repeat(16)); // 64 hex chars
+
+      const { validateEnvironment } = await import('../validateEnv');
+      const result = validateEnvironment();
+
+      expect(result.missing).not.toContain('ENCRYPTION_MASTER_KEY');
+    });
+
+    it('logs a CRITICAL message for a malformed key', async () => {
+      stubAllRequired();
+      vi.stubEnv('ENCRYPTION_MASTER_KEY', 'g'.repeat(64));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const { validateEnvironment } = await import('../validateEnv');
+      validateEnvironment();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ENCRYPTION_MASTER_KEY is set but is not a 64-character hex string')
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('getOptionalEnv', () => {
     it('returns the env value when set', async () => {
       vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://spawnforge.ai');

--- a/web/src/lib/config/validateEnv.ts
+++ b/web/src/lib/config/validateEnv.ts
@@ -9,7 +9,10 @@
  * Optional vars are documented with their defaults.
  */
 
-import { MASTER_KEY_HEX } from '@/lib/keys/encryption';
+// Import from the crypto-free format module, NOT from `@/lib/keys/encryption`:
+// validateEnv is loaded via instrumentation.ts `register()`, which runs in the
+// edge runtime too, where node `crypto` (pulled in by encryption.ts) is unavailable.
+import { MASTER_KEY_HEX } from '@/lib/keys/masterKeyFormat';
 
 /** Descriptor for a required environment variable. */
 interface RequiredVar {

--- a/web/src/lib/config/validateEnv.ts
+++ b/web/src/lib/config/validateEnv.ts
@@ -9,6 +9,8 @@
  * Optional vars are documented with their defaults.
  */
 
+import { MASTER_KEY_HEX } from '@/lib/keys/encryption';
+
 /** Descriptor for a required environment variable. */
 interface RequiredVar {
   key: string;
@@ -124,6 +126,17 @@ export function validateEnvironment(): EnvValidationResult {
     const msg = 'CLERK_SECRET_KEY is a TEST key (sk_test_*) in production. Use sk_live_* for production.';
     warnings.push(msg);
     console.warn(`[validateEnvironment] WARNING: ${msg}`);
+  }
+
+  // Encryption key charset validation: a present-but-malformed key (right length,
+  // non-hex chars) passes the missing-var check above, then crashes the first
+  // BYOK encrypt/decrypt with 'Invalid key length' instead of failing at boot.
+  // Catch the misconfiguration here so it surfaces as a clear startup error (#8641).
+  const masterKey = process.env.ENCRYPTION_MASTER_KEY;
+  if (masterKey && !MASTER_KEY_HEX.test(masterKey)) {
+    const msg = 'ENCRYPTION_MASTER_KEY is set but is not a 64-character hex string (32 bytes). BYOK encryption will crash on first use.';
+    if (!missing.includes('ENCRYPTION_MASTER_KEY')) missing.push('ENCRYPTION_MASTER_KEY');
+    console.error(`[validateEnvironment] CRITICAL: ${msg}`);
   }
 
   for (const v of OPTIONAL_VARS) {

--- a/web/src/lib/keys/__tests__/encryption.test.ts
+++ b/web/src/lib/keys/__tests__/encryption.test.ts
@@ -222,14 +222,41 @@ describe('encryption module', () => {
       expect(() => encryptProviderKey('test')).toThrow('64-character hex string');
     });
 
-    it('throws when key is the right length but contains non-hex chars', async () => {
-      // 64 chars but includes 'z' which is not a valid hex digit.
-      // Node's Buffer.from('zzz...', 'hex') returns a zero-length buffer
-      // (it stops at the first invalid nibble), so AES-256-GCM rejects it
-      // immediately with "Invalid key length".
+    it('throws the descriptive error for a 64-char all-non-hex key (#8641)', async () => {
+      // 64 chars but every char is 'z' (not a hex digit). Node's
+      // Buffer.from('zzz...', 'hex') stops at the first invalid nibble and
+      // returns a 0-byte buffer, which historically surfaced only as a cryptic
+      // "Invalid key length" at createCipheriv time. getMasterKey now validates
+      // the hex charset up front, so the clear ENCRYPTION_MASTER_KEY message fires.
       process.env.ENCRYPTION_MASTER_KEY = 'z'.repeat(64);
       const { encryptProviderKey } = await import('../encryption');
-      expect(() => encryptProviderKey('hex-chars-test')).toThrow();
+      expect(() => encryptProviderKey('hex-chars-test')).toThrow('64-character hex string');
+    });
+
+    it('throws for a 64-char key with a single non-hex char in the middle (#8641)', async () => {
+      // 'g' is the first illegal hex char; only the leading hex prefix decodes,
+      // yielding a < 32-byte buffer. Rejected at the charset gate.
+      const key = 'a'.repeat(40) + 'g' + 'a'.repeat(23); // 64 chars, one 'g'
+      expect(key.length).toBe(64);
+      process.env.ENCRYPTION_MASTER_KEY = key;
+      const { encryptProviderKey } = await import('../encryption');
+      expect(() => encryptProviderKey('mid-non-hex')).toThrow('64-character hex string');
+    });
+
+    it('accepts a valid uppercase-hex key (charset regex is case-insensitive) (#8641)', async () => {
+      process.env.ENCRYPTION_MASTER_KEY = freshKey().toUpperCase();
+      const { encryptProviderKey, decryptProviderKey } = await import('../encryption');
+      const { encrypted, iv } = encryptProviderKey('uppercase-hex-key');
+      expect(decryptProviderKey(encrypted, iv)).toBe('uppercase-hex-key');
+    });
+
+    it('MASTER_KEY_HEX regex matches 64 hex chars and rejects bad input (#8641)', async () => {
+      const { MASTER_KEY_HEX } = await import('../encryption');
+      expect(MASTER_KEY_HEX.test('a'.repeat(64))).toBe(true);
+      expect(MASTER_KEY_HEX.test('A'.repeat(64))).toBe(true);
+      expect(MASTER_KEY_HEX.test('z'.repeat(64))).toBe(false);
+      expect(MASTER_KEY_HEX.test('a'.repeat(63))).toBe(false);
+      expect(MASTER_KEY_HEX.test('a'.repeat(65))).toBe(false);
     });
 
     it('throws on decryptProviderKey when master key is missing', async () => {

--- a/web/src/lib/keys/encryption.ts
+++ b/web/src/lib/keys/encryption.ts
@@ -8,15 +8,28 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 const TAG_LENGTH = 16;
 
+/** A valid AES-256 master key: exactly 64 hexadecimal characters (32 bytes). */
+export const MASTER_KEY_HEX = /^[0-9a-fA-F]{64}$/;
+
 function getMasterKey(): Buffer {
   const key = process.env.ENCRYPTION_MASTER_KEY;
-  if (!key || key.length !== 64) {
+  // Validate hex charset, not just length: Buffer.from(s, 'hex') silently stops
+  // at the first non-hex character, so a 64-char non-hex string (e.g. all 'z')
+  // yields a 0-byte buffer that only fails at createCipheriv time with a cryptic
+  // 'Invalid key length'. Reject it here with a clear message instead (#8641).
+  if (!key || !MASTER_KEY_HEX.test(key)) {
     throw new Error(
       'ENCRYPTION_MASTER_KEY must be a 64-character hex string (32 bytes). ' +
         'Generate with: node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"'
     );
   }
-  return Buffer.from(key, 'hex');
+  const buf = Buffer.from(key, 'hex');
+  // Defense-in-depth: the regex already guarantees 32 bytes, but assert it so a
+  // future regex change can never silently produce a short key.
+  if (buf.length !== 32) {
+    throw new Error('ENCRYPTION_MASTER_KEY must decode to exactly 32 bytes.');
+  }
+  return buf;
 }
 
 /** Encrypt a provider API key for storage at rest */

--- a/web/src/lib/keys/encryption.ts
+++ b/web/src/lib/keys/encryption.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { MASTER_KEY_HEX } from './masterKeyFormat';
 
 const ALGORITHM = 'aes-256-gcm';
 // IV_LENGTH = 16 (128-bit). NIST SP 800-38D recommends 96-bit (12-byte) IVs for
@@ -8,8 +9,9 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 const TAG_LENGTH = 16;
 
-/** A valid AES-256 master key: exactly 64 hexadecimal characters (32 bytes). */
-export const MASTER_KEY_HEX = /^[0-9a-fA-F]{64}$/;
+// Re-exported from the crypto-free `masterKeyFormat` module so existing importers
+// (and the encryption test suite) keep resolving `MASTER_KEY_HEX` from here.
+export { MASTER_KEY_HEX };
 
 function getMasterKey(): Buffer {
   const key = process.env.ENCRYPTION_MASTER_KEY;

--- a/web/src/lib/keys/masterKeyFormat.ts
+++ b/web/src/lib/keys/masterKeyFormat.ts
@@ -1,0 +1,13 @@
+/**
+ * Format constraint for the AES-256 BYOK master key, in a module with NO node
+ * `crypto` dependency.
+ *
+ * This lives apart from `encryption.ts` (which imports node `crypto`) so that
+ * edge-runtime code paths can validate the key format without dragging the
+ * node-only crypto module into the edge bundle. `validateEnv.ts` is loaded by
+ * `instrumentation.ts`'s `register()`, which Next.js invokes in BOTH the nodejs
+ * and edge runtimes — importing `encryption.ts` there would break the edge build.
+ */
+
+/** A valid AES-256 master key: exactly 64 hexadecimal characters (32 bytes). */
+export const MASTER_KEY_HEX = /^[0-9a-fA-F]{64}$/;

--- a/web/src/lib/logging/__tests__/logger.test.ts
+++ b/web/src/lib/logging/__tests__/logger.test.ts
@@ -294,6 +294,23 @@ describe('logger', () => {
       expect(entry.error).toContain('[REDACTED]');
     });
 
+    it('scrubs hyphenated OpenAI/Anthropic keys embedded in a non-sensitive value (regression for #8642)', () => {
+      // These project/key formats contain internal hyphens that terminated the
+      // old `sk-[A-Za-z0-9]{20,}` class at the first dash, leaving the key in logs.
+      const openaiProj = 'sk-proj-Abc123Def456Ghi789Jkl012Mno345';
+      const anthropic = 'sk-ant-api03-Abc123Def456Ghi789Jkl012Mno345pqr';
+      const entry = logProd(() =>
+        logger.error('provider call failed', {
+          detail: `openai=${openaiProj} anthropic=${anthropic}`,
+        }),
+      );
+      expect(entry.detail).not.toContain(openaiProj);
+      expect(entry.detail).not.toContain(anthropic);
+      expect(entry.detail).not.toContain('sk-proj-');
+      expect(entry.detail).not.toContain('sk-ant-api03-');
+      expect(entry.detail).toContain('[REDACTED]');
+    });
+
     it('scrubs forge_ and JWT patterns inside the log message itself', () => {
       const entry = logProd(() =>
         logger.info('user provided forge_abc123def456 and eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'),

--- a/web/src/lib/logging/__tests__/logger.test.ts
+++ b/web/src/lib/logging/__tests__/logger.test.ts
@@ -353,6 +353,35 @@ describe('logger', () => {
       expect(data.self).toBe('[Circular]');
     });
 
+    it('does not flag a legitimately shared object reference as [Circular] across sibling keys (regression #8789)', () => {
+      // The same object referenced under two DIFFERENT top-level context keys
+      // is NOT a cycle — each must serialize in full. A WeakSet shared across
+      // sibling keys would mark the second visit [Circular] and drop its data.
+      const entry = logProd(() => {
+        const shared: Record<string, unknown> = { id: 'asset-1', count: 7 };
+        logger.info('shared-ref', { primary: shared, mirror: shared });
+      });
+      const primary = entry.primary as Record<string, unknown>;
+      const mirror = entry.mirror as Record<string, unknown>;
+      expect(primary).toEqual({ id: 'asset-1', count: 7 });
+      // The second sibling must be fully present, not collapsed to '[Circular]'.
+      expect(mirror).toEqual({ id: 'asset-1', count: 7 });
+      expect(mirror).not.toBe('[Circular]');
+    });
+
+    it('still detects a TRUE cycle within a single top-level key (regression #8789)', () => {
+      // The per-key fix must not weaken genuine cycle protection: a self-
+      // referential object under one key must still resolve to '[Circular]'.
+      const entry = logProd(() => {
+        const cyclic: Record<string, unknown> = { name: 'root' };
+        cyclic.self = cyclic;
+        logger.info('still-cyclic', { node: cyclic });
+      });
+      const node = entry.node as Record<string, unknown>;
+      expect(node.name).toBe('root');
+      expect(node.self).toBe('[Circular]');
+    });
+
     it('scrubs a credential embedded in an Error object message', () => {
       const entry = logProd(() =>
         logger.error('caught', { err: new Error('failed with sk_test_supersecret123') }),

--- a/web/src/lib/logging/__tests__/logger.test.ts
+++ b/web/src/lib/logging/__tests__/logger.test.ts
@@ -228,6 +228,124 @@ describe('logger', () => {
     });
   });
 
+  describe('secret redaction (#8642)', () => {
+    /** Run a logger call in production mode and return the parsed JSON entry. */
+    function logProd(fn: () => void): LogEntry {
+      (process.env as Record<string, string>).NODE_ENV = 'production';
+      const cap = captureConsole();
+      try {
+        fn();
+        return JSON.parse(cap.entries[0].args[0] as string) as LogEntry;
+      } finally {
+        cap.restore();
+      }
+    }
+
+    it('masks values under sensitive key names', () => {
+      const entry = logProd(() =>
+        logger.info('resolved key', {
+          apiKey: 'sk-secret-value',
+          token: 'tok_abcdef',
+          password: 'hunter2',
+          authorization: 'Bearer xyz',
+          encryptedKey: 'AAAA==',
+          userId: 'u-1',
+        }),
+      );
+      expect(entry.apiKey).toBe('[REDACTED]');
+      expect(entry.token).toBe('[REDACTED]');
+      expect(entry.password).toBe('[REDACTED]');
+      expect(entry.authorization).toBe('[REDACTED]');
+      expect(entry.encryptedKey).toBe('[REDACTED]');
+      // Non-sensitive fields are preserved
+      expect(entry.userId).toBe('u-1');
+    });
+
+    it('masks camelCase and snake_case key variants', () => {
+      const entry = logProd(() =>
+        logger.info('mixed', {
+          stripe_secret_key: 'sk_live_abc',
+          cacheKey: 'safe-value-but-masked',
+          sessionToken: 'abc',
+        }),
+      );
+      expect(entry.stripe_secret_key).toBe('[REDACTED]');
+      expect(entry.cacheKey).toBe('[REDACTED]');
+      expect(entry.sessionToken).toBe('[REDACTED]');
+    });
+
+    it('does not mask innocuous keys that merely contain a sensitive substring', () => {
+      const entry = logProd(() =>
+        logger.info('innocuous', { monkey: 'banana', keyboard: 'qwerty', donkey: 'kong' }),
+      );
+      expect(entry.monkey).toBe('banana');
+      expect(entry.keyboard).toBe('qwerty');
+      expect(entry.donkey).toBe('kong');
+    });
+
+    it('scrubs secret-shaped substrings from non-sensitive string values', () => {
+      const entry = logProd(() =>
+        logger.error('db failure', {
+          error: 'auth failed for Bearer abc.def.ghi using sk_live_deadbeef0000',
+        }),
+      );
+      expect(entry.error).not.toContain('abc.def.ghi');
+      expect(entry.error).not.toContain('sk_live_deadbeef0000');
+      expect(entry.error).toContain('[REDACTED]');
+    });
+
+    it('scrubs forge_ and JWT patterns inside the log message itself', () => {
+      const entry = logProd(() =>
+        logger.info('user provided forge_abc123def456 and eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'),
+      );
+      expect(entry.message).not.toContain('forge_abc123def456');
+      expect(entry.message).toContain('[REDACTED]');
+    });
+
+    it('redacts sensitive keys nested inside objects and arrays', () => {
+      const entry = logProd(() =>
+        logger.info('nested', {
+          resolved: { provider: 'openai', key: 'sk-nested-secret' },
+          items: [{ token: 'nested-token' }],
+        }),
+      );
+      const resolved = entry.resolved as Record<string, unknown>;
+      expect(resolved.provider).toBe('openai');
+      expect(resolved.key).toBe('[REDACTED]');
+      const items = entry.items as Array<Record<string, unknown>>;
+      expect(items[0].token).toBe('[REDACTED]');
+    });
+
+    it('redacts a bound sensitive field on a child logger', () => {
+      const entry = logProd(() => {
+        const reqLog = logger.child({ apiKey: 'sk-bound-secret', requestId: 'req_1' });
+        reqLog.info('child');
+      });
+      expect(entry.apiKey).toBe('[REDACTED]');
+      expect(entry.requestId).toBe('req_1');
+    });
+
+    it('handles circular references without throwing', () => {
+      const entry = logProd(() => {
+        const circular: Record<string, unknown> = { name: 'root' };
+        circular.self = circular;
+        logger.info('circular', { data: circular });
+      });
+      const data = entry.data as Record<string, unknown>;
+      expect(data.name).toBe('root');
+      expect(data.self).toBe('[Circular]');
+    });
+
+    it('scrubs a credential embedded in an Error object message', () => {
+      const entry = logProd(() =>
+        logger.error('caught', { err: new Error('failed with sk_test_supersecret123') }),
+      );
+      const err = entry.err as Record<string, unknown>;
+      expect(String(err.message)).not.toContain('sk_test_supersecret123');
+      expect(String(err.message)).toContain('[REDACTED]');
+    });
+  });
+
   describe('log level filtering', () => {
     it('suppresses debug when LOG_LEVEL=warn', () => {
       (process.env as Record<string, string>).LOG_LEVEL = 'warn';

--- a/web/src/lib/logging/logger.ts
+++ b/web/src/lib/logging/logger.ts
@@ -62,7 +62,10 @@ const SENSITIVE_KEY_TOKENS = new Set([
 const SECRET_VALUE_PATTERNS: RegExp[] = [
   /Bearer\s+[A-Za-z0-9._\-]+/gi,
   /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]+/g,
-  /\bsk-[A-Za-z0-9]{20,}/g,
+  // OpenAI (`sk-...`, `sk-proj-...`) and Anthropic (`sk-ant-api03-...`) keys embed
+  // hyphens in the body, so the character class must include `-` and `_` or the
+  // match terminates at the first hyphen and the key survives unredacted.
+  /\bsk-[A-Za-z0-9_-]{20,}/g,
   /\bwhsec_[A-Za-z0-9]+/g,
   /\bforge_[A-Za-z0-9]+/g,
   /\beyJ[A-Za-z0-9._\-]{20,}/g, // JWT

--- a/web/src/lib/logging/logger.ts
+++ b/web/src/lib/logging/logger.ts
@@ -121,9 +121,15 @@ function redactValue(value: unknown, depth: number, seen: WeakSet<object>): unkn
 
 /** Redact a flat context object's fields prior to serialization. */
 function redactContext(context: LogContext): LogContext {
-  const seen = new WeakSet<object>();
   const out: LogContext = {};
   for (const [k, v] of Object.entries(context)) {
+    // A FRESH cycle-tracking set per top-level key. A WeakSet shared across
+    // sibling keys would wrongly flag a legitimately shared object reference
+    // (the same object appearing under two different top-level keys) as
+    // [Circular] on the second visit and silently drop its data. A cycle is
+    // only meaningful WITHIN a single value's own root-to-descendant traversal,
+    // never across siblings — so the set must not outlive one top-level key.
+    const seen = new WeakSet<object>();
     out[k] = isSensitiveKey(k) && v != null ? REDACTED : redactValue(v, 1, seen);
   }
   return out;

--- a/web/src/lib/logging/logger.ts
+++ b/web/src/lib/logging/logger.ts
@@ -40,6 +40,92 @@ const LOG_LEVEL_ORDER: Record<LogLevel, number> = {
   error: 3,
 };
 
+const REDACTED = '[REDACTED]';
+
+/**
+ * Sensitive name tokens. A context key is masked when any camelCase/underscore
+ * segment of its name matches one of these (e.g. `apiKey`, `encrypted_key`,
+ * `Authorization` all match). Erring toward over-masking is intentional — a
+ * logger must never be the thing that leaks a credential (#8642).
+ */
+const SENSITIVE_KEY_TOKENS = new Set([
+  'key', 'apikey', 'token', 'secret', 'password', 'pwd', 'passphrase',
+  'authorization', 'auth', 'credential', 'credentials', 'cookie', 'session',
+  'encryptedkey', 'privatekey', 'jwt', 'bearer',
+]);
+
+/**
+ * Value patterns that look like secrets regardless of the key they sit under.
+ * These scrub credentials embedded in otherwise-innocent strings — e.g. an
+ * error message that interpolated a key, logged under `{ error: err.message }`.
+ */
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  /Bearer\s+[A-Za-z0-9._\-]+/gi,
+  /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]+/g,
+  /\bsk-[A-Za-z0-9]{20,}/g,
+  /\bwhsec_[A-Za-z0-9]+/g,
+  /\bforge_[A-Za-z0-9]+/g,
+  /\beyJ[A-Za-z0-9._\-]{20,}/g, // JWT
+];
+
+const MAX_REDACT_DEPTH = 6;
+
+function isSensitiveKey(key: string): boolean {
+  // Split camelCase and any non-alphanumeric separators, then lower-case.
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^a-zA-Z0-9]+/);
+  return segments.some((seg) => SENSITIVE_KEY_TOKENS.has(seg.toLowerCase()));
+}
+
+function scrubString(value: string): string {
+  let out = value;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    out = out.replace(pattern, REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Recursively redact a value: mask values whose key name is sensitive, scrub
+ * secret-shaped substrings from strings, and bound depth/cycles so a pathological
+ * context object can never hang or overflow the logger.
+ */
+function redactValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') return scrubString(value);
+  if (value === null || typeof value !== 'object') return value;
+
+  if (seen.has(value as object)) return '[Circular]';
+  if (depth >= MAX_REDACT_DEPTH) return '[Truncated]';
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, depth + 1, seen));
+  }
+
+  // Error objects don't enumerate `message`/`stack` as own keys — surface a
+  // scrubbed message so a credential embedded in an error never escapes.
+  if (value instanceof Error) {
+    return { name: value.name, message: scrubString(value.message) };
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = isSensitiveKey(k) && v != null ? REDACTED : redactValue(v, depth + 1, seen);
+  }
+  return out;
+}
+
+/** Redact a flat context object's fields prior to serialization. */
+function redactContext(context: LogContext): LogContext {
+  const seen = new WeakSet<object>();
+  const out: LogContext = {};
+  for (const [k, v] of Object.entries(context)) {
+    out[k] = isSensitiveKey(k) && v != null ? REDACTED : redactValue(v, 1, seen);
+  }
+  return out;
+}
+
 /**
  * Determine the minimum log level from env.
  * Defaults to 'info' in production and 'debug' in development.
@@ -98,12 +184,14 @@ function buildEntry(
   context: LogContext,
   boundContext: LogContext,
 ): LogEntry {
+  // Merge bound + per-call context, then run a single redaction pass so neither
+  // a sensitive key name nor a secret-shaped value reaches stdout / aggregation.
+  const merged = redactContext({ ...boundContext, ...context });
   return {
     timestamp: new Date().toISOString(),
     level,
-    message,
-    ...boundContext,
-    ...context,
+    message: scrubString(message),
+    ...merged,
   };
 }
 


### PR DESCRIPTION
## Summary
- **#8642 — secret redaction:** the logger's `sk-` pattern used `[A-Za-z0-9]{20,}`, which terminated at the first hyphen — so `sk-proj-...` (OpenAI) and `sk-ant-api03-...` (Anthropic) keys survived in logs unredacted. Broadened the character class to `[A-Za-z0-9_-]{20,}` so the whole key body is scrubbed, and added the `sk_/pk_/rk_(live|test)_` family pattern.
- **#8641 — master-key validation:** `getMasterKey()` now rejects a non-hex `ENCRYPTION_MASTER_KEY` via `MASTER_KEY_HEX` (`^[0-9a-fA-F]{64}$`) before `Buffer.from(…, 'hex')` can silently truncate it, with a defense-in-depth 32-byte assert. Extracted the regex into a crypto-free `masterKeyFormat.ts` so `validateEnv` (loaded by `instrumentation.register()` in the **edge** runtime too) no longer drags `node:crypto` into the edge bundle; `encryption.ts` re-exports it to preserve the single source of truth. `validateEnvironment()` applies the same regex at boot.
- **#8648 — health branch leak:** the health route no longer emits `branch` (internal git ref naming), even when `VERCEL_GIT_COMMIT_REF` is set.

Closes #8641
Closes #8642
Closes #8648

## Test plan
- [x] Regression test scrubs `sk-proj-…`/`sk-ant-api03-…` embedded in a non-sensitive value (fails on the old regex)
- [x] Master-key tests: rejects 64-char non-hex, accepts upper/mixed-case hex, rejects wrong length; regex unit tests; CRITICAL boot-error path
- [x] Health regression: `body` never has `branch` and `JSON.stringify(body)` lacks `main` with `VERCEL_GIT_COMMIT_REF=main`
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, logger/encryption/health vitest green