### PR TITLE
feat(monitoring): Sentry cron check-in monitors for Vercel crons

### DIFF
--- a/web/src/app/api/cron/health-monitor/cron-monitor.test.ts
+++ b/web/src/app/api/cron/health-monitor/cron-monitor.test.ts
@@ -1,0 +1,84 @@
+vi.mock('server-only', () => ({}));
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Verifies the route delegates its authorized run through the Sentry cron
+// check-in monitor (#8818). The real no-op (no-DSN) behaviour is exercised by
+// route.test.ts; here we assert the wiring: GET → withCronMonitor(slug, work).
+
+const { mockWithCronMonitor, realMonitor } = vi.hoisted(() => ({
+  mockWithCronMonitor: vi.fn(),
+  realMonitor: {
+    path: '/api/cron/health-monitor',
+    schedule: '*/5 * * * *',
+    slug: 'spawnforge-health-monitor',
+  } as const,
+}));
+
+vi.mock('@/lib/monitoring/cronMonitors', () => ({
+  getCronMonitor: vi.fn(() => realMonitor),
+  withCronMonitor: (...args: unknown[]) => mockWithCronMonitor(...args),
+}));
+
+vi.mock('@/lib/monitoring/healthChecks', () => ({
+  runAllHealthChecks: vi.fn().mockResolvedValue({
+    overall: 'healthy',
+    timestamp: new Date().toISOString(),
+    environment: 'test',
+    version: '1.0.0',
+    services: [],
+  }),
+  computeCriticalStatus: vi.fn().mockReturnValue('healthy'),
+}));
+vi.mock('@/lib/monitoring/sentry-server', () => ({ captureException: vi.fn() }));
+vi.mock('@/lib/billing/webhookIdempotency', () => ({
+  cleanupExpired: vi.fn().mockResolvedValue(0),
+}));
+vi.mock('@/lib/logging/logger', () => ({
+  logger: {
+    child: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { GET } from './route';
+
+const CRON_SECRET = 'test-cron-secret';
+
+function authedReq(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/cron/health-monitor', {
+    headers: { authorization: `Bearer ${CRON_SECRET}` },
+  });
+}
+
+describe('GET /api/cron/health-monitor — Sentry cron monitor wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CRON_SECRET', CRON_SECRET);
+    // The wrapper invokes the supplied work function and returns its result.
+    mockWithCronMonitor.mockImplementation(
+      (_monitor: unknown, work: () => Promise<unknown>) => work(),
+    );
+  });
+
+  it('wraps the authorized run in withCronMonitor with the health-monitor entry', async () => {
+    const res = await GET(authedReq());
+
+    expect(res.status).toBe(200);
+    expect(mockWithCronMonitor).toHaveBeenCalledTimes(1);
+    const [monitorArg, workArg] = mockWithCronMonitor.mock.calls[0];
+    expect(monitorArg).toEqual(realMonitor);
+    expect(typeof workArg).toBe('function');
+  });
+
+  it('does NOT invoke the monitor for an unauthorized (401) request', async () => {
+    const res = await GET(
+      new NextRequest('http://localhost:3000/api/cron/health-monitor'),
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockWithCronMonitor).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/api/cron/health-monitor/route.ts
+++ b/web/src/app/api/cron/health-monitor/route.ts
@@ -7,8 +7,14 @@ import {
   type ServiceHealth,
 } from '@/lib/monitoring/healthChecks';
 import { captureException } from '@/lib/monitoring/sentry-server';
+import { getCronMonitor, withCronMonitor } from '@/lib/monitoring/cronMonitors';
 import { logger } from '@/lib/logging/logger';
 import { cleanupExpired } from '@/lib/billing/webhookIdempotency';
+
+// Sentry cron check-in monitor for this Vercel-scheduled route (#8818). The
+// non-null assertion is guarded by `cronMonitors.test.ts`, which asserts every
+// vercel.json cron path has a registry entry — a missing entry fails CI.
+const HEALTH_MONITOR = getCronMonitor('/api/cron/health-monitor')!;
 
 /**
  * GET /api/cron/health-monitor
@@ -83,11 +89,14 @@ function reportFailuresToSentry(
   }
 }
 
-export async function GET(req: NextRequest): Promise<NextResponse> {
-  if (!isAuthorizedCron(req)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
+/**
+ * The actual monitored cron work, wrapped by the Sentry check-in monitor.
+ * Returns the response summary; never throws for service failures (those are
+ * reported via Sentry and still resolve 200). A genuine throw here (e.g. a
+ * health-check infra error) propagates so the Sentry check-in is marked
+ * `error` and the missed/failed monitor alert fires.
+ */
+async function runHealthMonitor(): Promise<NextResponse> {
   const log = logger.child({ endpoint: 'GET /api/cron/health-monitor' });
   log.info('Synthetic health monitor starting');
 
@@ -159,6 +168,17 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   // Always return 200 — Vercel cron considers non-200 a failure and backs off.
   // Service failures are communicated exclusively via Sentry.
   return NextResponse.json(summary, { status: 200 });
+}
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  if (!isAuthorizedCron(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Wrap the authorized cron run in a Sentry check-in monitor (#8818) so a
+  // missed / errored / long run surfaces as a Sentry alert. No-ops without
+  // SENTRY_DSN, so dev/CI/preview behaviour is unchanged.
+  return withCronMonitor(HEALTH_MONITOR, runHealthMonitor);
 }
 
 export const dynamic = 'force-dynamic';

--- a/web/src/lib/monitoring/__tests__/cronMonitors.test.ts
+++ b/web/src/lib/monitoring/__tests__/cronMonitors.test.ts
@@ -1,0 +1,161 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockWithMonitor = vi.fn();
+vi.mock('@sentry/nextjs', () => ({
+  withMonitor: (...args: unknown[]) => mockWithMonitor(...args),
+}));
+
+import {
+  CRON_MONITORS,
+  getCronMonitor,
+  withCronMonitor,
+  type CronMonitor,
+} from '../cronMonitors';
+
+describe('CRON_MONITORS registry', () => {
+  it('has at least one monitor', () => {
+    expect(CRON_MONITORS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique paths and unique slugs', () => {
+    const paths = CRON_MONITORS.map((m) => m.path);
+    const slugs = CRON_MONITORS.map((m) => m.slug);
+    expect(new Set(paths).size).toBe(paths.length);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('uses kebab-case slugs (Sentry-safe identifiers)', () => {
+    for (const m of CRON_MONITORS) {
+      expect(m.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it('uses 5-field crontab schedules', () => {
+    for (const m of CRON_MONITORS) {
+      expect(m.schedule.trim().split(/\s+/)).toHaveLength(5);
+    }
+  });
+});
+
+describe('CRON_MONITORS ↔ vercel.json parity', () => {
+  // The registry is the runtime mirror of the source-of-truth `web/vercel.json`.
+  // Drift in either direction (a Vercel cron without a monitor, or a monitor
+  // for a non-existent cron) must fail CI rather than ship an unmonitored job.
+  type VercelCron = { path: string; schedule: string };
+  const vercelJson = JSON.parse(
+    readFileSync(join(__dirname, '../../../../vercel.json'), 'utf8'),
+  ) as { crons?: VercelCron[] };
+  const vercelCrons = vercelJson.crons ?? [];
+
+  it('every vercel.json cron has a registry entry with a matching schedule', () => {
+    for (const cron of vercelCrons) {
+      const monitor = getCronMonitor(cron.path);
+      expect(
+        monitor,
+        `vercel.json cron ${cron.path} has no Sentry monitor in CRON_MONITORS`,
+      ).toBeDefined();
+      expect(monitor?.schedule).toBe(cron.schedule);
+    }
+  });
+
+  it('every registry entry maps to a real vercel.json cron', () => {
+    const vercelPaths = new Set(vercelCrons.map((c) => c.path));
+    for (const m of CRON_MONITORS) {
+      expect(
+        vercelPaths.has(m.path),
+        `CRON_MONITORS entry ${m.path} is not declared in vercel.json crons`,
+      ).toBe(true);
+    }
+  });
+
+  it('registry count equals vercel.json cron count', () => {
+    expect(CRON_MONITORS.length).toBe(vercelCrons.length);
+  });
+});
+
+describe('getCronMonitor', () => {
+  it('returns the monitor for a known path', () => {
+    const m = getCronMonitor('/api/cron/health-monitor');
+    expect(m?.slug).toBe('spawnforge-health-monitor');
+  });
+
+  it('returns undefined for an unknown path', () => {
+    expect(getCronMonitor('/api/cron/does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('withCronMonitor', () => {
+  const monitor: CronMonitor = {
+    path: '/api/cron/test',
+    schedule: '*/5 * * * *',
+    slug: 'test-monitor',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('no-ops (calls handler directly, no check-in) when SENTRY_DSN is absent', async () => {
+    vi.stubEnv('SENTRY_DSN', '');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', '');
+    const handler = vi.fn().mockResolvedValue('result');
+
+    const out = await withCronMonitor(monitor, handler);
+
+    expect(out).toBe('result');
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mockWithMonitor).not.toHaveBeenCalled();
+  });
+
+  it('wraps in Sentry.withMonitor with the slug + crontab schedule when DSN is set', async () => {
+    vi.stubEnv('SENTRY_DSN', 'https://key@sentry.io/123');
+    const handler = vi.fn().mockResolvedValue('ok');
+    mockWithMonitor.mockImplementation(
+      (_slug: string, cb: () => Promise<unknown>) => cb(),
+    );
+
+    const out = await withCronMonitor(monitor, handler);
+
+    expect(out).toBe('ok');
+    expect(mockWithMonitor).toHaveBeenCalledTimes(1);
+    const [slug, cb, config] = mockWithMonitor.mock.calls[0];
+    expect(slug).toBe('test-monitor');
+    expect(typeof cb).toBe('function');
+    expect(config).toEqual(
+      expect.objectContaining({
+        schedule: { type: 'crontab', value: '*/5 * * * *' },
+      }),
+    );
+  });
+
+  it('activates via NEXT_PUBLIC_SENTRY_DSN fallback', async () => {
+    vi.stubEnv('SENTRY_DSN', '');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_DSN', 'https://key@sentry.io/456');
+    const handler = vi.fn().mockResolvedValue('ok');
+    mockWithMonitor.mockImplementation(
+      (_slug: string, cb: () => Promise<unknown>) => cb(),
+    );
+
+    await withCronMonitor(monitor, handler);
+
+    expect(mockWithMonitor).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the handler rejection (so the check-in is marked error)', async () => {
+    vi.stubEnv('SENTRY_DSN', 'https://key@sentry.io/123');
+    const boom = new Error('infra down');
+    const handler = vi.fn().mockRejectedValue(boom);
+    mockWithMonitor.mockImplementation(
+      (_slug: string, cb: () => Promise<unknown>) => cb(),
+    );
+
+    await expect(withCronMonitor(monitor, handler)).rejects.toThrow('infra down');
+  });
+});

--- a/web/src/lib/monitoring/cronMonitors.ts
+++ b/web/src/lib/monitoring/cronMonitors.ts
@@ -1,0 +1,86 @@
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Sentry cron (check-in) monitors for Vercel-scheduled routes.
+ *
+ * Each scheduled route declared under `crons` in `web/vercel.json` is mirrored
+ * here so its handler can be wrapped in `Sentry.withMonitor()`. That tells
+ * Sentry to expect a check-in on the given crontab schedule and to alert when a
+ * run is missed, errors, or runs long — turning a silent cron failure (Vercel
+ * cron failures are otherwise invisible) into a Sentry alert.
+ *
+ * SOURCE-OF-TRUTH: `web/vercel.json` is what Vercel actually schedules. This
+ * registry is the runtime mirror of it; `cronMonitors.test.ts` asserts the two
+ * stay in lockstep so adding a Vercel cron without a monitor (or vice versa)
+ * fails CI rather than shipping an unmonitored job.
+ *
+ * GUARD: `withCronMonitor` no-ops (runs the handler directly, no check-in) when
+ * `SENTRY_DSN` is absent — local dev, CI, and previews without Sentry behave
+ * exactly as before. Mirrors the `DSN` guard in `sentry-server.ts`.
+ */
+
+export interface CronMonitor {
+  /** Vercel cron `path` (e.g. `/api/cron/health-monitor`). */
+  readonly path: string;
+  /** Crontab schedule expression (e.g. `*\/5 * * * *`). Mirrors vercel.json. */
+  readonly schedule: string;
+  /**
+   * Stable Sentry monitor slug. Kebab-cased, deterministic, and decoupled from
+   * the path so a route rename does not orphan the dashboard monitor.
+   */
+  readonly slug: string;
+}
+
+/**
+ * The monitor registry. One entry per `crons[]` entry in `web/vercel.json`.
+ *
+ * When you add a Vercel cron, add the matching entry here (the parity test will
+ * remind you). Keep `slug` stable across renames — it is the Sentry dashboard
+ * identity.
+ */
+export const CRON_MONITORS: readonly CronMonitor[] = [
+  {
+    path: '/api/cron/health-monitor',
+    schedule: '*/5 * * * *',
+    slug: 'spawnforge-health-monitor',
+  },
+] as const;
+
+/** Look up a monitor by its Vercel cron path. */
+export function getCronMonitor(path: string): CronMonitor | undefined {
+  return CRON_MONITORS.find((m) => m.path === path);
+}
+
+/**
+ * Wrap a cron handler in a Sentry check-in monitor.
+ *
+ * On each invocation Sentry records an `in_progress` check-in, then `ok` or
+ * `error` based on whether the handler resolves or throws. `withMonitor` also
+ * upserts the monitor's schedule config so the dashboard knows when to expect
+ * the next run and can alert on a missed one.
+ *
+ * No-ops (calls `handler()` directly) when `SENTRY_DSN` is not configured, so
+ * the wrap is inert in environments without Sentry.
+ *
+ * The handler's resolved value is forwarded unchanged; thrown errors propagate
+ * after the failed check-in is recorded (so existing error handling is intact).
+ */
+export function withCronMonitor<T>(
+  monitor: CronMonitor,
+  handler: () => Promise<T>,
+): Promise<T> {
+  // Treat an empty string as "not set" so SENTRY_DSN="" still falls through to
+  // the public DSN (and ultimately to the inert no-op path). `||` is correct
+  // here precisely because empty/missing are equivalent for a DSN.
+  const dsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return handler();
+
+  return Sentry.withMonitor(monitor.slug, handler, {
+    schedule: { type: 'crontab', value: monitor.schedule },
+    // Allow a run up to 5 min to complete and tolerate a 1-min late start
+    // before flagging a missed/long check-in. Conservative defaults that suit
+    // the 5-minute health cadence; tune per-monitor if cadences diverge.
+    maxRuntime: 5,
+    checkinMargin: 1,
+  });
+}


### PR DESCRIPTION
## Summary

Vercel cron failures are invisible by default — if a scheduled route stops running, errors, or runs long, nothing alerts. This wraps each Vercel-scheduled route handler in `Sentry.withMonitor()` (check-in monitors), turning a silent cron failure into a Sentry alert.

There is one Vercel cron in the repo today (`web/vercel.json` → `/api/cron/health-monitor`, `*/5 * * * *`), so this creates one monitor: **`spawnforge-health-monitor`**.

`@sentry/nextjs` is already installed and initialized — **no SDK change, no new dependency.**

## Changes
- **`web/src/lib/monitoring/cronMonitors.ts`** — `CRON_MONITORS` registry (path + crontab schedule + stable kebab slug) mirroring `web/vercel.json`, plus `withCronMonitor(monitor, handler)`. It wraps the handler in `Sentry.withMonitor(slug, handler, { schedule: { type: 'crontab', value } , maxRuntime, checkinMargin })`, and **no-ops** (runs the handler directly) when `SENTRY_DSN`/`NEXT_PUBLIC_SENTRY_DSN` is absent — dev/CI/preview unchanged.
- **`web/src/app/api/cron/health-monitor/route.ts`** — extracted the post-auth work into `runHealthMonitor()` and wired `GET` through `withCronMonitor`. Only the **authorized** run fires a check-in; a 401 does not. Existing behaviour (always 200, Sentry-only failure reporting, #8637 webhook-claim cleanup) is preserved.

## Tests
- `cronMonitors.test.ts` — registry shape, bidirectional **parity with `web/vercel.json`** (count + path + schedule, so drift fails CI), `getCronMonitor`, and `withCronMonitor` (DSN guard / no-op / wrap config / error propagation). 13 tests.
- `cron-monitor.test.ts` — `GET` delegates the authorized run through `withCronMonitor` with the health-monitor entry; 401 fires no check-in. 2 tests.
- All cron + cronMonitors suites green: 48/48.

## Provisioning (to make it live)
- Confirm `SENTRY_DSN` is set in Vercel Production (already is for existing health-monitor reporting). Without it, the wrap no-ops.
- After the first prod run, verify Sentry → Crons shows monitor `spawnforge-health-monitor` (`*/5 * * * *`, crontab) receiving check-ins; optionally set its alert owner/recipients.
- Cost: 1 monitor is within the free quota ($0 incremental). Each future Vercel cron must get a `CRON_MONITORS` entry (parity test enforces) and costs +$0.78/monitor beyond quota.

Closes #8818

skip changeset (observability/infra-only, no user-facing change)

## Test plan
- [x] `npx vitest run` on the 4 cron + cronMonitors test files — 48 passed
- [x] `npx eslint --max-warnings 0` on changed files — clean
- [x] `npx tsc --noEmit` (whole web project, Node 24) — clean
- [ ] Post-deploy: confirm `spawnforge-health-monitor` check-ins in Sentry → Crons