### PR TITLE
chore(design): bump @vitejs/plugin-react 4 → 5.2.0 (stay current on Vite 6)

### DIFF
--- a/apps/design/package.json
+++ b/apps/design/package.json
@@ -23,7 +23,7 @@
     "@storybook/react": "^8.6",
     "@storybook/react-vite": "^8.6",
     "@storybook/test": "^8.6",
-    "@vitejs/plugin-react": "^4",
+    "@vitejs/plugin-react": "^5.2.0",
     "chromatic": "^11",
     "storybook": "^8.6",
     "vite": "^6.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@storybook/react": "^8.6",
         "@storybook/react-vite": "^8.6",
         "@storybook/test": "^8.6",
-        "@vitejs/plugin-react": "^4",
+        "@vitejs/plugin-react": "^5.2.0",
         "chromatic": "^11",
         "storybook": "^8.6",
         "vite": "^6.4.2"
@@ -50,11 +50,6 @@
       "engines": {
         "node": ">=24 <25"
       }
-    },
-    "apps/design/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/design/node_modules/@spawnforge/ui": {
       "resolved": "apps/design/vendored/spawnforge-ui",
@@ -70,25 +65,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
-    "apps/design/node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "apps/design/vendored/spawnforge-ui": {
@@ -1377,6 +1353,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -1430,6 +1416,38 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -5290,6 +5308,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -9766,6 +9791,27 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -18278,6 +18324,16 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-remove-scroll": {


### PR DESCRIPTION
## Summary
- Bumps `@vitejs/plugin-react` `^4` → `^5.2.0` in `apps/design` (the Storybook workbench, our only real Vite consumer).
- 5.2.0 is the **newest plugin-react that still supports Vite 6** (peer `vite: ^4.2 || ^5 || ^6 || ^7 || ^8`), so it gets us off the stale v4 line and forward-stages Vite 7/8 **without** a breaking jump.
- Relocked the single root `package-lock.json`; `npm ci` validates clean (no EUSAGE drift).

## Why not plugin-react 6 / Vite 8?
Dependabot #8798 tried plugin-react → 6, which **requires `vite: ^8`** (plus new required peers `@rolldown/plugin-babel` + `babel-plugin-react-compiler`). We're on Vite `^6`, and Storybook 8.6's vite builder **caps at Vite 6** (Storybook 9 caps at 7; only Storybook 10 accepts Vite 8). So full Vite 8 is a Storybook **8→10** migration — deferred and tracked in #8810. `vitest@4.1.8` already supports Vite 8, so the test stack is not the blocker; Storybook is.

This is the correct intermediate "stay current" step, and supersedes #8798.

Closes #8812

## Test plan
- [x] `@vitejs/plugin-react` resolves to 5.2.0 in `package-lock.json`
- [x] `npm ci --dry-run` clean — lockfile/manifest agree, no drift
- [ ] CI: `apps/design` Storybook build green
- [ ] CI: full suite green (Vite/Storybook/vitest unchanged)