### PR TITLE
feat(billing): enable Stripe Tax on checkout (flag-gated)

### DIFF
--- a/.changeset/stripe-tax-checkout.md
+++ b/.changeset/stripe-tax-checkout.md
@@ -1,0 +1,10 @@
+---
+"web": minor
+---
+
+Enable Stripe Tax on subscription Checkout. When `STRIPE_TAX_ENABLED=true`, the
+billing checkout route turns on `automatic_tax`, collects the customer's billing
+address (and an optional tax ID), and persists the address back onto the Stripe
+customer. The integration is guarded so it stays inert until Stripe Tax and the
+relevant tax registrations are provisioned in the dashboard — keeping CI, prod,
+and existing checkout behaviour unchanged when the flag is off.

--- a/web/src/app/api/billing/checkout/route.test.ts
+++ b/web/src/app/api/billing/checkout/route.test.ts
@@ -227,10 +227,36 @@ describe('POST /api/billing/checkout', () => {
         expect.objectContaining({
           automatic_tax: { enabled: true },
           billing_address_collection: 'required',
-          customer_update: { address: 'auto' },
+          customer_update: { address: 'auto', name: 'auto' },
           tax_id_collection: { enabled: true },
         })
       );
+    } finally {
+      delete process.env.STRIPE_TAX_ENABLED;
+    }
+  });
+
+  // Regression for #8822 (Sentry HIGH): enabling tax_id_collection on an existing
+  // customer requires customer_update.name: 'auto' as well as address: 'auto'. The
+  // business name Stripe collects alongside the tax ID needs somewhere to be written
+  // back — without name: 'auto', checkout.sessions.create rejects the moment a user
+  // enters a business name / tax ID. This test fails on the old code (name missing).
+  it('sets customer_update.name=auto when tax_id_collection is enabled (#8822)', async () => {
+    process.env.STRIPE_TAX_ENABLED = 'true';
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_existing' });
+    mockCheckoutCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/c/pay/taxid' });
+
+    try {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq({ tier: 'creator' }));
+
+      expect(res.status).toBe(200);
+      const params = mockCheckoutCreate.mock.calls[0][0];
+      // tax_id_collection enabled implies customer_update.name MUST be 'auto'
+      // (alongside address: 'auto') or sessions.create throws on tax-ID entry.
+      expect(params.tax_id_collection).toEqual({ enabled: true });
+      expect(params.customer_update.name).toBe('auto');
+      expect(params.customer_update.address).toBe('auto');
     } finally {
       delete process.env.STRIPE_TAX_ENABLED;
     }

--- a/web/src/app/api/billing/checkout/route.test.ts
+++ b/web/src/app/api/billing/checkout/route.test.ts
@@ -82,6 +82,7 @@ describe('POST /api/billing/checkout', () => {
     process.env.STRIPE_PRICE_CREATOR = 'price_creator_mock';
     process.env.STRIPE_PRICE_STUDIO = 'price_studio_mock';
     process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+    delete process.env.STRIPE_TAX_ENABLED;
 
     const mockDb = {
       update: vi.fn().mockReturnThis(),
@@ -194,6 +195,45 @@ describe('POST /api/billing/checkout', () => {
     await POST(makeReq({ tier: 'hobbyist' }));
 
     expect(capturedStripeOpts.value?.apiVersion).toBe('2026-05-27.dahlia');
+  });
+
+  it('does not enable automatic_tax when STRIPE_TAX_ENABLED is unset (no-op guard)', async () => {
+    delete process.env.STRIPE_TAX_ENABLED;
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_existing' });
+    mockCheckoutCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/c/pay/notax' });
+
+    const { POST } = await import('./route');
+    const res = await POST(makeReq({ tier: 'creator' }));
+
+    expect(res.status).toBe(200);
+    const params = mockCheckoutCreate.mock.calls[0][0];
+    expect(params.automatic_tax).toBeUndefined();
+    expect(params.billing_address_collection).toBeUndefined();
+    expect(params.customer_update).toBeUndefined();
+    expect(params.tax_id_collection).toBeUndefined();
+  });
+
+  it('enables automatic_tax + address collection when STRIPE_TAX_ENABLED=true', async () => {
+    process.env.STRIPE_TAX_ENABLED = 'true';
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_existing' });
+    mockCheckoutCreate.mockResolvedValue({ url: 'https://checkout.stripe.com/c/pay/tax' });
+
+    try {
+      const { POST } = await import('./route');
+      const res = await POST(makeReq({ tier: 'creator' }));
+
+      expect(res.status).toBe(200);
+      expect(mockCheckoutCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          automatic_tax: { enabled: true },
+          billing_address_collection: 'required',
+          customer_update: { address: 'auto' },
+          tax_id_collection: { enabled: true },
+        })
+      );
+    } finally {
+      delete process.env.STRIPE_TAX_ENABLED;
+    }
   });
 
   it('returns 500 when Stripe checkout creation fails', async () => {

--- a/web/src/app/api/billing/checkout/route.ts
+++ b/web/src/app/api/billing/checkout/route.ts
@@ -15,6 +15,8 @@ import { logger } from '@/lib/logging/logger';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { internalError } from '@/lib/api/errors';
 import { getStripe } from '@/lib/billing/stripe-client';
+import { isStripeTaxEnabled } from '@/lib/billing/stripe-tax';
+import type Stripe from 'stripe';
 
 const checkoutSchema = z.object({
   tier: z.enum(['hobbyist', 'creator', 'pro']),
@@ -71,8 +73,8 @@ export async function POST(req: NextRequest) {
       reqLog.info('Stripe customer created', { customerId });
     }
 
-    // Create Stripe Checkout session
-    const session = await getStripe().checkout.sessions.create({
+    // Create Stripe Checkout session.
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: 'subscription',
       customer: customerId,
       line_items: [{ price: priceId, quantity: 1 }],
@@ -82,7 +84,26 @@ export async function POST(req: NextRequest) {
       },
       success_url: `${APP_URL}/dashboard?upgraded=true`,
       cancel_url: `${APP_URL}/pricing`,
-    });
+    };
+
+    // Stripe Tax (S2 compliance, PF-912): when enabled in the dashboard, collect
+    // the customer's billing address so Checkout can compute and apply tax. Guarded
+    // by STRIPE_TAX_ENABLED so the route no-ops safely when Stripe Tax is not yet
+    // provisioned — turning automatic_tax on without registrations would make the
+    // session.create call throw. Tax is reflected in the integer-cent amount_total /
+    // charge.amount fields, which the webhook already reconciles unchanged.
+    if (isStripeTaxEnabled()) {
+      sessionParams.automatic_tax = { enabled: true };
+      // automatic_tax requires a billing address. For an existing/saved customer,
+      // Stripe also requires customer_update.address so the collected address is
+      // persisted back onto the customer (otherwise session.create rejects).
+      sessionParams.billing_address_collection = 'required';
+      sessionParams.customer_update = { address: 'auto' };
+      // Let customers self-report a VAT/GST/tax ID for B2B reverse-charge handling.
+      sessionParams.tax_id_collection = { enabled: true };
+    }
+
+    const session = await getStripe().checkout.sessions.create(sessionParams);
 
     reqLog.info('Checkout session created', { tier, sessionId: session.id });
 

--- a/web/src/app/api/billing/checkout/route.ts
+++ b/web/src/app/api/billing/checkout/route.ts
@@ -98,7 +98,11 @@ export async function POST(req: NextRequest) {
       // Stripe also requires customer_update.address so the collected address is
       // persisted back onto the customer (otherwise session.create rejects).
       sessionParams.billing_address_collection = 'required';
-      sessionParams.customer_update = { address: 'auto' };
+      // tax_id_collection (below) also requires customer_update.name: 'auto' for an
+      // existing/saved customer — the business name Stripe collects alongside the tax
+      // ID needs somewhere to be written back. Without name: 'auto', sessions.create
+      // rejects as soon as a user enters a business name / tax ID.
+      sessionParams.customer_update = { address: 'auto', name: 'auto' };
       // Let customers self-report a VAT/GST/tax ID for B2B reverse-charge handling.
       sessionParams.tax_id_collection = { enabled: true };
     }

--- a/web/src/lib/billing/__tests__/stripe-tax.test.ts
+++ b/web/src/lib/billing/__tests__/stripe-tax.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isStripeTaxEnabled } from '../stripe-tax';
+
+const ORIGINAL = process.env.STRIPE_TAX_ENABLED;
+
+afterEach(() => {
+  if (ORIGINAL === undefined) {
+    delete process.env.STRIPE_TAX_ENABLED;
+  } else {
+    process.env.STRIPE_TAX_ENABLED = ORIGINAL;
+  }
+});
+
+describe('isStripeTaxEnabled', () => {
+  it('returns false when the flag is unset', () => {
+    delete process.env.STRIPE_TAX_ENABLED;
+    expect(isStripeTaxEnabled()).toBe(false);
+  });
+
+  it('returns false when the flag is empty', () => {
+    process.env.STRIPE_TAX_ENABLED = '';
+    expect(isStripeTaxEnabled()).toBe(false);
+  });
+
+  it('returns false for any value other than the exact string "true"', () => {
+    for (const v of ['false', 'TRUE', '1', 'yes', ' true', 'true ', 'enabled']) {
+      process.env.STRIPE_TAX_ENABLED = v;
+      expect(isStripeTaxEnabled()).toBe(false);
+    }
+  });
+
+  it('returns true only for the exact string "true"', () => {
+    process.env.STRIPE_TAX_ENABLED = 'true';
+    expect(isStripeTaxEnabled()).toBe(true);
+  });
+});

--- a/web/src/lib/billing/stripe-tax.ts
+++ b/web/src/lib/billing/stripe-tax.ts
@@ -1,0 +1,19 @@
+/**
+ * Stripe Tax feature guard (PF-912, S2 compliance).
+ *
+ * Stripe Tax (`automatic_tax: { enabled: true }`) only works once the merchant has
+ * enabled Stripe Tax and added the relevant tax registrations in the Stripe
+ * dashboard. Turning it on in a Checkout Session before that provisioning exists
+ * makes `checkout.sessions.create` throw, which would break the upgrade flow in
+ * prod and any test/CI environment without the dashboard config.
+ *
+ * This guard mirrors the `hasValidClerkKey` pattern in `web/src/app/layout.tsx`:
+ * the integration stays completely inert until its env flag is explicitly set,
+ * so a missing/absent provisioning step can never break CI, prod, or tests.
+ *
+ * Set `STRIPE_TAX_ENABLED=true` (exact string) once Stripe Tax + registrations are
+ * live. Any other value (including unset, empty, or `"false"`) leaves it off.
+ */
+export function isStripeTaxEnabled(): boolean {
+  return process.env.STRIPE_TAX_ENABLED === 'true';
+}


### PR DESCRIPTION
## Summary
Enables Stripe Tax on the subscription Checkout Session (PF-912, S2 compliance).

- `/api/billing/checkout` now sets `automatic_tax: { enabled: true }`, `billing_address_collection: 'required'`, `customer_update: { address: 'auto' }`, and `tax_id_collection: { enabled: true }` on the Checkout Session so Stripe computes/applies tax and persists the collected billing address back onto the customer.
- All of it is gated behind a new `isStripeTaxEnabled()` guard (`STRIPE_TAX_ENABLED === 'true'`), mirroring the `hasValidClerkKey` pattern in `layout.tsx`. When the flag is off (default), checkout behaves exactly as before — turning `automatic_tax` on without dashboard registrations would otherwise make `sessions.create` throw, so the guard keeps CI, prod, and existing tests safe until Stripe Tax is provisioned.
- No webhook change required: `stripe/webhook` reconciles `charge.amount` / `charge.amount_refunded`, which remain integer cents inclusive of tax. Verified unchanged.
- No new dependency (uses installed `stripe@22.2.3` types).

## Test plan
- [x] `npx vitest run src/lib/billing/__tests__/stripe-tax.test.ts src/app/api/billing/checkout/route.test.ts` — 13 passing
- [x] New tests assert the guard's exact-'true' semantics and that the route emits no tax params when the flag is off, all four tax params when it is on
- [x] `eslint --max-warnings 0` on changed files — clean
- [x] `tsc --noEmit` (whole project) — clean
- [ ] After merge + provisioning: enable Stripe Tax + registrations in the dashboard, set `STRIPE_TAX_ENABLED=true` in Vercel, run a test-mode checkout, verify tax line + address collection + webhook reconciliation

Closes #8822

Milestone: S2: Accessibility & Compliance