### PR TITLE
feat(infra): R2 event-queue consumer for asset post-processing

### DIFF
--- a/infra/asset-postprocess/README.md
+++ b/infra/asset-postprocess/README.md
@@ -1,0 +1,117 @@
+# Asset Post-Processing Worker (Cloudflare Queue consumer)
+
+Validates generated SpawnForge assets (GLB / image maps / audio) after they land
+in the `spawnforge-assets` R2 bucket.
+
+```
+R2 object-create on spawnforge-assets
+  → R2 event notification
+  → Cloudflare Queue (spawnforge-asset-postprocess)
+  → this Worker (queue consumer)
+  → validates the artifact, writes <key>.status.json sidecar back to R2
+```
+
+## Why
+
+A generation provider (Meshy / Replicate / Suno) can report success yet upload an
+empty or malformed artifact (a 0-byte GLB, a `{}` texture-map set, no audio). The
+web status routes already guard this on the read path
+(`web/src/app/api/generate/<type>/status/route.ts` →
+`provider-success-with-no-artifact must map to failed`). This Worker adds a
+second, upload-time check so a bad artifact is flagged the moment it lands,
+independent of whether a client is polling.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `worker.mjs` | Queue consumer entrypoint (`queue()` handler) + R2 read/write |
+| `validate.mjs` | Pure, dependency-free artifact validation (magic bytes + non-empty floors). Shared by the Worker and the tests |
+| `wrangler.toml` | Worker config: R2 binding + Queue consumer binding |
+| `*.test.mjs` | Vitest suites (43 cases) for the pure logic + the queue handler |
+| `vitest.config.mjs` | Standalone vitest config (node env, no web/jsdom deps) |
+
+## Safety / env guard
+
+Every binding is optional. If `ASSET_BUCKET` is not bound (misconfigured deploy,
+or `wrangler dev` without R2) the consumer ACKs every message as an inert no-op
+and logs once — it never throws in a way that wedges the queue. The Worker is
+completely inert until the user provisions the bucket + queue (see below), so it
+cannot break prod or CI before then.
+
+A "failed"-validation message is ACKed (the failure is recorded in the sidecar) —
+only an unexpected/transient error (e.g. an R2 fetch hiccup) is `retry()`d, so
+Cloudflare redelivers and eventually dead-letters.
+
+## Tests
+
+The Worker lives outside `web/src`, so it is NOT covered by
+`web/vitest.config.node.ts`. Run its suites with the standalone config:
+
+```bash
+cd infra/asset-postprocess
+npx vitest run --config vitest.config.mjs
+```
+
+(43 tests: artifact classification, GLB/image/audio/binary validation,
+truncated-upload + empty-artifact failure paths, message-key extraction,
+sidecar/delete skipping, and the queue handler's ACK/retry/no-op branches.)
+
+## Local `wrangler dev` smoke test
+
+You can exercise the consumer locally with Miniflare's queue + R2 emulation —
+no Cloudflare account or network needed:
+
+```bash
+cd infra/asset-postprocess
+
+# 1. Start the Worker locally. --local uses Miniflare; R2 + Queue are emulated.
+npx wrangler dev --local
+
+# 2. In a second shell, put a (valid) GLB into the emulated R2 bucket, then a
+#    deliberately-empty one, so you can see both a "valid" and a "failed" path.
+#    (printf builds a 20-byte GLB header: "glTF" + version 2 + length 20.)
+printf 'glTF\x02\x00\x00\x00\x14\x00\x00\x00\x00\x00\x00\x00' \
+  | npx wrangler r2 object put spawnforge-assets/assets/dev/m1/file/model.glb --local --pipe
+printf '' \
+  | npx wrangler r2 object put spawnforge-assets/assets/dev/m2/file/empty.glb --local --pipe
+
+# 3. Enqueue R2-event-shaped messages to drive the consumer:
+npx wrangler queues consumer ...   # or use the dashboard "Send message" tester
+#    body: {"object":{"key":"assets/dev/m1/file/model.glb"},"action":"PutObject"}
+#    body: {"object":{"key":"assets/dev/m2/file/empty.glb"},"action":"PutObject"}
+
+# 4. Read back the status sidecars the Worker wrote:
+npx wrangler r2 object get spawnforge-assets/assets/dev/m1/file/model.glb.status.json --local --pipe
+#   → {"key":"...model.glb","status":"valid","kind":"glb",...}
+npx wrangler r2 object get spawnforge-assets/assets/dev/m2/file/empty.glb.status.json --local --pipe
+#   → {"key":"...empty.glb","status":"failed","kind":"glb","reason":"GLB too small or empty",...}
+```
+
+The pure validation logic is also fully unit-tested above; `wrangler dev` is for
+verifying the R2/Queue wiring end to end.
+
+## Provisioning (user-side, one time)
+
+Cloudflare account `0b949ff499d179e24dde841f71d6134f`. Cost: ~$0 within the
+existing Workers Paid plan.
+
+```bash
+cd infra/asset-postprocess
+
+# 1. Create the queue + a dead-letter queue.
+npx wrangler queues create spawnforge-asset-postprocess
+npx wrangler queues create spawnforge-asset-postprocess-dlq
+
+# 2. Deploy the consumer Worker (registers the queue-consumer binding).
+npx wrangler deploy
+
+# 3. Enable R2 event notifications: route object-create events on the
+#    spawnforge-assets bucket to the queue.
+npx wrangler r2 bucket notification create spawnforge-assets \
+  --event-type object-create \
+  --queue spawnforge-asset-postprocess
+```
+
+After step 3, every new upload to `spawnforge-assets` is validated automatically.
+Until then the Worker is inert (no events delivered) and nothing changes.

--- a/infra/asset-postprocess/validate.mjs
+++ b/infra/asset-postprocess/validate.mjs
@@ -1,0 +1,194 @@
+// @ts-check
+/**
+ * Pure, dependency-free artifact validation for generated SpawnForge assets.
+ *
+ * This module is imported by BOTH the Cloudflare Queue consumer Worker
+ * (`worker.mjs`) and the co-located vitest suite (`validate.test.mjs`). It has
+ * NO Cloudflare / web / Node runtime dependencies so it runs identically in the
+ * Workers runtime and under vitest's `node` environment.
+ *
+ * Semantics mirror the web generate-status routes
+ * (web/src/app/api/generate/<type>/status/route.ts): a provider can report success
+ * yet upload an empty / malformed artifact. The consumer must catch that and
+ * signal `failed`, never `valid`, so the poller refunds instead of sticking the
+ * job in `downloading` for the full poll cap. See gotchas.md →
+ * "provider-success-with-no-artifact must map to failed".
+ */
+
+/** GLB binary header magic: ASCII "glTF" little-endian (0x46546C67). */
+const GLB_MAGIC = 0x46546c67;
+/** GLB container format version this engine accepts (Bevy/gltf load v2). */
+const GLB_VERSION = 2;
+/** Minimum bytes for a meaningful GLB (12-byte header + at least one chunk header). */
+const GLB_MIN_BYTES = 20;
+/** Minimum bytes for a non-empty raster image artifact (texture/sprite/map). */
+const IMAGE_MIN_BYTES = 16;
+/** Minimum bytes for a non-empty audio artifact. */
+const AUDIO_MIN_BYTES = 64;
+
+/**
+ * Classify an R2 object key into the artifact kind we should validate against.
+ * Falls back to extension-based detection; unknown kinds are validated as
+ * "binary" (non-empty only).
+ *
+ * @param {string} key R2 object key, e.g. "assets/u_1/a_2/file/model.glb"
+ * @param {string | undefined | null} contentType R2 httpMetadata.contentType
+ * @returns {'glb' | 'image' | 'audio' | 'binary'}
+ */
+export function classifyArtifact(key, contentType) {
+  const ct = (contentType ?? '').toLowerCase();
+  const lowerKey = (key ?? '').toLowerCase();
+
+  if (ct.includes('model/gltf-binary') || lowerKey.endsWith('.glb')) return 'glb';
+  if (ct.startsWith('image/') || /\.(png|jpe?g|webp|ktx2|basis)$/.test(lowerKey)) {
+    return 'image';
+  }
+  if (ct.startsWith('audio/') || /\.(mp3|wav|ogg|flac|m4a)$/.test(lowerKey)) {
+    return 'audio';
+  }
+  return 'binary';
+}
+
+/**
+ * Validate a GLB binary by header. Checks magic + version + plausible length.
+ * Does NOT fully parse chunks (too expensive in a Worker) — header validity +
+ * the declared total length matching the actual byte length catches truncated /
+ * empty / wrong-format uploads, which is the failure class we care about.
+ *
+ * @param {ArrayBuffer | Uint8Array} bytes
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+export function validateGlb(bytes) {
+  const view = toDataView(bytes);
+  if (!view || view.byteLength < GLB_MIN_BYTES) {
+    return { valid: false, reason: 'GLB too small or empty' };
+  }
+  const magic = view.getUint32(0, true);
+  if (magic !== GLB_MAGIC) {
+    return { valid: false, reason: 'GLB magic mismatch (not a glTF-binary)' };
+  }
+  const version = view.getUint32(4, true);
+  if (version !== GLB_VERSION) {
+    return { valid: false, reason: `unsupported GLB version ${version}` };
+  }
+  const declaredLength = view.getUint32(8, true);
+  // Declared length must be at least the header and must not exceed the bytes we
+  // actually received (a truncated upload declares more than it delivered).
+  if (declaredLength < GLB_MIN_BYTES || declaredLength > view.byteLength) {
+    return { valid: false, reason: 'GLB declared length inconsistent with payload' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Validate a raster image artifact by magic bytes (PNG / JPEG / WebP) and a
+ * non-empty floor. Unknown-but-non-trivial image payloads pass on size alone so
+ * we never false-fail a valid but exotic format (KTX2/basis are GPU textures).
+ *
+ * @param {ArrayBuffer | Uint8Array} bytes
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+export function validateImage(bytes) {
+  const view = toDataView(bytes);
+  if (!view || view.byteLength < IMAGE_MIN_BYTES) {
+    return { valid: false, reason: 'image too small or empty' };
+  }
+  const b0 = view.getUint8(0);
+  const b1 = view.getUint8(1);
+  const b2 = view.getUint8(2);
+  const b3 = view.getUint8(3);
+  // PNG: 89 50 4E 47
+  if (b0 === 0x89 && b1 === 0x50 && b2 === 0x4e && b3 === 0x47) return { valid: true };
+  // JPEG: FF D8 FF
+  if (b0 === 0xff && b1 === 0xd8 && b2 === 0xff) return { valid: true };
+  // WebP: "RIFF" .... "WEBP"
+  if (b0 === 0x52 && b1 === 0x49 && b2 === 0x46 && b3 === 0x46 && view.byteLength >= 12) {
+    if (
+      view.getUint8(8) === 0x57 &&
+      view.getUint8(9) === 0x45 &&
+      view.getUint8(10) === 0x42 &&
+      view.getUint8(11) === 0x50
+    ) {
+      return { valid: true };
+    }
+  }
+  // Unknown signature but non-trivial payload (KTX2/basis GPU textures, etc.).
+  return { valid: true };
+}
+
+/**
+ * Validate an audio artifact: non-empty floor + best-effort magic for the
+ * common container formats we accept.
+ *
+ * @param {ArrayBuffer | Uint8Array} bytes
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+export function validateAudio(bytes) {
+  const view = toDataView(bytes);
+  if (!view || view.byteLength < AUDIO_MIN_BYTES) {
+    return { valid: false, reason: 'audio too small or empty' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Validate any non-empty binary artifact (fallback kind).
+ *
+ * @param {ArrayBuffer | Uint8Array} bytes
+ * @returns {{ valid: boolean, reason?: string }}
+ */
+export function validateBinary(bytes) {
+  const view = toDataView(bytes);
+  if (!view || view.byteLength === 0) {
+    return { valid: false, reason: 'artifact is empty' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Top-level dispatch: classify by key/content-type, then validate.
+ *
+ * @param {string} key
+ * @param {string | undefined | null} contentType
+ * @param {ArrayBuffer | Uint8Array} bytes
+ * @returns {{ valid: boolean, kind: 'glb'|'image'|'audio'|'binary', reason?: string }}
+ */
+export function validateArtifact(key, contentType, bytes) {
+  const kind = classifyArtifact(key, contentType);
+  switch (kind) {
+    case 'glb':
+      return { kind, ...validateGlb(bytes) };
+    case 'image':
+      return { kind, ...validateImage(bytes) };
+    case 'audio':
+      return { kind, ...validateAudio(bytes) };
+    default:
+      return { kind, ...validateBinary(bytes) };
+  }
+}
+
+/**
+ * Normalize ArrayBuffer | Uint8Array into a DataView. Returns null for nullish
+ * or non-buffer inputs so callers fail closed.
+ *
+ * @param {ArrayBuffer | Uint8Array | null | undefined} bytes
+ * @returns {DataView | null}
+ */
+function toDataView(bytes) {
+  if (bytes == null) return null;
+  if (bytes instanceof Uint8Array) {
+    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+  if (bytes instanceof ArrayBuffer) {
+    return new DataView(bytes);
+  }
+  return null;
+}
+
+export const __test__ = {
+  GLB_MAGIC,
+  GLB_VERSION,
+  GLB_MIN_BYTES,
+  IMAGE_MIN_BYTES,
+  AUDIO_MIN_BYTES,
+};

--- a/infra/asset-postprocess/validate.mjs
+++ b/infra/asset-postprocess/validate.mjs
@@ -111,6 +111,10 @@ export function validateImage(bytes) {
     ) {
       return { valid: true };
     }
+    // A RIFF container that is NOT WebP (e.g. a WAV audio file mislabeled
+    // image/*) must be rejected — do NOT fall through to the unknown-payload
+    // pass-through below, which is reserved for non-RIFF exotic textures.
+    return { valid: false, reason: 'RIFF container is not a WebP image' };
   }
   // Unknown signature but non-trivial payload (KTX2/basis GPU textures, etc.).
   return { valid: true };

--- a/infra/asset-postprocess/validate.test.mjs
+++ b/infra/asset-postprocess/validate.test.mjs
@@ -102,6 +102,17 @@ describe('validateImage', () => {
     ]);
     expect(validateImage(webp)).toEqual({ valid: true });
   });
+  it('rejects a non-WebP RIFF container, e.g. a WAV mislabeled image/* (regression #8819 / Sentry)', () => {
+    // "RIFF" header + "WAVE" form-type (0x57 0x41 0x56 0x45) — a WAV audio file
+    // is a RIFF container too. It must NOT fall through to the unknown-payload
+    // pass-through and be accepted as a valid image.
+    const wav = bytesOf([
+      0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45, 0, 0, 0, 0,
+    ]);
+    const r = validateImage(wav);
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/RIFF/);
+  });
   it('rejects empty / too-small image (the empty-artifact failure class)', () => {
     expect(validateImage(new Uint8Array(0)).valid).toBe(false);
     expect(validateImage(new Uint8Array(4)).valid).toBe(false);

--- a/infra/asset-postprocess/validate.test.mjs
+++ b/infra/asset-postprocess/validate.test.mjs
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyArtifact,
+  validateGlb,
+  validateImage,
+  validateAudio,
+  validateBinary,
+  validateArtifact,
+} from './validate.mjs';
+
+/** Build a minimal valid GLB header buffer with a given declared length. */
+function makeGlb({ magic = 0x46546c67, version = 2, length = 20, totalBytes = 20 } = {}) {
+  const buf = new ArrayBuffer(totalBytes);
+  const view = new DataView(buf);
+  view.setUint32(0, magic, true);
+  view.setUint32(4, version, true);
+  view.setUint32(8, length, true);
+  return new Uint8Array(buf);
+}
+
+function bytesOf(arr) {
+  return new Uint8Array(arr);
+}
+
+describe('classifyArtifact', () => {
+  it('classifies GLB by extension', () => {
+    expect(classifyArtifact('assets/u/a/file/model.glb', undefined)).toBe('glb');
+  });
+  it('classifies GLB by content-type', () => {
+    expect(classifyArtifact('assets/u/a/file/model.bin', 'model/gltf-binary')).toBe('glb');
+  });
+  it('classifies images by extension and content-type', () => {
+    expect(classifyArtifact('x/tex.png', undefined)).toBe('image');
+    expect(classifyArtifact('x/tex.jpg', undefined)).toBe('image');
+    expect(classifyArtifact('x/tex.bin', 'image/webp')).toBe('image');
+    expect(classifyArtifact('x/tex.ktx2', undefined)).toBe('image');
+  });
+  it('classifies audio by extension and content-type', () => {
+    expect(classifyArtifact('x/song.mp3', undefined)).toBe('audio');
+    expect(classifyArtifact('x/clip.wav', undefined)).toBe('audio');
+    expect(classifyArtifact('x/clip.bin', 'audio/ogg')).toBe('audio');
+  });
+  it('falls back to binary for unknown', () => {
+    expect(classifyArtifact('x/thing.dat', undefined)).toBe('binary');
+    expect(classifyArtifact('', null)).toBe('binary');
+  });
+  it('is case-insensitive on extension and content-type', () => {
+    expect(classifyArtifact('X/MODEL.GLB', undefined)).toBe('glb');
+    expect(classifyArtifact('x/t.PNG', undefined)).toBe('image');
+  });
+});
+
+describe('validateGlb', () => {
+  it('accepts a well-formed GLB header', () => {
+    expect(validateGlb(makeGlb())).toEqual({ valid: true });
+  });
+  it('rejects empty / too-small buffers', () => {
+    expect(validateGlb(new Uint8Array(0)).valid).toBe(false);
+    expect(validateGlb(new Uint8Array(8)).valid).toBe(false);
+  });
+  it('rejects wrong magic', () => {
+    const r = validateGlb(makeGlb({ magic: 0x12345678 }));
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/magic/);
+  });
+  it('rejects unsupported version', () => {
+    const r = validateGlb(makeGlb({ version: 1 }));
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/version/);
+  });
+  it('rejects a truncated upload (declared length exceeds payload)', () => {
+    // 20-byte buffer but header declares 5000 bytes -> truncated.
+    const r = validateGlb(makeGlb({ length: 5000, totalBytes: 20 }));
+    expect(r.valid).toBe(false);
+    expect(r.reason).toMatch(/declared length/);
+  });
+  it('rejects a nonsensically small declared length', () => {
+    const r = validateGlb(makeGlb({ length: 4, totalBytes: 20 }));
+    expect(r.valid).toBe(false);
+  });
+  it('accepts ArrayBuffer input as well as Uint8Array', () => {
+    expect(validateGlb(makeGlb().buffer)).toEqual({ valid: true });
+  });
+  it('fails closed on nullish input', () => {
+    expect(validateGlb(null).valid).toBe(false);
+    expect(validateGlb(undefined).valid).toBe(false);
+  });
+});
+
+describe('validateImage', () => {
+  it('accepts a PNG signature', () => {
+    const png = bytesOf([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(validateImage(png)).toEqual({ valid: true });
+  });
+  it('accepts a JPEG signature', () => {
+    const jpg = bytesOf([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(validateImage(jpg)).toEqual({ valid: true });
+  });
+  it('accepts a WebP signature', () => {
+    const webp = bytesOf([
+      0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50, 0, 0, 0, 0,
+    ]);
+    expect(validateImage(webp)).toEqual({ valid: true });
+  });
+  it('rejects empty / too-small image (the empty-artifact failure class)', () => {
+    expect(validateImage(new Uint8Array(0)).valid).toBe(false);
+    expect(validateImage(new Uint8Array(4)).valid).toBe(false);
+  });
+  it('passes unknown-signature but non-trivial payload (KTX2/basis)', () => {
+    const ktx = new Uint8Array(64).fill(0xab);
+    expect(validateImage(ktx).valid).toBe(true);
+  });
+});
+
+describe('validateAudio', () => {
+  it('accepts a non-empty audio payload', () => {
+    expect(validateAudio(new Uint8Array(128).fill(1)).valid).toBe(true);
+  });
+  it('rejects an empty / tiny audio payload', () => {
+    expect(validateAudio(new Uint8Array(0)).valid).toBe(false);
+    expect(validateAudio(new Uint8Array(8)).valid).toBe(false);
+  });
+});
+
+describe('validateBinary', () => {
+  it('accepts any non-empty binary', () => {
+    expect(validateBinary(new Uint8Array(1)).valid).toBe(true);
+  });
+  it('rejects empty binary', () => {
+    expect(validateBinary(new Uint8Array(0)).valid).toBe(false);
+    expect(validateBinary(null).valid).toBe(false);
+  });
+});
+
+describe('validateArtifact (dispatch)', () => {
+  it('routes GLB keys to GLB validation', () => {
+    const r = validateArtifact('a/model.glb', undefined, makeGlb());
+    expect(r).toEqual({ valid: true, kind: 'glb' });
+  });
+  it('routes and fails an empty GLB (provider-success-with-no-artifact)', () => {
+    const r = validateArtifact('a/model.glb', 'model/gltf-binary', new Uint8Array(0));
+    expect(r.kind).toBe('glb');
+    expect(r.valid).toBe(false);
+  });
+  it('routes image keys to image validation', () => {
+    const png = bytesOf([0x89, 0x50, 0x4e, 0x47, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(validateArtifact('a/tex.png', undefined, png)).toEqual({
+      valid: true,
+      kind: 'image',
+    });
+  });
+  it('routes audio keys to audio validation', () => {
+    expect(validateArtifact('a/song.mp3', undefined, new Uint8Array(128)).kind).toBe('audio');
+  });
+  it('routes unknown keys to binary validation', () => {
+    expect(validateArtifact('a/thing.dat', undefined, new Uint8Array(4)).kind).toBe('binary');
+  });
+});

--- a/infra/asset-postprocess/vitest.config.mjs
+++ b/infra/asset-postprocess/vitest.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone config for the infra Worker's pure-logic tests. The Worker lives
+// outside web/src (Cloudflare runtime, no web/Next deps), so it is NOT covered
+// by web/vitest.config.node.ts. This config has no setup files and no jsdom — it
+// just runs the .test.mjs suites in a node environment.
+export default defineConfig({
+  test: {
+    name: 'asset-postprocess',
+    environment: 'node',
+    include: ['**/*.test.mjs'],
+  },
+});

--- a/infra/asset-postprocess/worker.mjs
+++ b/infra/asset-postprocess/worker.mjs
@@ -1,0 +1,181 @@
+// @ts-check
+/**
+ * SpawnForge generated-asset post-processing Worker (Cloudflare Queue consumer).
+ *
+ * Pipeline: R2 event notification (object-create on `spawnforge-assets`)
+ *   -> Cloudflare Queue (`spawnforge-asset-postprocess`)
+ *   -> this consumer Worker.
+ *
+ * For each uploaded artifact (GLB / image maps / audio) the consumer:
+ *   1. fetches the object from the bound R2 bucket,
+ *   2. validates it with the pure `validateArtifact()` logic (magic bytes +
+ *      non-empty floors) — the same failure class the web status routes guard,
+ *   3. writes a small status object back to R2 next to the artifact
+ *      (`<key>.status.json`) so the app / status routes can observe the result,
+ *   4. ACKs the message on success, RETRIES on transient/unexpected errors so
+ *      Cloudflare redelivers (and eventually dead-letters).
+ *
+ * FEATURE/ENV GUARD: every binding is optional. If `env.ASSET_BUCKET` is not
+ * bound (e.g. a misconfigured deploy, or local `wrangler dev` without R2), the
+ * consumer ACKs every message as a safe no-op and logs once — it NEVER throws
+ * in a way that wedges the queue. Provisioning the bucket + queue is the user's
+ * deploy step; until then this Worker is inert, never breaking anything.
+ *
+ * This file has no npm dependencies — it is deployed as-is by `wrangler deploy`.
+ */
+
+import { validateArtifact } from './validate.mjs';
+
+/** Suffix for the sidecar status object written next to each artifact. */
+const STATUS_SUFFIX = '.status.json';
+
+/**
+ * @typedef {Object} R2ObjectBody
+ * @property {() => Promise<ArrayBuffer>} arrayBuffer
+ * @property {{ contentType?: string }} [httpMetadata]
+ * @property {number} [size]
+ */
+
+/**
+ * @typedef {Object} R2Bucket
+ * @property {(key: string) => Promise<R2ObjectBody | null>} get
+ * @property {(key: string, value: string, opts?: object) => Promise<unknown>} put
+ */
+
+/**
+ * @typedef {Object} QueueMessage
+ * @property {unknown} body
+ * @property {() => void} ack
+ * @property {() => void} retry
+ */
+
+/**
+ * Extract the R2 object key from an R2 event-notification message body.
+ * R2 event notifications deliver `{ account, bucket, object: { key, size }, action }`.
+ * Returns null when the shape is unrecognized (we then ACK as a no-op rather
+ * than retry forever on malformed input).
+ *
+ * @param {unknown} body
+ * @returns {string | null}
+ */
+export function extractKey(body) {
+  if (body == null || typeof body !== 'object') return null;
+  const b = /** @type {Record<string, unknown>} */ (body);
+  // R2 event-notification shape.
+  if (b.object && typeof b.object === 'object') {
+    const key = /** @type {Record<string, unknown>} */ (b.object).key;
+    if (typeof key === 'string' && key.length > 0) return key;
+  }
+  // Tolerate a flat `{ key }` shape (manual enqueue / tests).
+  if (typeof b.key === 'string' && b.key.length > 0) return b.key;
+  return null;
+}
+
+/**
+ * Should this key be skipped (not a real artifact)? We never re-process our own
+ * sidecar status objects, and skip delete actions.
+ *
+ * @param {string} key
+ * @param {unknown} body
+ * @returns {boolean}
+ */
+export function shouldSkip(key, body) {
+  if (key.endsWith(STATUS_SUFFIX)) return true;
+  const action =
+    body && typeof body === 'object'
+      ? /** @type {Record<string, unknown>} */ (body).action
+      : undefined;
+  // R2 emits actions like "PutObject" / "DeleteObject"; only validate creates.
+  if (typeof action === 'string' && /delete/i.test(action)) return true;
+  return false;
+}
+
+/**
+ * Process a single queue message against the bound R2 bucket. Returns the
+ * status record that was (or would be) written. Pure-ish: side effects limited
+ * to `bucket.get` / `bucket.put`. Throws only on unexpected/transient failures
+ * so the caller can `retry()`.
+ *
+ * @param {unknown} body
+ * @param {R2Bucket} bucket
+ * @returns {Promise<{ key: string, status: 'valid'|'failed'|'skipped', kind?: string, reason?: string }>}
+ */
+export async function processMessage(body, bucket) {
+  const key = extractKey(body);
+  if (!key) {
+    return { key: '', status: 'skipped', reason: 'unrecognized message shape' };
+  }
+  if (shouldSkip(key, body)) {
+    return { key, status: 'skipped', reason: 'status sidecar or delete event' };
+  }
+
+  const object = await bucket.get(key);
+  if (!object) {
+    // Object vanished (deleted between event and processing). Not retryable.
+    return { key, status: 'skipped', reason: 'object not found' };
+  }
+
+  const bytes = await object.arrayBuffer();
+  const contentType = object.httpMetadata?.contentType;
+  const result = validateArtifact(key, contentType, bytes);
+
+  const record = {
+    key,
+    status: /** @type {'valid'|'failed'} */ (result.valid ? 'valid' : 'failed'),
+    kind: result.kind,
+    reason: result.reason,
+    bytes: bytes.byteLength,
+    validatedAt: new Date().toISOString(),
+  };
+
+  await bucket.put(`${key}${STATUS_SUFFIX}`, JSON.stringify(record), {
+    httpMetadata: { contentType: 'application/json' },
+  });
+
+  return { key, status: record.status, kind: result.kind, reason: result.reason };
+}
+
+export default {
+  /**
+   * Cloudflare Queue consumer entrypoint.
+   *
+   * @param {{ messages: QueueMessage[] }} batch
+   * @param {{ ASSET_BUCKET?: R2Bucket }} env
+   * @returns {Promise<void>}
+   */
+  async queue(batch, env) {
+    const bucket = env.ASSET_BUCKET;
+    if (!bucket) {
+      // ENV GUARD: bucket not bound — ACK everything as an inert no-op so the
+      // queue drains instead of wedging on retry. Deploy provisions the binding.
+      console.warn(
+        '[asset-postprocess] ASSET_BUCKET not bound; ACKing batch as no-op'
+      );
+      for (const message of batch.messages) message.ack();
+      return;
+    }
+
+    for (const message of batch.messages) {
+      try {
+        const outcome = await processMessage(message.body, bucket);
+        if (outcome.status === 'failed') {
+          console.warn(
+            `[asset-postprocess] artifact FAILED validation: ${outcome.key} (${outcome.kind}) — ${outcome.reason}`
+          );
+        }
+        // Validation ran (valid OR failed) and the status was persisted: ACK.
+        // A "failed" artifact is a successfully-processed message — the failure
+        // is recorded in the sidecar, not a reason to redeliver.
+        message.ack();
+      } catch (err) {
+        // Unexpected/transient error (R2 fetch hiccup, etc.) — RETRY so
+        // Cloudflare redelivers and eventually dead-letters.
+        console.error(
+          `[asset-postprocess] transient error, retrying message:`,
+          err instanceof Error ? err.message : String(err)
+        );
+        message.retry();
+      }
+    }
+  },
+};

--- a/infra/asset-postprocess/worker.test.mjs
+++ b/infra/asset-postprocess/worker.test.mjs
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi } from 'vitest';
+import workerDefault, {
+  extractKey,
+  shouldSkip,
+  processMessage,
+} from './worker.mjs';
+
+function makeGlbBytes() {
+  const buf = new ArrayBuffer(20);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x46546c67, true);
+  view.setUint32(4, 2, true);
+  view.setUint32(8, 20, true);
+  return new Uint8Array(buf);
+}
+
+/** Minimal in-memory R2 bucket stub. */
+function makeBucket(objects = {}) {
+  const store = { ...objects };
+  return {
+    puts: {},
+    async get(key) {
+      const o = store[key];
+      if (!o) return null;
+      return {
+        httpMetadata: { contentType: o.contentType },
+        async arrayBuffer() {
+          return o.bytes.buffer.slice(
+            o.bytes.byteOffset,
+            o.bytes.byteOffset + o.bytes.byteLength
+          );
+        },
+      };
+    },
+    async put(key, value) {
+      this.puts[key] = value;
+      store[key] = { bytes: new TextEncoder().encode(value), contentType: 'application/json' };
+    },
+  };
+}
+
+describe('extractKey', () => {
+  it('reads R2 event-notification object.key', () => {
+    expect(extractKey({ object: { key: 'assets/u/a/model.glb' }, action: 'PutObject' })).toBe(
+      'assets/u/a/model.glb'
+    );
+  });
+  it('reads a flat { key } shape', () => {
+    expect(extractKey({ key: 'x/y.png' })).toBe('x/y.png');
+  });
+  it('returns null for unrecognized shapes', () => {
+    expect(extractKey(null)).toBeNull();
+    expect(extractKey('nope')).toBeNull();
+    expect(extractKey({})).toBeNull();
+    expect(extractKey({ object: {} })).toBeNull();
+  });
+});
+
+describe('shouldSkip', () => {
+  it('skips our own status sidecars', () => {
+    expect(shouldSkip('x/y.png.status.json', {})).toBe(true);
+  });
+  it('skips delete actions', () => {
+    expect(shouldSkip('x/y.png', { action: 'DeleteObject' })).toBe(true);
+  });
+  it('does not skip real create events', () => {
+    expect(shouldSkip('x/y.png', { action: 'PutObject' })).toBe(false);
+  });
+});
+
+describe('processMessage', () => {
+  it('validates a good GLB and writes a "valid" status sidecar', async () => {
+    const bucket = makeBucket({
+      'a/model.glb': { bytes: makeGlbBytes(), contentType: 'model/gltf-binary' },
+    });
+    const out = await processMessage({ object: { key: 'a/model.glb' }, action: 'PutObject' }, bucket);
+    expect(out.status).toBe('valid');
+    expect(out.kind).toBe('glb');
+    const sidecar = JSON.parse(bucket.puts['a/model.glb.status.json']);
+    expect(sidecar.status).toBe('valid');
+    expect(sidecar.bytes).toBe(20);
+  });
+
+  it('marks an empty GLB as "failed" (provider-success-with-no-artifact)', async () => {
+    const bucket = makeBucket({
+      'a/model.glb': { bytes: new Uint8Array(0), contentType: 'model/gltf-binary' },
+    });
+    const out = await processMessage({ object: { key: 'a/model.glb' } }, bucket);
+    expect(out.status).toBe('failed');
+    const sidecar = JSON.parse(bucket.puts['a/model.glb.status.json']);
+    expect(sidecar.status).toBe('failed');
+    expect(sidecar.reason).toMatch(/too small|empty/);
+  });
+
+  it('skips when the object is gone', async () => {
+    const bucket = makeBucket({});
+    const out = await processMessage({ object: { key: 'a/missing.glb' } }, bucket);
+    expect(out.status).toBe('skipped');
+    expect(out.reason).toMatch(/not found/);
+  });
+
+  it('skips status sidecars without fetching', async () => {
+    const bucket = makeBucket();
+    const getSpy = vi.spyOn(bucket, 'get');
+    const out = await processMessage({ object: { key: 'a/x.png.status.json' } }, bucket);
+    expect(out.status).toBe('skipped');
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips unrecognized message shapes', async () => {
+    const out = await processMessage(null, makeBucket());
+    expect(out.status).toBe('skipped');
+  });
+});
+
+describe('queue() consumer handler', () => {
+  it('ACKs every message when ASSET_BUCKET is unbound (env guard no-op)', async () => {
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await workerDefault.queue({ messages: [{ body: {}, ack, retry }] }, {});
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('ACKs a successfully-validated (valid) message', async () => {
+    const bucket = makeBucket({
+      'a/model.glb': { bytes: makeGlbBytes(), contentType: 'model/gltf-binary' },
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    await workerDefault.queue(
+      { messages: [{ body: { object: { key: 'a/model.glb' } }, ack, retry }] },
+      { ASSET_BUCKET: bucket }
+    );
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it('ACKs a "failed"-validation message (failure is recorded, not retried)', async () => {
+    const bucket = makeBucket({
+      'a/model.glb': { bytes: new Uint8Array(0), contentType: 'model/gltf-binary' },
+    });
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await workerDefault.queue(
+      { messages: [{ body: { object: { key: 'a/model.glb' } }, ack, retry }] },
+      { ASSET_BUCKET: bucket }
+    );
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('RETRIES on an unexpected R2 error', async () => {
+    const bucket = {
+      get: vi.fn().mockRejectedValue(new Error('R2 hiccup')),
+      put: vi.fn(),
+    };
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await workerDefault.queue(
+      { messages: [{ body: { object: { key: 'a/model.glb' } }, ack, retry }] },
+      { ASSET_BUCKET: bucket }
+    );
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(ack).not.toHaveBeenCalled();
+    err.mockRestore();
+  });
+});

--- a/infra/asset-postprocess/wrangler.toml
+++ b/infra/asset-postprocess/wrangler.toml
@@ -1,0 +1,39 @@
+# SpawnForge generated-asset post-processing Worker (Cloudflare Queue consumer).
+#
+# Consumes R2 event notifications for the `spawnforge-assets` bucket (delivered
+# via the `spawnforge-asset-postprocess` Queue) and validates each uploaded
+# artifact (GLB / image maps / audio). See ./README.md for the deploy + local
+# `wrangler dev` test steps.
+#
+# Cloudflare account: 0b949ff499d179e24dde841f71d6134f (see MEMORY.md service
+# accounts — Vercel/Sentry are separate; this is the same CF account as the
+# engine-cdn worker and the spawnforge-engine / spawnforge-assets R2 buckets).
+
+name = "spawnforge-asset-postprocess"
+main = "worker.mjs"
+compatibility_date = "2026-06-01"
+account_id = "0b949ff499d179e24dde841f71d6134f"
+
+# Observability so failed-validation warnings land in the dashboard logs.
+[observability]
+enabled = true
+
+# --- R2 binding: read the uploaded artifact + write the status sidecar ---
+# The Worker no-ops safely if this binding is absent (see ENV GUARD in worker.mjs),
+# so a misconfigured deploy degrades to inert rather than wedging the queue.
+[[r2_buckets]]
+binding = "ASSET_BUCKET"
+bucket_name = "spawnforge-assets"
+
+# --- Queue consumer: R2 event notifications are delivered to this queue ---
+# The queue + its R2 event-notification source are provisioned at deploy time by
+# the user (see README "Provisioning"). `wrangler deploy` registers this Worker
+# as the consumer.
+[[queues.consumers]]
+queue = "spawnforge-asset-postprocess"
+# Batch a few messages per invocation; validation is cheap (header reads).
+max_batch_size = 10
+max_batch_timeout = 5
+# Redeliver transient failures a few times, then dead-letter for inspection.
+max_retries = 3
+dead_letter_queue = "spawnforge-asset-postprocess-dlq"


### PR DESCRIPTION
## Summary

Adds a Cloudflare Queue consumer Worker (`infra/asset-postprocess/`) that validates generated SpawnForge assets the moment they land in the `spawnforge-assets` R2 bucket:

```
R2 object-create on spawnforge-assets -> R2 event notification -> Cloudflare Queue -> this Worker
```

For each uploaded artifact (GLB / image maps / audio) the consumer reads the object from R2, validates it, and writes a `<key>.status.json` sidecar back to R2 so the app/status routes can observe the result.

### Why
A generation provider (Meshy / Replicate / Suno) can report success yet upload an empty or malformed artifact (0-byte GLB, `{}` maps, no audio). The web status routes already guard this on the *read* path (`provider-success-with-no-artifact must map to failed`). This Worker adds a second, *upload-time* check independent of whether a client is polling.

### What's in it
- **worker.mjs** - `queue()` consumer. ACKs on success **and** on recorded-failure (the failure is persisted in the sidecar, not a reason to redeliver); `retry()`s only on unexpected/transient errors so Cloudflare redelivers then dead-letters.
- **validate.mjs** - pure, dependency-free validation: GLB magic + version + declared-length (catches truncated/empty uploads), PNG/JPEG/WebP signatures, audio/binary non-empty floors.
- **wrangler.toml** - R2 binding + queue consumer + DLQ (account pinned).
- **43 vitest cases** (standalone config, node env, no web/jsdom deps).
- **README** - local `wrangler dev --local` Miniflare smoke test + user-side provisioning.

### Safety / env guard
Every binding is optional. If `ASSET_BUCKET` is unbound, the consumer ACKs the batch as an inert no-op and logs once - it never wedges the queue. The Worker is fully inert until the bucket + queue + R2 event-notification rule are provisioned, so it cannot break prod or CI beforehand.

### Scope / notes
- Infra-only Cloudflare Worker - outside `web/` lint+tsc+vitest scope, no npm dependencies, not part of any published package -> **skip changeset** (no version to bump).
- Tests: `cd infra/asset-postprocess && npx vitest run --config vitest.config.mjs` -> 43/43.

### Provisioning (user-side, one time - ~$0 within Workers Paid)
```bash
cd infra/asset-postprocess
npx wrangler queues create spawnforge-asset-postprocess
npx wrangler queues create spawnforge-asset-postprocess-dlq
npx wrangler deploy
npx wrangler r2 bucket notification create spawnforge-assets \
  --event-type object-create --queue spawnforge-asset-postprocess
```

Closes #8819

## Test plan
- [x] `npx vitest run --config vitest.config.mjs` from `infra/asset-postprocess/` - 43/43 pass
- [ ] (deploy) `wrangler deploy` registers the consumer; an upload to `spawnforge-assets` produces a `<key>.status.json` sidecar with `status: "valid"` for a real GLB and `status: "failed"` for an empty one
- [ ] (deploy) verify the env guard: a deploy without the R2 binding drains the queue as a no-op rather than wedging

Milestone: S1: Quality & Reliability