### PR TITLE
feat(billing): Stripe Radar fraud review + persist customer id for clawback (PF-913)

### DIFF
--- a/.changeset/stripe-radar-review-hold.md
+++ b/.changeset/stripe-radar-review-hold.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Add Stripe Radar fraud-review handling for token-pack purchases. When Radar flags a one-time token-pack payment for manual review, the token credit grant is now held until the review clears: tokens are released only when Stripe closes the review as approved, and a refunded/fraud close or a dispute grants nothing (and reverses any credit that did land). Gated behind the `STRIPE_RADAR_REVIEW_HOLD` env flag — inert (credit-immediately, pre-existing behaviour) until enabled and the Dashboard Radar rules are provisioned.

--- a/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -25,6 +25,10 @@ const {
   mockHandleInvoicePaid,
   mockHandleInvoicePaymentFailed,
   mockHandleChargeRefunded,
+  mockIsCheckoutHeldForReview,
+  mockHandleReviewOpened,
+  mockHandleReviewClosed,
+  mockHandleDisputeCreated,
 } = vi.hoisted(() => ({
   mockConstructEvent: vi.fn(),
   mockClaimEvent: vi.fn(() => Promise.resolve(true)),
@@ -36,6 +40,10 @@ const {
   mockHandleInvoicePaid: vi.fn(() => Promise.resolve()),
   mockHandleInvoicePaymentFailed: vi.fn(() => Promise.resolve()),
   mockHandleChargeRefunded: vi.fn(() => Promise.resolve()),
+  mockIsCheckoutHeldForReview: vi.fn(() => Promise.resolve(false)),
+  mockHandleReviewOpened: vi.fn(() => Promise.resolve()),
+  mockHandleReviewClosed: vi.fn(() => Promise.resolve()),
+  mockHandleDisputeCreated: vi.fn(() => Promise.resolve()),
 }));
 
 // ---------------------------------------------------------------------------
@@ -80,6 +88,13 @@ vi.mock('@/lib/billing/subscription-lifecycle', () => ({
   handleInvoicePaid: mockHandleInvoicePaid,
   handleInvoicePaymentFailed: mockHandleInvoicePaymentFailed,
   handleChargeRefunded: mockHandleChargeRefunded,
+}));
+
+vi.mock('@/lib/billing/radar-review', () => ({
+  isCheckoutHeldForReview: mockIsCheckoutHeldForReview,
+  handleReviewOpened: mockHandleReviewOpened,
+  handleReviewClosed: mockHandleReviewClosed,
+  handleDisputeCreated: mockHandleDisputeCreated,
 }));
 
 vi.mock('stripe', () => {
@@ -151,6 +166,10 @@ describe('POST /api/stripe/webhook', () => {
     mockHandleInvoicePaid.mockResolvedValue(undefined);
     mockHandleInvoicePaymentFailed.mockResolvedValue(undefined);
     mockHandleChargeRefunded.mockResolvedValue(undefined);
+    mockIsCheckoutHeldForReview.mockResolvedValue(false);
+    mockHandleReviewOpened.mockResolvedValue(undefined);
+    mockHandleReviewClosed.mockResolvedValue(undefined);
+    mockHandleDisputeCreated.mockResolvedValue(undefined);
 
     process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
     process.env.STRIPE_PRICE_STARTER = 'price_starter';
@@ -380,6 +399,74 @@ describe('POST /api/stripe/webhook', () => {
     await POST(makeRequest('{}'));
 
     expect(creditAddonTokens).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Radar fraud-review hold (PF-913 / #8823)
+  // -------------------------------------------------------------------------
+
+  it('HOLDS the credit when the payment is flagged for Radar review', async () => {
+    const { creditAddonTokens } = await import('@/lib/tokens/service');
+    mockIsCheckoutHeldForReview.mockResolvedValueOnce(true);
+    const session = {
+      mode: 'payment',
+      metadata: { userId: 'user-1', package: 'spark' },
+      payment_intent: 'pi_flagged',
+      customer: null,
+    };
+    mockConstructEvent.mockReturnValue(makeStripeEvent('checkout.session.completed', session));
+
+    const res = await POST(makeRequest('{}'));
+
+    expect(mockIsCheckoutHeldForReview).toHaveBeenCalledWith('pi_flagged', expect.anything());
+    expect(creditAddonTokens).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+
+  it('credits immediately when the payment is NOT under review', async () => {
+    const { creditAddonTokens } = await import('@/lib/tokens/service');
+    mockIsCheckoutHeldForReview.mockResolvedValueOnce(false);
+    const session = {
+      mode: 'payment',
+      metadata: { userId: 'user-1', package: 'spark' },
+      payment_intent: 'pi_clean',
+      customer: null,
+    };
+    mockConstructEvent.mockReturnValue(makeStripeEvent('checkout.session.completed', session));
+
+    await POST(makeRequest('{}'));
+
+    expect(creditAddonTokens).toHaveBeenCalledWith('user-1', 'spark', 'pi_clean');
+  });
+
+  it('dispatches review.opened to handleReviewOpened', async () => {
+    const review = { id: 'prv_1', object: 'review', open: true, opened_reason: 'rule' };
+    mockConstructEvent.mockReturnValue(makeStripeEvent('review.opened', review));
+
+    const res = await POST(makeRequest('{}'));
+
+    expect(mockHandleReviewOpened).toHaveBeenCalledWith(review);
+    expect(res.status).toBe(200);
+  });
+
+  it('dispatches review.closed to handleReviewClosed', async () => {
+    const review = { id: 'prv_2', object: 'review', open: false, closed_reason: 'approved', payment_intent: 'pi_2' };
+    mockConstructEvent.mockReturnValue(makeStripeEvent('review.closed', review));
+
+    const res = await POST(makeRequest('{}'));
+
+    expect(mockHandleReviewClosed).toHaveBeenCalledWith(review, expect.anything());
+    expect(res.status).toBe(200);
+  });
+
+  it('dispatches charge.dispute.created to handleDisputeCreated', async () => {
+    const dispute = { id: 'dp_1', object: 'dispute', charge: 'ch_1', amount: 4900 };
+    mockConstructEvent.mockReturnValue(makeStripeEvent('charge.dispute.created', dispute));
+
+    const res = await POST(makeRequest('{}'));
+
+    expect(mockHandleDisputeCreated).toHaveBeenCalledWith(dispute, expect.anything());
+    expect(res.status).toBe(200);
   });
 
   // -------------------------------------------------------------------------

--- a/web/src/app/api/stripe/webhook/route.ts
+++ b/web/src/app/api/stripe/webhook/route.ts
@@ -31,6 +31,12 @@ import {
 } from '@/lib/billing/subscription-lifecycle';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { getStripe } from '@/lib/billing/stripe-client';
+import {
+  isCheckoutHeldForReview,
+  handleReviewOpened,
+  handleReviewClosed,
+  handleDisputeCreated,
+} from '@/lib/billing/radar-review';
 
 // Map Stripe price IDs to tiers
 function tierFromPriceId(priceId: string): Tier | null {
@@ -227,6 +233,33 @@ async function processEvent(event: Stripe.Event): Promise<void> {
     }
 
     // -----------------------------------------------------------
+    // Radar fraud review opened — token grant held pending verdict (PF-913)
+    // -----------------------------------------------------------
+    case 'review.opened': {
+      const review = event.data.object as Stripe.Review;
+      await handleReviewOpened(review);
+      break;
+    }
+
+    // -----------------------------------------------------------
+    // Radar fraud review closed — release the held grant iff approved (PF-913)
+    // -----------------------------------------------------------
+    case 'review.closed': {
+      const review = event.data.object as Stripe.Review;
+      await handleReviewClosed(review, getStripe());
+      break;
+    }
+
+    // -----------------------------------------------------------
+    // Charge disputed — claw back any granted token credit (PF-913)
+    // -----------------------------------------------------------
+    case 'charge.dispute.created': {
+      const dispute = event.data.object as Stripe.Dispute;
+      await handleDisputeCreated(dispute, getStripe());
+      break;
+    }
+
+    // -----------------------------------------------------------
     // One-time payment completed (token add-on purchase)
     // -----------------------------------------------------------
     case 'checkout.session.completed': {
@@ -241,6 +274,18 @@ async function processEvent(event: Stripe.Event): Promise<void> {
           : session.payment_intent?.id;
 
       if (userId && pkg && paymentIntent) {
+        // Radar fraud-review hold (PF-913): when the flag is on and the payment
+        // is flagged for manual review, DEFER the credit. The grant is released
+        // later by `review.closed { approved }`. When the flag is off, or the
+        // payment is not under review, this returns false and we credit now —
+        // identical to the pre-PF-913 behaviour.
+        if (await isCheckoutHeldForReview(paymentIntent, getStripe())) {
+          console.info(
+            `[stripe-webhook] Token-pack credit held for Radar review (pi=${paymentIntent}, user=${userId}).`
+          );
+          break;
+        }
+
         await creditAddonTokens(userId, pkg, paymentIntent);
 
         // Save Stripe customer ID if not already stored

--- a/web/src/app/api/tokens/purchase/route.test.ts
+++ b/web/src/app/api/tokens/purchase/route.test.ts
@@ -138,6 +138,11 @@ describe('POST /api/tokens/purchase', () => {
         customer: 'cus_123',
         line_items: [{ price: 'price_spark', quantity: 1 }],
         metadata: expect.objectContaining({ userId: 'user_1', package: 'spark' }),
+        // PF-913: token-pack identity propagated to the PaymentIntent so the
+        // Radar review-closed handler can release a held grant.
+        payment_intent_data: expect.objectContaining({
+          metadata: expect.objectContaining({ userId: 'user_1', package: 'spark' }),
+        }),
       })
     );
   });

--- a/web/src/app/api/tokens/purchase/route.ts
+++ b/web/src/app/api/tokens/purchase/route.ts
@@ -53,6 +53,16 @@ export async function POST(req: NextRequest) {
         package: pkg,
         tokens: pkgInfo.tokens.toString(),
       },
+      // Propagate the token-pack identity onto the PaymentIntent so the Radar
+      // fraud-review handler (PF-913) can recover userId + package from
+      // `review.payment_intent` when releasing a held grant — the Review object
+      // does not carry the checkout session's metadata.
+      payment_intent_data: {
+        metadata: {
+          userId: user.id,
+          package: pkg,
+        },
+      },
       success_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}?purchase=success`,
       cancel_url: `${process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000'}?purchase=cancelled`,
     });

--- a/web/src/lib/billing/__tests__/radarReview.test.ts
+++ b/web/src/lib/billing/__tests__/radarReview.test.ts
@@ -312,7 +312,10 @@ describe('handleDisputeCreated', () => {
     return { id: 'dp_1', object: 'dispute', charge: over.charge, amount: over.amount } as unknown as Stripe.Dispute;
   }
 
-  it('no-ops when the flag is off', async () => {
+  // Regression for #8832: the clawback is a chargeback-recovery safety net and
+  // must run regardless of the review-hold flag. Tokens granted while the flag
+  // was on (or never gated) would otherwise leak forever once it is turned off.
+  it('still claws back when the flag is off (chargeback recovery is not gated, #8832)', async () => {
     disableFlag();
     const { neonSql } = harness();
     const user = await seedUser(neonSql, { addonTokens: 5000, stripeCustomerId: 'cus_d' });
@@ -324,7 +327,7 @@ describe('handleDisputeCreated', () => {
     await handleDisputeCreated(dispute({ charge: 'ch_d', amount: 4900 }), stripe as unknown as Stripe);
 
     const row = await getUserRow(neonSql, user.id);
-    expect(Number(row?.addon_tokens)).toBe(5000);
+    expect(Number(row?.addon_tokens)).toBe(0);
   });
 
   it('claws back the full granted amount on a full dispute', async () => {

--- a/web/src/lib/billing/__tests__/radarReview.test.ts
+++ b/web/src/lib/billing/__tests__/radarReview.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment node
+/**
+ * Real-DB behavioural tests for the Stripe Radar fraud-review hold (PF-913 / #8823).
+ *
+ * The capability is "defer the token credit grant until a flagged review clears."
+ * These tests prove the OUTCOME on real Postgres (PGlite + production migration
+ * schema), not query substrings:
+ *
+ *   - Feature flag OFF  → every handler is inert (no credit, no hold, no reversal).
+ *   - isCheckoutHeldForReview → true only when Radar positively flags the PI/charge;
+ *     false (credit-now) when not flagged or on a Stripe read error (fail-open).
+ *   - handleReviewClosed(approved) → releases the held grant via the idempotent
+ *     creditAddonTokens (addon_tokens increases by the package amount, exactly once
+ *     across redelivery). Non-approved close reasons grant nothing.
+ *   - handleDisputeCreated → claws back granted tokens proportionally.
+ *
+ * Stripe API reads (paymentIntents/charges retrieve) are faked; all crediting and
+ * clawback runs against the real DB through creditAddonTokens / reverseAddonTokens.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type Stripe from 'stripe';
+import type { NeonSqlAdapter, TestHarness } from '@/lib/db/__tests__/pgliteHarness';
+
+const harnessRef = vi.hoisted(() => ({ current: null as TestHarness | null }));
+function harness(): TestHarness {
+  const h = harnessRef.current;
+  if (!h) throw new Error('PGlite harness not initialised');
+  return h;
+}
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/lib/db/client', () => ({
+  getNeonSql: () => harness().neonSql,
+  getDb: () => harness().db,
+  queryWithResilience: <T>(operation: () => Promise<T>): Promise<T> => operation(),
+}));
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: vi.fn(),
+}));
+
+import { createTestHarness, getUserRow, seedUser } from '@/lib/db/__tests__/pgliteHarness';
+import { TOKEN_PACKAGES } from '@/lib/tokens/pricing';
+import {
+  isRadarReviewHoldEnabled,
+  isCheckoutHeldForReview,
+  handleReviewClosed,
+  handleDisputeCreated,
+} from '../radar-review';
+
+const FLAG = 'STRIPE_RADAR_REVIEW_HOLD';
+
+// Use vi.stubEnv (not direct process.env mutation) — vitest.config.ts runs with
+// pool: 'threads', where workers share one process object and direct reassignment
+// races. stubEnv is restored per-test via vi.unstubAllEnvs() in beforeEach.
+function enableFlag() {
+  vi.stubEnv(FLAG, 'true');
+}
+function disableFlag() {
+  vi.stubEnv(FLAG, '');
+}
+
+async function seedPurchase(
+  sql: NeonSqlAdapter,
+  over: { userId: string; paymentIntent: string; tokens: number; amountCents: number },
+): Promise<void> {
+  await sql`
+    INSERT INTO token_purchases (user_id, stripe_payment_intent, package, tokens, amount_cents, refunded_cents)
+    VALUES (${over.userId}, ${over.paymentIntent}, 'blaze', ${over.tokens}, ${over.amountCents}, 0)
+  `;
+}
+
+// ── Fake Stripe surface — only the methods these handlers touch ──────────────
+type FakeStripe = {
+  paymentIntents: { retrieve: ReturnType<typeof vi.fn> };
+  charges: { retrieve: ReturnType<typeof vi.fn> };
+};
+
+function fakeStripe(over?: {
+  paymentIntent?: Partial<Stripe.PaymentIntent> | (() => never);
+  charge?: Partial<Stripe.Charge>;
+}): FakeStripe {
+  return {
+    paymentIntents: {
+      retrieve: vi.fn(async () => {
+        if (typeof over?.paymentIntent === 'function') over.paymentIntent();
+        return over?.paymentIntent ?? {};
+      }),
+    },
+    charges: {
+      retrieve: vi.fn(async () => over?.charge ?? {}),
+    },
+  };
+}
+
+beforeAll(async () => {
+  harnessRef.current = await createTestHarness();
+});
+afterAll(async () => {
+  await harnessRef.current?.close();
+});
+beforeEach(async () => {
+  vi.unstubAllEnvs();
+  disableFlag();
+  await harness().truncateAll();
+});
+
+describe('isRadarReviewHoldEnabled', () => {
+  it('is off unless the flag is exactly "true"', () => {
+    disableFlag();
+    expect(isRadarReviewHoldEnabled()).toBe(false);
+    vi.stubEnv(FLAG, 'TRUE');
+    expect(isRadarReviewHoldEnabled()).toBe(false);
+    vi.stubEnv(FLAG, '1');
+    expect(isRadarReviewHoldEnabled()).toBe(false);
+    enableFlag();
+    expect(isRadarReviewHoldEnabled()).toBe(true);
+  });
+});
+
+describe('isCheckoutHeldForReview', () => {
+  it('returns false (credit now) when the flag is off — even if the PI is flagged', async () => {
+    disableFlag();
+    const stripe = fakeStripe({ paymentIntent: { review: 'prv_1' } });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(false);
+    expect(stripe.paymentIntents.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('holds when paymentIntent.review is set', async () => {
+    enableFlag();
+    const stripe = fakeStripe({ paymentIntent: { review: 'prv_1', latest_charge: null } });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(true);
+  });
+
+  it('holds when latest_charge.review is set', async () => {
+    enableFlag();
+    const stripe = fakeStripe({
+      paymentIntent: { review: null, latest_charge: { review: 'prv_2' } as Stripe.Charge },
+    });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(true);
+  });
+
+  it('holds when latest_charge.outcome.type is manual_review', async () => {
+    enableFlag();
+    const stripe = fakeStripe({
+      paymentIntent: {
+        review: null,
+        latest_charge: { review: null, outcome: { type: 'manual_review' } } as Stripe.Charge,
+      },
+    });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(true);
+  });
+
+  it('does NOT hold an unflagged payment', async () => {
+    enableFlag();
+    const stripe = fakeStripe({
+      paymentIntent: {
+        review: null,
+        latest_charge: { review: null, outcome: { type: 'authorized' } } as Stripe.Charge,
+      },
+    });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(false);
+  });
+
+  it('fails open (does NOT hold) when the Stripe read throws', async () => {
+    enableFlag();
+    const stripe = fakeStripe({
+      paymentIntent: () => {
+        throw new Error('stripe down');
+      },
+    });
+    expect(await isCheckoutHeldForReview('pi_1', stripe as unknown as Stripe)).toBe(false);
+  });
+});
+
+describe('handleReviewClosed', () => {
+  const pkgTokens = TOKEN_PACKAGES.blaze.tokens;
+
+  function reviewClosed(reason: Stripe.Review.ClosedReason, pi = 'pi_held'): Stripe.Review {
+    return {
+      id: 'prv_close',
+      object: 'review',
+      closed_reason: reason,
+      open: false,
+      payment_intent: pi,
+    } as unknown as Stripe.Review;
+  }
+
+  it('no-ops when the flag is off', async () => {
+    disableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0 });
+    const stripe = fakeStripe({ paymentIntent: { metadata: { userId: user.id, package: 'blaze' } } });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    expect(stripe.paymentIntents.retrieve).not.toHaveBeenCalled();
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(0);
+  });
+
+  it('releases the held grant when closed as approved', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0 });
+    const stripe = fakeStripe({
+      paymentIntent: { metadata: { userId: user.id, package: 'blaze' } },
+    });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(pkgTokens);
+  });
+
+  it('is idempotent across review.closed redelivery (grants exactly once)', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0 });
+    const stripe = fakeStripe({
+      paymentIntent: { metadata: { userId: user.id, package: 'blaze' } },
+    });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(pkgTokens);
+  });
+
+  it('grants nothing when closed as refunded_as_fraud', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0 });
+    const stripe = fakeStripe({
+      paymentIntent: { metadata: { userId: user.id, package: 'blaze' } },
+    });
+
+    await handleReviewClosed(reviewClosed('refunded_as_fraud'), stripe as unknown as Stripe);
+
+    expect(stripe.paymentIntents.retrieve).not.toHaveBeenCalled();
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(0);
+  });
+
+  it('grants nothing when the PI carries no token-pack metadata', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0 });
+    const stripe = fakeStripe({ paymentIntent: { metadata: {} } });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(0);
+  });
+});
+
+describe('handleDisputeCreated', () => {
+  function dispute(over: { charge: string; amount: number }): Stripe.Dispute {
+    return { id: 'dp_1', object: 'dispute', charge: over.charge, amount: over.amount } as unknown as Stripe.Dispute;
+  }
+
+  it('no-ops when the flag is off', async () => {
+    disableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 5000, stripeCustomerId: 'cus_d' });
+    await seedPurchase(neonSql, { userId: user.id, paymentIntent: 'pi_d', tokens: 5000, amountCents: 4900 });
+    const stripe = fakeStripe({
+      charge: { customer: 'cus_d', payment_intent: 'pi_d', amount: 4900 } as Stripe.Charge,
+    });
+
+    await handleDisputeCreated(dispute({ charge: 'ch_d', amount: 4900 }), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(5000);
+  });
+
+  it('claws back the full granted amount on a full dispute', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 5000, stripeCustomerId: 'cus_d2' });
+    await seedPurchase(neonSql, { userId: user.id, paymentIntent: 'pi_d2', tokens: 5000, amountCents: 4900 });
+    const stripe = fakeStripe({
+      charge: { customer: 'cus_d2', payment_intent: 'pi_d2', amount: 4900 } as Stripe.Charge,
+    });
+
+    await handleDisputeCreated(dispute({ charge: 'ch_d2', amount: 4900 }), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(0);
+  });
+
+  it('does nothing for an unknown customer', async () => {
+    enableFlag();
+    const stripe = fakeStripe({
+      charge: { customer: 'cus_unknown', payment_intent: 'pi_x', amount: 4900 } as Stripe.Charge,
+    });
+    // Should resolve without throwing and credit nothing.
+    await expect(
+      handleDisputeCreated(dispute({ charge: 'ch_x', amount: 4900 }), stripe as unknown as Stripe),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/web/src/lib/billing/__tests__/radarReview.test.ts
+++ b/web/src/lib/billing/__tests__/radarReview.test.ts
@@ -212,6 +212,58 @@ describe('handleReviewClosed', () => {
     expect(Number(row?.addon_tokens)).toBe(pkgTokens);
   });
 
+  it('persists stripe_customer_id on the approved path so the clawback can find the user', async () => {
+    // Data-integrity regression (PF-913 / #8823): the held→approved grant must
+    // write the Stripe customer id, otherwise a first-time buyer (no prior
+    // stripe_customer_id) is unreachable by the refund/dispute clawback, which
+    // resolves the user SOLELY via findUserByStripeCustomer.
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0, stripeCustomerId: null });
+    const stripe = fakeStripe({
+      paymentIntent: { metadata: { userId: user.id, package: 'blaze' }, customer: 'cus_held' },
+    });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(Number(row?.addon_tokens)).toBe(pkgTokens);
+    expect(row?.stripe_customer_id).toBe('cus_held');
+
+    // End-to-end: the clawback path must now resolve this user by customer id
+    // and reverse the credit (a later dispute on the approved charge). The
+    // approved grant above already created the token_purchases row for
+    // pi_held, so no extra seeding is needed.
+    const disputeStripe = fakeStripe({
+      charge: {
+        customer: 'cus_held',
+        payment_intent: 'pi_held',
+        amount: TOKEN_PACKAGES.blaze.priceCents,
+      } as Stripe.Charge,
+    });
+    await handleDisputeCreated(
+      { id: 'dp_held', object: 'dispute', charge: 'ch_held', amount: TOKEN_PACKAGES.blaze.priceCents } as unknown as Stripe.Dispute,
+      disputeStripe as unknown as Stripe,
+    );
+
+    const afterDispute = await getUserRow(neonSql, user.id);
+    expect(Number(afterDispute?.addon_tokens)).toBe(0);
+  });
+
+  it('does not overwrite an existing stripe_customer_id on the approved path', async () => {
+    enableFlag();
+    const { neonSql } = harness();
+    const user = await seedUser(neonSql, { addonTokens: 0, stripeCustomerId: 'cus_existing' });
+    const stripe = fakeStripe({
+      paymentIntent: { metadata: { userId: user.id, package: 'blaze' }, customer: 'cus_other' },
+    });
+
+    await handleReviewClosed(reviewClosed('approved'), stripe as unknown as Stripe);
+
+    const row = await getUserRow(neonSql, user.id);
+    expect(row?.stripe_customer_id).toBe('cus_existing');
+  });
+
   it('is idempotent across review.closed redelivery (grants exactly once)', async () => {
     enableFlag();
     const { neonSql } = harness();

--- a/web/src/lib/billing/radar-review.ts
+++ b/web/src/lib/billing/radar-review.ts
@@ -214,15 +214,18 @@ export async function handleReviewOpened(review: Stripe.Review): Promise<void> {
  * proportionally (full dispute = full reversal) via the shared
  * `reverseAddonTokens` path, which is idempotent on `(chargeId, amount)`.
  *
- * No-op when the feature flag is off, or when the dispute has no customer /
- * charge we can resolve.
+ * NOT gated on `isRadarReviewHoldEnabled()`. A dispute clawback is a
+ * chargeback-recovery safety net, not part of the review-hold feature: tokens
+ * granted while the flag was ON (or never gated at all) must still be reversed
+ * after the flag is turned OFF, or a disputed purchase leaks tokens forever.
+ * This mirrors `handleChargeRefunded`, which is likewise unconditional.
+ *
+ * No-op only when the dispute has no customer / charge we can resolve.
  */
 export async function handleDisputeCreated(
   dispute: Stripe.Dispute,
   stripe: Stripe
 ): Promise<void> {
-  if (!isRadarReviewHoldEnabled()) return;
-
   const chargeId = refId(dispute.charge);
   if (!chargeId) return;
 

--- a/web/src/lib/billing/radar-review.ts
+++ b/web/src/lib/billing/radar-review.ts
@@ -1,0 +1,209 @@
+/**
+ * Stripe Radar fraud-review handling for token-pack purchases (PF-913 / #8823).
+ *
+ * Capability: when Radar flags a one-time token-pack payment for manual review,
+ * DEFER (hold) the token credit grant until the review clears. Tokens are only
+ * granted once Stripe closes the review as `approved`. A review closed as
+ * `refunded` / `refunded_as_fraud` / `disputed` / `canceled` never grants, and a
+ * dispute reverses any credit that did land.
+ *
+ * Why hold rather than credit-then-claw-back: a fraudulent buyer can spend
+ * generation tokens the instant they're credited, so by the time a refund or
+ * dispute arrives the value is already consumed and unrecoverable. Holding the
+ * grant behind the Radar verdict closes that abuse window.
+ *
+ * FEATURE GUARD — `STRIPE_RADAR_REVIEW_HOLD`:
+ *   - Unset / not exactly the string "true"  → DISABLED. The webhook credits a
+ *     token-pack purchase immediately at `checkout.session.completed`, exactly as
+ *     before this change. `review.*` / `charge.dispute.created` events are
+ *     acknowledged and ignored. This is the safe default so the feature is inert
+ *     until the user provisions Radar review rules in the Stripe Dashboard.
+ *   - "true" → ENABLED. Flagged purchases are held; the credit is released on a
+ *     `review.closed { closed_reason: 'approved' }` event.
+ *
+ * NO new DB table / migration: the "held" state is simply the ABSENCE of a
+ * `token_purchases` row for the payment intent. The eventual release calls the
+ * existing idempotent `creditAddonTokens()` (keyed UNIQUE on
+ * `stripe_payment_intent` via ON CONFLICT DO NOTHING), so a duplicate
+ * `review.closed` redelivery — or a race with any other crediting path — grants
+ * exactly once.
+ *
+ * This module is additive to `subscription-lifecycle.ts` and shares its
+ * `reverseAddonTokens` clawback (PF-911 edits the same webhook route file in a
+ * parallel branch — keep changes here additive).
+ */
+
+import type Stripe from 'stripe';
+import { creditAddonTokens } from '@/lib/tokens/service';
+import { TOKEN_PACKAGES, type TokenPackage } from '@/lib/tokens/pricing';
+import {
+  findUserByStripeCustomer,
+  reverseAddonTokens,
+} from '@/lib/billing/subscription-lifecycle';
+import { captureException } from '@/lib/monitoring/sentry-server';
+
+/**
+ * Whether the Radar review-hold capability is enabled. Mirrors the
+ * `hasValidClerkKey`-style env guard: any value other than the exact string
+ * "true" leaves the feature OFF, so it is inert until the user provisions the
+ * Dashboard Radar rules and flips the flag.
+ */
+export function isRadarReviewHoldEnabled(): boolean {
+  return process.env.STRIPE_RADAR_REVIEW_HOLD === 'true';
+}
+
+/** Type guard for a value that is a known token package key. */
+function isTokenPackage(value: string | undefined): value is TokenPackage {
+  return value != null && Object.prototype.hasOwnProperty.call(TOKEN_PACKAGES, value);
+}
+
+/** Resolve a Stripe id-or-object reference to its id string. */
+function refId(
+  ref: string | { id: string } | null | undefined
+): string | null {
+  if (!ref) return null;
+  return typeof ref === 'string' ? ref : ref.id;
+}
+
+/**
+ * Decide whether a completed token-pack checkout should be HELD (credit
+ * deferred) because Radar flagged its payment for manual review.
+ *
+ * Returns `false` (do NOT hold → credit immediately) when:
+ *   - the feature flag is off, OR
+ *   - we cannot positively confirm an open review (fail-open: never strand a
+ *     legitimate buyer's tokens on an inconclusive read).
+ *
+ * Returns `true` only when we positively observe an OPEN review on the payment
+ * intent or its latest charge. The caller credits iff this returns `false`.
+ *
+ * Detection reads the PaymentIntent (expanding `latest_charge`) and checks:
+ *   - `paymentIntent.review` is set (an open Review id/object), or
+ *   - `latest_charge.review` is set, or
+ *   - `latest_charge.outcome.type === 'manual_review'` (Radar's review verdict).
+ */
+export async function isCheckoutHeldForReview(
+  paymentIntentId: string,
+  stripe: Stripe
+): Promise<boolean> {
+  if (!isRadarReviewHoldEnabled()) return false;
+
+  try {
+    const pi = await stripe.paymentIntents.retrieve(paymentIntentId, {
+      expand: ['latest_charge'],
+    });
+
+    if (pi.review) return true;
+
+    const charge =
+      pi.latest_charge && typeof pi.latest_charge === 'object'
+        ? (pi.latest_charge as Stripe.Charge)
+        : null;
+
+    if (charge?.review) return true;
+    if (charge?.outcome?.type === 'manual_review') return true;
+
+    return false;
+  } catch (err) {
+    // Fail-open: if we cannot read the review state, do NOT hold — a flagged
+    // payment that slips through is still caught later by `review.closed`
+    // (refunded/disputed reverse via the dispute/refund paths), whereas wrongly
+    // holding a legitimate purchase strands a paying customer's tokens forever.
+    captureException(err, {
+      route: '/api/stripe/webhook',
+      phase: 'radar-review-hold-check',
+      paymentIntentId,
+    });
+    return false;
+  }
+}
+
+/**
+ * Release a held credit when its Radar review closes as `approved`.
+ *
+ * Recovers the `userId` + `package` from the PaymentIntent metadata (propagated
+ * by the checkout route via `payment_intent_data.metadata`) and grants via the
+ * idempotent `creditAddonTokens`. Any non-`approved` close reason
+ * (refunded / refunded_as_fraud / disputed / canceled / …) grants nothing — the
+ * hold simply expires with no tokens issued.
+ *
+ * No-op when the feature flag is off.
+ */
+export async function handleReviewClosed(
+  review: Stripe.Review,
+  stripe: Stripe
+): Promise<void> {
+  if (!isRadarReviewHoldEnabled()) return;
+
+  // Only an explicit `approved` close releases the held grant.
+  if (review.closed_reason !== 'approved') return;
+
+  const paymentIntentId = refId(review.payment_intent);
+  if (!paymentIntentId) return;
+
+  // The token-pack metadata (userId, package) lives on the PaymentIntent —
+  // propagated from the checkout session via `payment_intent_data.metadata`.
+  const pi = await stripe.paymentIntents.retrieve(paymentIntentId);
+  const userId = pi.metadata?.userId;
+  const pkg = pi.metadata?.package;
+
+  // Not a token-pack payment (no metadata) → nothing to release.
+  if (!userId || !isTokenPackage(pkg)) return;
+
+  await creditAddonTokens(userId, pkg, paymentIntentId);
+}
+
+/**
+ * `review.opened` — observational only. The actual hold is enforced at
+ * `checkout.session.completed` (we simply do not credit a flagged purchase), so
+ * there is nothing to mutate here. Kept as a seam for future alerting.
+ *
+ * No-op when the feature flag is off.
+ */
+export async function handleReviewOpened(review: Stripe.Review): Promise<void> {
+  if (!isRadarReviewHoldEnabled()) return;
+  console.info(
+    `[stripe-webhook] Radar review opened (${review.id}, reason=${review.opened_reason}); token grant held pending review.`
+  );
+}
+
+/**
+ * `charge.dispute.created` — a customer disputed a charge. If tokens were
+ * already granted for the disputed charge's payment intent, claw them back
+ * proportionally (full dispute = full reversal) via the shared
+ * `reverseAddonTokens` path, which is idempotent on `(chargeId, amount)`.
+ *
+ * No-op when the feature flag is off, or when the dispute has no customer /
+ * charge we can resolve.
+ */
+export async function handleDisputeCreated(
+  dispute: Stripe.Dispute,
+  stripe: Stripe
+): Promise<void> {
+  if (!isRadarReviewHoldEnabled()) return;
+
+  const chargeId = refId(dispute.charge);
+  if (!chargeId) return;
+
+  // Resolve customer + payment intent from the charge (the Dispute object does
+  // not directly carry the customer).
+  const charge = await stripe.charges.retrieve(chargeId);
+  const customerId = refId(charge.customer);
+  if (!customerId) return;
+
+  const user = await findUserByStripeCustomer(customerId);
+  if (!user) return;
+
+  const paymentIntentId = refId(charge.payment_intent);
+
+  // amount is the disputed amount (cents); charge.amount is the original total.
+  if (dispute.amount <= 0 || charge.amount <= 0) return;
+
+  await reverseAddonTokens(
+    user.id,
+    chargeId,
+    dispute.amount,
+    charge.amount,
+    paymentIntentId
+  );
+}

--- a/web/src/lib/billing/radar-review.ts
+++ b/web/src/lib/billing/radar-review.ts
@@ -34,7 +34,11 @@
  */
 
 import type Stripe from 'stripe';
+import { eq } from 'drizzle-orm';
+import { getDb, queryWithResilience } from '@/lib/db/client';
+import { users } from '@/lib/db/schema';
 import { creditAddonTokens } from '@/lib/tokens/service';
+import { updateUserStripe } from '@/lib/auth/user-service';
 import { TOKEN_PACKAGES, type TokenPackage } from '@/lib/tokens/pricing';
 import {
   findUserByStripeCustomer,
@@ -63,6 +67,34 @@ function refId(
 ): string | null {
   if (!ref) return null;
   return typeof ref === 'string' ? ref : ref.id;
+}
+
+/**
+ * Persist the Stripe customer id onto the user record if not already stored.
+ *
+ * The dispute/refund clawback safety net (`handleDisputeCreated` →
+ * `findUserByStripeCustomer`, and `charge.refunded` → `handleChargeRefunded`)
+ * resolves the user SOLELY by `users.stripe_customer_id`. The normal
+ * `checkout.session.completed` credit path saves this id (see the webhook
+ * route), but a HELD purchase skips that path entirely — so without persisting
+ * it here, a first-time buyer whose held purchase is later approved would have
+ * NO `stripe_customer_id`, and a subsequent refund/dispute could not reverse the
+ * credit. Mirror the webhook's "save if not already stored" write.
+ */
+async function persistStripeCustomerId(
+  userId: string,
+  customerId: string
+): Promise<void> {
+  const [user] = await queryWithResilience(() =>
+    getDb()
+      .select({ id: users.id, stripeCustomerId: users.stripeCustomerId })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+  );
+  if (user && !user.stripeCustomerId) {
+    await updateUserStripe(userId, customerId);
+  }
 }
 
 /**
@@ -151,6 +183,15 @@ export async function handleReviewClosed(
   if (!userId || !isTokenPackage(pkg)) return;
 
   await creditAddonTokens(userId, pkg, paymentIntentId);
+
+  // Persist the Stripe customer id so a later refund/dispute can claw this
+  // credit back. The normal credit path (`checkout.session.completed`) saves
+  // it, but a held purchase bypasses that path — without this write, a
+  // first-time buyer approved here would be unreachable by the clawback.
+  const customerId = refId(pi.customer);
+  if (customerId) {
+    await persistStripeCustomerId(userId, customerId);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Stripe Radar fraud-review handling (PF-913) with a data-integrity fix on the held→approved credit path.

- Adds Radar `review.closed` / `review.opened` handling so flagged purchases hold token credit until the review clears.
- **Data-integrity fix:** `handleReviewClosed`'s approved/credit path credited tokens via `creditAddonTokens` but never persisted `stripe_customer_id` on the user. The refund/dispute clawback safety net (`handleChargeRefunded`, `handleDisputeCreated`) resolves the user **solely** via `findUserByStripeCustomer` (`users.stripe_customer_id`), so a first-time buyer whose held purchase was later approved could not be clawed back if the charge was refunded/disputed. Added a `persistStripeCustomerId` helper (mirrors the existing checkout "save if not already stored" write — does not overwrite an existing id) and call it in the approved path using the customer id from the already-retrieved PaymentIntent.

## Test plan

- [x] `cd web && npx vitest run src/lib/billing/__tests__` → 8 files / 135 tests green
- [x] New regression test drives the **full** held→approved→dispute clawback against a real pglite DB harness and asserts `addon_tokens` returns to 0; reverting only the source file makes it fail (`expected null to be cus_held`)
- [x] Second regression test: an existing `stripe_customer_id` is not overwritten
- [x] eslint clean, no test weakened
