### PR TITLE
feat(billing): deepen Stripe customer portal + adaptive pricing

### DIFF
--- a/.changeset/stripe-portal-adaptive-pricing.md
+++ b/.changeset/stripe-portal-adaptive-pricing.md
@@ -1,0 +1,10 @@
+---
+"web": minor
+---
+
+Deepen the Stripe Customer Portal billing route: support pinning a portal
+configuration via `STRIPE_PORTAL_CONFIGURATION_ID` (plan switching across the
+4 tiers, payment-method update, cancellation retention coupon) and a
+`?flow=cancel` deep-link into the cancellation/retention flow. All additions
+are env- and subscription-guarded, so the portal keeps working against the
+Stripe Dashboard default configuration with no provisioning.

--- a/web/src/app/api/billing/portal/route.test.ts
+++ b/web/src/app/api/billing/portal/route.test.ts
@@ -31,8 +31,8 @@ vi.mock('stripe', () => {
   };
 });
 
-function makeReq() {
-  return new NextRequest('http://localhost:3000/api/billing/portal', { method: 'POST' });
+function makeReq(url = 'http://localhost:3000/api/billing/portal') {
+  return new NextRequest(url, { method: 'POST' });
 }
 
 function mockMiddlewareSuccess(overrides?: Partial<ReturnType<typeof makeUser>>) {
@@ -119,6 +119,49 @@ describe('POST /api/billing/portal', () => {
     await POST(makeReq());
 
     expect(capturedStripeOpts.value?.apiVersion).toBe('2026-05-27.dahlia');
+  });
+
+  it('pins the portal configuration id from STRIPE_PORTAL_CONFIGURATION_ID', async () => {
+    process.env.STRIPE_PORTAL_CONFIGURATION_ID = 'bpc_test_123';
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_123' });
+    mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/p/session/mock' });
+
+    const { POST } = await import('./route');
+    await POST(makeReq());
+
+    expect(mockPortalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: 'cus_123', configuration: 'bpc_test_123' })
+    );
+    delete process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+  });
+
+  it('deep-links into the cancel/retention flow when ?flow=cancel and a subscription exists', async () => {
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_123', stripeSubscriptionId: 'sub_789' });
+    mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/p/session/mock' });
+
+    const { POST } = await import('./route');
+    await POST(makeReq('http://localhost:3000/api/billing/portal?flow=cancel'));
+
+    expect(mockPortalCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_123',
+        flow_data: expect.objectContaining({
+          type: 'subscription_cancel',
+          subscription_cancel: { subscription: 'sub_789' },
+        }),
+      })
+    );
+  });
+
+  it('does not add the cancel flow when the user has no subscription on file', async () => {
+    mockMiddlewareSuccess({ stripeCustomerId: 'cus_123', stripeSubscriptionId: null });
+    mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/p/session/mock' });
+
+    const { POST } = await import('./route');
+    await POST(makeReq('http://localhost:3000/api/billing/portal?flow=cancel'));
+
+    const callArg = mockPortalCreate.mock.calls[0][0];
+    expect(callArg.flow_data).toBeUndefined();
   });
 
   it('returns 500 when Stripe portal creation fails', async () => {

--- a/web/src/app/api/billing/portal/route.ts
+++ b/web/src/app/api/billing/portal/route.ts
@@ -2,12 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withApiMiddleware } from '@/lib/api/middleware';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { getStripe } from '@/lib/billing/stripe-client';
+import { buildPortalSessionParams } from '@/lib/billing/portal-config';
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
 
 /**
  * POST /api/billing/portal
  * Create a Stripe billing portal session for managing subscriptions.
+ *
+ * Plan switching across the 4 tiers, payment-method update, and the cancellation
+ * retention coupon are all governed by the Stripe portal configuration (managed
+ * in the Dashboard, or pinned via STRIPE_PORTAL_CONFIGURATION_ID). The optional
+ * `?flow=cancel` query param deep-links the customer straight into the
+ * cancellation/retention flow. See `buildPortalSessionParams`.
  */
 export async function POST(req: NextRequest) {
   const mid = await withApiMiddleware(req, {
@@ -26,11 +33,17 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const flow = req.nextUrl.searchParams.get('flow');
+
   try {
-    const session = await getStripe().billingPortal.sessions.create({
-      customer: user.stripeCustomerId,
-      return_url: `${APP_URL}/dashboard`,
-    });
+    const session = await getStripe().billingPortal.sessions.create(
+      buildPortalSessionParams({
+        customer: user.stripeCustomerId,
+        returnUrl: `${APP_URL}/dashboard`,
+        flow,
+        subscriptionId: user.stripeSubscriptionId,
+      })
+    );
 
     return NextResponse.json({ url: session.url });
   } catch (error) {

--- a/web/src/lib/billing/__tests__/portal-config.test.ts
+++ b/web/src/lib/billing/__tests__/portal-config.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildPortalSessionParams, isCancelFlow } from '../portal-config';
+
+const ORIGINAL_ENV = process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+
+describe('isCancelFlow', () => {
+  it('matches only the literal "cancel"', () => {
+    expect(isCancelFlow('cancel')).toBe(true);
+    expect(isCancelFlow('Cancel')).toBe(false);
+    expect(isCancelFlow('cancel_subscription')).toBe(false);
+    expect(isCancelFlow('switch')).toBe(false);
+    expect(isCancelFlow(undefined)).toBe(false);
+    expect(isCancelFlow(null)).toBe(false);
+    expect(isCancelFlow('')).toBe(false);
+  });
+});
+
+describe('buildPortalSessionParams', () => {
+  beforeEach(() => {
+    delete process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+    } else {
+      process.env.STRIPE_PORTAL_CONFIGURATION_ID = ORIGINAL_ENV;
+    }
+  });
+
+  it('returns minimal params when no optional config is present', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+    });
+    expect(params).toEqual({
+      customer: 'cus_123',
+      return_url: 'https://app.example.com/dashboard',
+    });
+    expect(params.configuration).toBeUndefined();
+    expect(params.flow_data).toBeUndefined();
+  });
+
+  it('pins the configuration id from STRIPE_PORTAL_CONFIGURATION_ID', () => {
+    process.env.STRIPE_PORTAL_CONFIGURATION_ID = 'bpc_live_abc';
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+    });
+    expect(params.configuration).toBe('bpc_live_abc');
+  });
+
+  it('prefers an explicit configurationId over the env var', () => {
+    process.env.STRIPE_PORTAL_CONFIGURATION_ID = 'bpc_from_env';
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      configurationId: 'bpc_explicit',
+    });
+    expect(params.configuration).toBe('bpc_explicit');
+  });
+
+  it('treats a whitespace-only env var as absent', () => {
+    process.env.STRIPE_PORTAL_CONFIGURATION_ID = '   ';
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+    });
+    expect(params.configuration).toBeUndefined();
+  });
+
+  it('trims a padded configuration id', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      configurationId: '  bpc_padded  ',
+    });
+    expect(params.configuration).toBe('bpc_padded');
+  });
+
+  it('adds the subscription_cancel flow when flow=cancel and a subscription id is present', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      flow: 'cancel',
+      subscriptionId: 'sub_456',
+    });
+    expect(params.flow_data).toEqual({
+      type: 'subscription_cancel',
+      subscription_cancel: { subscription: 'sub_456' },
+      after_completion: {
+        type: 'redirect',
+        redirect: { return_url: 'https://app.example.com/dashboard' },
+      },
+    });
+  });
+
+  it('omits the cancel flow when no subscription id is available', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      flow: 'cancel',
+      subscriptionId: null,
+    });
+    expect(params.flow_data).toBeUndefined();
+  });
+
+  it('omits the cancel flow when subscription id is whitespace-only', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      flow: 'cancel',
+      subscriptionId: '   ',
+    });
+    expect(params.flow_data).toBeUndefined();
+  });
+
+  it('ignores an unknown flow value even with a subscription id', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      flow: 'upgrade',
+      subscriptionId: 'sub_456',
+    });
+    expect(params.flow_data).toBeUndefined();
+  });
+
+  it('combines configuration id and cancel flow together', () => {
+    const params = buildPortalSessionParams({
+      customer: 'cus_123',
+      returnUrl: 'https://app.example.com/dashboard',
+      flow: 'cancel',
+      subscriptionId: 'sub_456',
+      configurationId: 'bpc_combo',
+    });
+    expect(params.configuration).toBe('bpc_combo');
+    expect(params.flow_data?.type).toBe('subscription_cancel');
+  });
+});

--- a/web/src/lib/billing/portal-config.ts
+++ b/web/src/lib/billing/portal-config.ts
@@ -1,0 +1,91 @@
+import type Stripe from 'stripe';
+
+/**
+ * Portal session builder for the Stripe Customer Portal.
+ *
+ * Plan switching across the 4 tiers, payment-method update, and the cancellation
+ * retention coupon are all defined on a Stripe **portal configuration** object
+ * (Dashboard → Settings → Billing → Customer portal, or via the API). Adaptive
+ * Pricing is a separate Dashboard toggle. None of that requires code here — the
+ * portal renders whatever the active configuration allows.
+ *
+ * This helper layers two optional, fully env-guarded behaviours on top of the
+ * Dashboard default:
+ *
+ *  1. `STRIPE_PORTAL_CONFIGURATION_ID` — pin the session to a specific portal
+ *     configuration (e.g. a versioned config that enables plan switching across
+ *     hobbyist/creator/pro + payment-method update + retention coupon). When
+ *     unset, Stripe falls back to the account's default (Dashboard-managed)
+ *     configuration, so the portal keeps working with zero code config.
+ *
+ *  2. `flow=cancel` — deep-link the customer straight into the subscription
+ *     cancellation flow, where the Dashboard-configured retention coupon is
+ *     offered. Requires a subscription id; if the user has no subscription on
+ *     file the flow is silently omitted and the portal opens home instead.
+ *
+ * Every addition is omit-when-absent: a missing env var, unknown flow, or
+ * missing subscription id yields the original `{ customer, return_url }` params,
+ * so missing provisioning never breaks the route, CI, or existing behaviour.
+ */
+
+export type PortalFlow = 'cancel' | undefined;
+
+export interface BuildPortalParamsInput {
+  customer: string;
+  returnUrl: string;
+  /** Optional deep-link flow. Only `'cancel'` is recognised; anything else is ignored. */
+  flow?: string | null;
+  /**
+   * The user's active Stripe subscription id. Required for the `cancel` flow —
+   * Stripe rejects a `subscription_cancel` flow without it. When absent, the
+   * cancel flow is skipped (portal opens home).
+   */
+  subscriptionId?: string | null;
+  /** Override for the portal configuration id. Defaults to STRIPE_PORTAL_CONFIGURATION_ID. */
+  configurationId?: string;
+}
+
+/** True when `flow` requests the cancellation/retention deep-link. */
+export function isCancelFlow(flow?: string | null): boolean {
+  return flow === 'cancel';
+}
+
+/**
+ * Build the params for `stripe.billingPortal.sessions.create`.
+ *
+ * Pure + env-guarded: returns the minimal valid params when no optional config
+ * is present, and layers `configuration` / `flow_data` on only when explicitly
+ * provided (and, for the cancel flow, only when a subscription id is available).
+ */
+export function buildPortalSessionParams(
+  input: BuildPortalParamsInput
+): Stripe.BillingPortal.SessionCreateParams {
+  const { customer, returnUrl, flow, subscriptionId } = input;
+
+  const params: Stripe.BillingPortal.SessionCreateParams = {
+    customer,
+    return_url: returnUrl,
+  };
+
+  const configurationId =
+    input.configurationId ?? process.env.STRIPE_PORTAL_CONFIGURATION_ID;
+  // Trim to treat a whitespace-only env var as absent.
+  if (configurationId && configurationId.trim().length > 0) {
+    params.configuration = configurationId.trim();
+  }
+
+  // The retention/cancel deep-link requires a concrete subscription to cancel.
+  if (isCancelFlow(flow) && subscriptionId && subscriptionId.trim().length > 0) {
+    params.flow_data = {
+      type: 'subscription_cancel',
+      subscription_cancel: { subscription: subscriptionId.trim() },
+      // After the cancel flow completes, send the customer back to the dashboard.
+      after_completion: {
+        type: 'redirect',
+        redirect: { return_url: returnUrl },
+      },
+    };
+  }
+
+  return params;
+}


### PR DESCRIPTION
## Summary

Deepens the Stripe Customer Portal billing route (`web/src/app/api/billing/portal/route.ts`) so it can drive plan switching across the 4 tiers, payment-method updates, and a cancellation retention coupon — all governed by the Stripe portal **configuration** object — plus an optional deep-link straight into the cancellation/retention flow.

- New pure helper `buildPortalSessionParams` (`web/src/lib/billing/portal-config.ts`):
  - Pins a portal configuration via `STRIPE_PORTAL_CONFIGURATION_ID` when set (plan switching / payment-method update / retention coupon live on that config). When unset, Stripe uses the account's default Dashboard config — portal keeps working with zero provisioning.
  - `?flow=cancel` deep-links into the `subscription_cancel` flow (where the Dashboard retention coupon is offered). Requires the user's `stripeSubscriptionId`; silently omitted when absent.
- Fully env- and subscription-guarded: a missing env var, unknown flow, or missing subscription id yields the original `{ customer, return_url }` params, so missing provisioning never breaks CI/prod/existing tests.
- Adaptive Pricing is a Dashboard-only toggle — no code path.
- No new dependencies, no DB/schema change.

## Test plan
- [x] `vitest run` portal-config + portal route — 20/20 pass
- [x] `eslint --max-warnings 0` on changed files — clean
- [x] `tsc --noEmit` whole project — clean
- [ ] After merge, set the Stripe Dashboard portal config + Adaptive Pricing toggle (see PR provisioning notes / ticket), optionally set `STRIPE_PORTAL_CONFIGURATION_ID` on Vercel.

Closes #8824 (PF-914)

Milestone: E4: Onboarding & Activation