### PR TITLE
fix(security): enforce content ownership on moderation appeals + complete GDPR export

### DIFF
--- a/.changeset/fix-user-data-authz.md
+++ b/.changeset/fix-user-data-authz.md
@@ -1,0 +1,17 @@
+---
+"web": patch
+---
+
+Harden moderation-appeal authorization and complete the GDPR data export.
+
+- `POST /api/moderation/appeal` now verifies the authenticated user owns the
+  referenced content (comment/game/asset) before filing an appeal, returning
+  404 (not 403, to avoid disclosing existence) when they do not. `contentId` is
+  now validated as a uuid so malformed ids are rejected with 400 instead of
+  surfacing as a 500. (#8613)
+- `POST /api/admin/moderation/appeals/[id]/review` re-confirms the appellant
+  authored the comment before clearing its `flagged` state (defense-in-depth).
+- `GET /api/user/export-data` now includes the previously-omitted user-owned
+  tables: game comments, ratings, likes, follows, forks, marketplace listings,
+  asset purchases, asset reviews, the seller profile, and moderation appeals.
+  (#8639)

--- a/web/src/app/api/admin/moderation/appeals/[id]/review/route.test.ts
+++ b/web/src/app/api/admin/moderation/appeals/[id]/review/route.test.ts
@@ -4,11 +4,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import { authenticateRequest, assertAdmin } from '@/lib/auth/api-auth';
 import { getDb } from '@/lib/db/client';
+import { eq, and } from 'drizzle-orm';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth/api-auth');
 vi.mock('@/lib/db/client');
+// Spy on the comparison builders so we can assert the unflag UPDATE is scoped
+// to the appellant's own comment (defense-in-depth, #8613). The .where() mock
+// is a passthrough, so the filter is only observable on eq/and call args.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>();
+  return { ...actual, eq: vi.fn(actual.eq), and: vi.fn(actual.and) };
+});
 
 function makeReviewRequest(body: Record<string, unknown>) {
   return new NextRequest('http://localhost/api/admin/moderation/appeals/appeal-1/review', {
@@ -82,13 +90,13 @@ describe('/api/admin/moderation/appeals/[id]/review POST', () => {
     expect(res.status).toBe(409);
   });
 
-  it('approves appeal and unflags comment', async () => {
+  it('approves appeal and unflags comment, scoped to the appellant', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'admin_1', user } });
     vi.mocked(assertAdmin).mockReturnValue(null);
 
     vi.mocked(getDb).mockReturnValue(makeMockDb([
-      { id: 'appeal-1', status: 'pending', contentType: 'comment', contentId: 'comment-1' },
+      { id: 'appeal-1', userId: 'author-1', status: 'pending', contentType: 'comment', contentId: 'comment-1' },
     ]) as unknown as ReturnType<typeof getDb>);
 
     const res = await POST(makeReviewRequest({ decision: 'approve', note: 'Content is fine' }), { params: makeParams() });
@@ -97,6 +105,10 @@ describe('/api/admin/moderation/appeals/[id]/review POST', () => {
     expect(res.status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.status).toBe('approved');
+    // The unflag UPDATE must re-confirm the appellant authored the comment, so
+    // a forged/stale appeal cannot unflag a comment its filer never owned.
+    expect(vi.mocked(and)).toHaveBeenCalled();
+    expect(vi.mocked(eq)).toHaveBeenCalledWith(expect.anything(), 'author-1');
   });
 
   it('rejects appeal without unflagging content', async () => {

--- a/web/src/app/api/admin/moderation/appeals/[id]/review/route.ts
+++ b/web/src/app/api/admin/moderation/appeals/[id]/review/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getDb, queryWithResilience } from '@/lib/db/client';
 import { moderationAppeals, gameComments } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { assertAdmin } from '@/lib/auth/api-auth';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { rateLimitAdminRoute } from '@/lib/rateLimit';
@@ -78,13 +78,21 @@ export async function POST(
         .where(eq(moderationAppeals.id, id))
     );
 
-    // If approved and the content is a comment, unflag it
+    // If approved and the content is a comment, unflag it. Defense-in-depth:
+    // re-confirm the appellant authored the comment before mutating its flag,
+    // so a stale/forged appeal cannot unflag a comment its filer never owned
+    // (the appeal POST also enforces ownership at submission time) (#8613).
     if (decision === 'approve' && appeal.contentType === 'comment') {
       await queryWithResilience(() =>
         getDb()
           .update(gameComments)
           .set({ flagged: 0 })
-          .where(eq(gameComments.id, appeal.contentId))
+          .where(
+            and(
+              eq(gameComments.id, appeal.contentId),
+              eq(gameComments.userId, appeal.userId)
+            )
+          )
       );
     }
 

--- a/web/src/app/api/moderation/appeal/route.test.ts
+++ b/web/src/app/api/moderation/appeal/route.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { POST } from './route';
 import { authenticateRequest } from '@/lib/auth/api-auth';
 import { getDb } from '@/lib/db/client';
+import { publishedGames, marketplaceAssets } from '@/lib/db/schema';
 import { makeUser, mockNextResponse } from '@/test/utils/apiTestUtils';
 import { NextRequest } from 'next/server';
 
@@ -140,4 +141,56 @@ describe('/api/moderation/appeal', () => {
     expect(data.id).toBe('appeal-1');
     expect(data.status).toBe('pending');
   });
+
+  // The ownership check (resolveContentOwner) has three branches that each query a
+  // DIFFERENT table+column. The comment branch is covered above; exercise the game
+  // and asset branches directly so a regression in either — wrong column, missing
+  // WHERE, or copy-paste of the userId column onto assets (which own via sellerId)
+  // — can't silently re-open the IDOR (#8638). For each branch we assert both the
+  // ownership gate (foreign owner → 404, owner → 201) AND that the lookup targeted
+  // that content type's real owner column.
+  const OWNERSHIP_BRANCHES: Array<{
+    contentType: 'game' | 'asset';
+    ownerColumn: unknown;
+  }> = [
+    { contentType: 'game', ownerColumn: publishedGames.userId },
+    { contentType: 'asset', ownerColumn: marketplaceAssets.sellerId },
+  ];
+
+  for (const { contentType, ownerColumn } of OWNERSHIP_BRANCHES) {
+    it(`returns 404 when the caller does not own the ${contentType} (IDOR guard)`, async () => {
+      const user = makeUser();
+      vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
+      const db = mockOwnershipDb([{ ownerId: 'someone-else' }]);
+      vi.mocked(getDb).mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+      const res = await POST(makeRequest({
+        contentId: VALID_UUID,
+        contentType,
+        reason: 'This content was not offensive, it was taken out of context',
+      }));
+
+      expect(res.status).toBe(404);
+      // Ownership lookup must target this content type's owner column.
+      expect(db.select.mock.calls[0][0].ownerId).toBe(ownerColumn);
+    });
+
+    it(`creates appeal and returns 201 when the caller owns the ${contentType}`, async () => {
+      const user = makeUser();
+      vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
+      const db = mockOwnershipDb([{ ownerId: user.id }]);
+      vi.mocked(getDb).mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+      const res = await POST(makeRequest({
+        contentId: VALID_UUID,
+        contentType,
+        reason: 'This content was not offensive, it was taken out of context',
+      }));
+      const data = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(data.id).toBe('appeal-1');
+      expect(db.select.mock.calls[0][0].ownerId).toBe(ownerColumn);
+    });
+  }
 });

--- a/web/src/app/api/moderation/appeal/route.test.ts
+++ b/web/src/app/api/moderation/appeal/route.test.ts
@@ -9,6 +9,11 @@ import { NextRequest } from 'next/server';
 
 vi.mock('@/lib/auth/api-auth');
 vi.mock('@/lib/db/client');
+// Don't let the per-IP appeal rate limiter (5/10min) trip across test cases —
+// every case shares the same localhost IP, so the 6th call would 429.
+vi.mock('@/lib/rateLimit', () => ({
+  rateLimitPublicRoute: vi.fn().mockResolvedValue(undefined),
+}));
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest('http://localhost/api/moderation/appeal', {
@@ -65,17 +70,67 @@ describe('/api/moderation/appeal', () => {
     expect(JSON.stringify(data.details)).toContain('reason');
   });
 
-  it('creates appeal and returns 201 on success', async () => {
+  const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+
+  // Build a db mock whose ownership lookup returns `ownerRows` and whose insert
+  // returns the created appeal. resolveContentOwner runs select().from().where().limit().
+  function mockOwnershipDb(ownerRows: Array<{ ownerId: string }>) {
+    const limit = vi.fn().mockResolvedValue(ownerRows);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    const select = vi.fn().mockReturnValue({ from });
+    const returning = vi.fn().mockResolvedValue([{ id: 'appeal-1', status: 'pending' }]);
+    const values = vi.fn().mockReturnValue({ returning });
+    const insert = vi.fn().mockReturnValue({ values });
+    return { select, insert };
+  }
+
+  it('returns 422 if contentId is not a uuid', async () => {
     const user = makeUser();
     vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
 
-    const mockReturning = vi.fn().mockResolvedValue([{ id: 'appeal-1', status: 'pending' }]);
-    const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
-    const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
-    vi.mocked(getDb).mockReturnValue({ insert: mockInsert } as unknown as ReturnType<typeof getDb>);
+    const res = await POST(makeRequest({ contentId: 'comment-1', contentType: 'comment', reason: 'Not offensive content here' }));
+    expect(res.status).toBe(422);
+    const data = await res.json();
+    expect(data.error).toBe('Validation failed');
+    expect(JSON.stringify(data.details)).toContain('contentId');
+  });
+
+  it('returns 404 when the content does not exist', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
+    vi.mocked(getDb).mockReturnValue(mockOwnershipDb([]) as unknown as ReturnType<typeof getDb>);
 
     const res = await POST(makeRequest({
-      contentId: 'comment-1',
+      contentId: VALID_UUID,
+      contentType: 'comment',
+      reason: 'This content was not offensive, it was taken out of context',
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the caller does not own the content (no leak via 403)', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
+    // Content owned by a DIFFERENT user.
+    vi.mocked(getDb).mockReturnValue(mockOwnershipDb([{ ownerId: 'someone-else' }]) as unknown as ReturnType<typeof getDb>);
+
+    const res = await POST(makeRequest({
+      contentId: VALID_UUID,
+      contentType: 'comment',
+      reason: 'This content was not offensive, it was taken out of context',
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('creates appeal and returns 201 when the caller owns the content', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: 'c1', user } });
+    // Content owned by the authenticated user (makeUser().id === 'user-uuid-1').
+    vi.mocked(getDb).mockReturnValue(mockOwnershipDb([{ ownerId: user.id }]) as unknown as ReturnType<typeof getDb>);
+
+    const res = await POST(makeRequest({
+      contentId: VALID_UUID,
       contentType: 'comment',
       reason: 'This content was not offensive, it was taken out of context',
     }));

--- a/web/src/app/api/moderation/appeal/route.ts
+++ b/web/src/app/api/moderation/appeal/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { eq } from 'drizzle-orm';
 import { getDb, queryWithResilience } from '@/lib/db/client';
-import { moderationAppeals } from '@/lib/db/schema';
+import {
+  moderationAppeals,
+  gameComments,
+  publishedGames,
+  marketplaceAssets,
+} from '@/lib/db/schema';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { rateLimitPublicRoute } from '@/lib/rateLimit';
 import { captureException } from '@/lib/monitoring/sentry-server';
@@ -9,10 +15,52 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 export const dynamic = 'force-dynamic';
 
 const appealSchema = z.object({
-  contentId: z.string().min(1).max(100),
+  // All three appealable content types are keyed by a uuid primary key, so the
+  // contentId must be a uuid — rejecting malformed ids early (400) instead of
+  // letting an invalid uuid cast surface as a 500 in the ownership lookup.
+  contentId: z.string().uuid(),
   contentType: z.enum(['comment', 'asset', 'game']),
   reason: z.string().trim().min(10).max(2000),
 });
+
+/**
+ * Resolve the owning user id for a piece of appealable content, or null if it
+ * does not exist. Comments and games are owned by `userId`; marketplace assets
+ * by `sellerId`.
+ */
+async function resolveContentOwner(
+  contentType: 'comment' | 'asset' | 'game',
+  contentId: string
+): Promise<string | null> {
+  if (contentType === 'comment') {
+    const [row] = await queryWithResilience(() =>
+      getDb()
+        .select({ ownerId: gameComments.userId })
+        .from(gameComments)
+        .where(eq(gameComments.id, contentId))
+        .limit(1)
+    );
+    return row?.ownerId ?? null;
+  }
+  if (contentType === 'game') {
+    const [row] = await queryWithResilience(() =>
+      getDb()
+        .select({ ownerId: publishedGames.userId })
+        .from(publishedGames)
+        .where(eq(publishedGames.id, contentId))
+        .limit(1)
+    );
+    return row?.ownerId ?? null;
+  }
+  const [row] = await queryWithResilience(() =>
+    getDb()
+      .select({ ownerId: marketplaceAssets.sellerId })
+      .from(marketplaceAssets)
+      .where(eq(marketplaceAssets.id, contentId))
+      .limit(1)
+  );
+  return row?.ownerId ?? null;
+}
 
 /**
  * POST /api/moderation/appeal
@@ -29,6 +77,16 @@ export async function POST(req: NextRequest) {
     if (mid.error) return mid.error;
 
     const { contentId, contentType, reason } = mid.body as z.infer<typeof appealSchema>;
+
+    // Authz: only the author/owner of the content may appeal its moderation.
+    // Without this check, any authenticated user could spam the moderation
+    // queue with appeals about other people's content and — if an admin
+    // approved one — get a comment they never authored unflagged (#8613).
+    // Return 404 (not 403) so we don't disclose whether the content exists.
+    const ownerId = await resolveContentOwner(contentType, contentId);
+    if (ownerId === null || ownerId !== mid.userId!) {
+      return NextResponse.json({ error: 'Content not found' }, { status: 404 });
+    }
 
     const [appeal] = await queryWithResilience(() =>
       getDb()

--- a/web/src/app/api/user/export-data/route.test.ts
+++ b/web/src/app/api/user/export-data/route.test.ts
@@ -23,15 +23,29 @@ function makeMockDb(overrides: Record<string, unknown[]> = {}) {
     feedback: [],
     providerKeys: [],
     apiKeys: [],
+    gameComments: [],
+    gameRatings: [],
+    gameLikes: [],
+    userFollows: [],
+    gameForks: [],
+    marketplaceAssets: [],
+    assetPurchases: [],
+    assetReviews: [],
+    sellerProfiles: [],
+    moderationAppeals: [],
   };
 
   const data = { ...defaults, ...overrides };
-  // Track call order to map to the correct data set
+  // Track call order to map to the correct data set — MUST match the order of
+  // the db.select(...) calls inside the route's Promise.all.
   let callIndex = 0;
   const dataOrder = [
     'users', 'projects', 'tokenUsage', 'tokenPurchases',
     'creditTransactions', 'costLog', 'publishedGames',
     'generationJobs', 'feedback', 'providerKeys', 'apiKeys',
+    'gameComments', 'gameRatings', 'gameLikes', 'userFollows',
+    'gameForks', 'marketplaceAssets', 'assetPurchases', 'assetReviews',
+    'sellerProfiles', 'moderationAppeals',
   ];
 
   const mockSelect = vi.fn().mockImplementation(() => {
@@ -93,6 +107,44 @@ describe('/api/user/export-data', () => {
     expect(data.feedback).toEqual([]);
     expect(data.providerKeys).toEqual([]);
     expect(data.apiKeys).toEqual([]);
+    // Community + marketplace + moderation data must be present in the export
+    // (GDPR completeness — these user-owned tables were previously omitted, #8639).
+    expect(data.gameComments).toEqual([]);
+    expect(data.gameRatings).toEqual([]);
+    expect(data.gameLikes).toEqual([]);
+    expect(data.following).toEqual([]);
+    expect(data.gameForks).toEqual([]);
+    expect(data.marketplaceAssets).toEqual([]);
+    expect(data.assetPurchases).toEqual([]);
+    expect(data.assetReviews).toEqual([]);
+    expect(data.sellerProfile).toBeNull();
+    expect(data.moderationAppeals).toEqual([]);
+  });
+
+  it('includes populated community and marketplace rows the user owns', async () => {
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({
+      ok: true,
+      ctx: { clerkId: 'clerk_abc', user },
+    });
+
+    const mockDb = makeMockDb({
+      gameComments: [{ id: 'gc-1', gameId: 'g-1', content: 'nice', parentId: null }],
+      assetPurchases: [{ id: 'ap-1', assetId: 'a-1', priceTokens: 50 }],
+      sellerProfiles: [{ id: 'sp-1', displayName: 'Seller', totalSales: 3 }],
+      moderationAppeals: [{ id: 'ma-1', contentId: 'c-1', contentType: 'comment', reason: 'context', status: 'pending' }],
+    });
+    vi.mocked(getDb).mockReturnValue(mockDb as unknown as ReturnType<typeof getDb>);
+
+    const res = await GET(new NextRequest('http://localhost/api/user/export-data'));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.gameComments).toEqual([expect.objectContaining({ id: 'gc-1' })]);
+    expect(data.assetPurchases).toEqual([expect.objectContaining({ id: 'ap-1' })]);
+    // sellerProfile is a single object (the user has at most one), not an array.
+    expect(data.sellerProfile).toEqual(expect.objectContaining({ id: 'sp-1' }));
+    expect(data.moderationAppeals).toEqual([expect.objectContaining({ id: 'ma-1' })]);
   });
 
   it('returns 500 when database query fails', async () => {

--- a/web/src/app/api/user/export-data/route.ts
+++ b/web/src/app/api/user/export-data/route.ts
@@ -15,6 +15,16 @@ import {
   feedback,
   providerKeys,
   apiKeys,
+  gameComments,
+  gameRatings,
+  gameLikes,
+  userFollows,
+  gameForks,
+  marketplaceAssets,
+  assetPurchases,
+  assetReviews,
+  sellerProfiles,
+  moderationAppeals,
 } from '@/lib/db/schema';
 
 /**
@@ -45,6 +55,16 @@ export async function GET(req: NextRequest) {
       userFeedback,
       userProviderKeys,
       userApiKeys,
+      userGameComments,
+      userGameRatings,
+      userGameLikes,
+      userFollowing,
+      userGameForks,
+      userMarketplaceAssets,
+      userAssetPurchases,
+      userAssetReviews,
+      userSellerProfile,
+      userModerationAppeals,
     ] = await queryWithResilience(() => {
       // eslint-disable-next-line no-restricted-syntax -- db ref needed for Promise.all inside queryWithResilience
       const db = getDb();
@@ -153,6 +173,96 @@ export async function GET(req: NextRequest) {
         expiresAt: apiKeys.expiresAt,
         createdAt: apiKeys.createdAt,
       }).from(apiKeys).where(eq(apiKeys.userId, userId)),
+
+      // Community: comments the user authored
+      db.select({
+        id: gameComments.id,
+        gameId: gameComments.gameId,
+        content: gameComments.content,
+        parentId: gameComments.parentId,
+        createdAt: gameComments.createdAt,
+      }).from(gameComments).where(eq(gameComments.userId, userId)),
+
+      // Community: ratings the user gave
+      db.select({
+        id: gameRatings.id,
+        gameId: gameRatings.gameId,
+        rating: gameRatings.rating,
+        createdAt: gameRatings.createdAt,
+        updatedAt: gameRatings.updatedAt,
+      }).from(gameRatings).where(eq(gameRatings.userId, userId)),
+
+      // Community: likes the user gave
+      db.select({
+        id: gameLikes.id,
+        gameId: gameLikes.gameId,
+        createdAt: gameLikes.createdAt,
+      }).from(gameLikes).where(eq(gameLikes.userId, userId)),
+
+      // Social graph: accounts the user follows (the user's own action)
+      db.select({
+        id: userFollows.id,
+        followingId: userFollows.followingId,
+        createdAt: userFollows.createdAt,
+      }).from(userFollows).where(eq(userFollows.followerId, userId)),
+
+      // Community: forks the user created
+      db.select({
+        id: gameForks.id,
+        originalGameId: gameForks.originalGameId,
+        forkedProjectId: gameForks.forkedProjectId,
+        createdAt: gameForks.createdAt,
+      }).from(gameForks).where(eq(gameForks.userId, userId)),
+
+      // Marketplace: assets the user listed for sale
+      db.select({
+        id: marketplaceAssets.id,
+        name: marketplaceAssets.name,
+        description: marketplaceAssets.description,
+        priceTokens: marketplaceAssets.priceTokens,
+        downloadCount: marketplaceAssets.downloadCount,
+        createdAt: marketplaceAssets.createdAt,
+        updatedAt: marketplaceAssets.updatedAt,
+      }).from(marketplaceAssets).where(eq(marketplaceAssets.sellerId, userId)),
+
+      // Marketplace: assets the user purchased
+      db.select({
+        id: assetPurchases.id,
+        assetId: assetPurchases.assetId,
+        priceTokens: assetPurchases.priceTokens,
+        createdAt: assetPurchases.createdAt,
+      }).from(assetPurchases).where(eq(assetPurchases.buyerId, userId)),
+
+      // Marketplace: reviews the user wrote
+      db.select({
+        id: assetReviews.id,
+        assetId: assetReviews.assetId,
+        rating: assetReviews.rating,
+        content: assetReviews.content,
+        createdAt: assetReviews.createdAt,
+      }).from(assetReviews).where(eq(assetReviews.userId, userId)),
+
+      // Marketplace: the user's seller profile (no earnings internals beyond totals)
+      db.select({
+        id: sellerProfiles.id,
+        displayName: sellerProfiles.displayName,
+        bio: sellerProfiles.bio,
+        portfolioUrl: sellerProfiles.portfolioUrl,
+        totalEarnings: sellerProfiles.totalEarnings,
+        totalSales: sellerProfiles.totalSales,
+        createdAt: sellerProfiles.createdAt,
+      }).from(sellerProfiles).where(eq(sellerProfiles.userId, userId)),
+
+      // Moderation: appeals the user filed
+      db.select({
+        id: moderationAppeals.id,
+        contentId: moderationAppeals.contentId,
+        contentType: moderationAppeals.contentType,
+        reason: moderationAppeals.reason,
+        status: moderationAppeals.status,
+        createdAt: moderationAppeals.createdAt,
+        reviewedAt: moderationAppeals.reviewedAt,
+      }).from(moderationAppeals).where(eq(moderationAppeals.userId, userId)),
     ]);
     });
 
@@ -169,6 +279,16 @@ export async function GET(req: NextRequest) {
       feedback: userFeedback,
       providerKeys: userProviderKeys,
       apiKeys: userApiKeys,
+      gameComments: userGameComments,
+      gameRatings: userGameRatings,
+      gameLikes: userGameLikes,
+      following: userFollowing,
+      gameForks: userGameForks,
+      marketplaceAssets: userMarketplaceAssets,
+      assetPurchases: userAssetPurchases,
+      assetReviews: userAssetReviews,
+      sellerProfile: userSellerProfile[0] ?? null,
+      moderationAppeals: userModerationAppeals,
     };
 
     return new NextResponse(JSON.stringify(exportData, null, 2), {


### PR DESCRIPTION
## Summary
- **#8613 — moderation-appeal IDOR:** `POST /api/moderation/appeal` now verifies the caller owns the referenced content before filing an appeal. `resolveContentOwner` checks the right column per type — comment (`gameComments.userId`), game (`publishedGames.userId`), asset (`marketplaceAssets.sellerId`) — and returns 404 on mismatch or non-existence (no existence disclosure). `contentId` tightened to uuid so malformed ids 400 instead of 500. The admin review route re-confirms the appellant authored the comment before clearing its flag (defense-in-depth against stale appeals).
- **#8639 — incomplete GDPR export:** the user-data export now includes all 10 previously-omitted user-owned tables (game comments, ratings, likes, follows, forks, marketplace listings, asset purchases, asset reviews, seller profile, moderation appeals), with sensitive columns scoped out (`providerKeys` omits `encryptedKey`/`iv`; `apiKeys` omits `keyHash`).

Closes #8613
Closes #8639

## Test plan
- [x] Appeal-route regression tests: uuid validation (422), content-not-found (404), non-owner (404, no 403 leak), owner success (201), and per-type IDOR cases for game + asset asserting the lookup targets the correct owner column
- [x] Admin review route asserts the defense-in-depth `and(eq(id), eq(userId))` WHERE clause fires
- [x] Export test asserts every newly-added table key is present (and a populated-rows pass-through case)
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, targeted vitest green

(Note: #8638's community-detail leak is fixed separately in #8784, not here.)