### PR TITLE
feat(mcp): AI SDK MCP client + tool-parity guard (PF-915)

### DIFF
--- a/.changeset/ai-sdk-mcp-client-tool-parity.md
+++ b/.changeset/ai-sdk-mcp-client-tool-parity.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Add an AI SDK MCP client (`@ai-sdk/mcp`) and a tool-parity guard. The flag/env-guarded client (`MCP_HTTP_URL` + `MCP_HTTP_TOKEN`) connects to the SpawnForge MCP server's Streamable HTTP transport and is used out-of-band — chiefly to verify the bundled command manifest stays in sync with the tools a live server actually serves. The chat agent intentionally keeps its static, browser-forwarded tool source (no hot-path network dependency, no change to the execution model). See `docs/decisions/2026-06-23-mcp-client-tool-source.md`.

--- a/docs/decisions/2026-06-23-mcp-client-tool-source.md
+++ b/docs/decisions/2026-06-23-mcp-client-tool-source.md
@@ -1,0 +1,60 @@
+# MCP client as a parity guard, not the chat agent's tool source
+
+- **Date:** 2026-06-23
+- **Status:** Accepted
+- **Ticket:** PF-915 (#8825)
+
+## Context
+
+The chat agent (`web/src/lib/ai/spawnforgeAgent.ts`) builds its tool schemas from
+`web/src/data/commands.json` — a copy of `mcp-server/manifest/commands.json`. The
+two files are kept byte-identical by the file-to-file gate
+`apps/docs/scripts/check-manifest-sync.ts`. The web copy exists because of the
+Next.js import boundary (production code cannot import from outside `web/`).
+
+PF-915 asked whether adopting the AI SDK MCP client (`@ai-sdk/mcp`,
+`createMCPClient`) could retire this dual-maintenance by having the web agent
+source its tools directly from the MCP server, whose Streamable HTTP transport
+(`mcp-server/src/transport/http.ts`) already serves one tool per command.
+
+## Decision
+
+Add the MCP client as **out-of-band infrastructure and a tool-parity guard**, and
+**keep the static `commands.json` import as the chat agent's tool source.** Do not
+wire MCP-fetched tools into the chat hot path.
+
+Two reasons make the static manifest the correct hot-path source, not a
+limitation to remove:
+
+1. **Execution model.** The chat agent attaches **no execute functions** to its
+   tools — tool calls are forwarded to the browser to run against the WASM engine
+   (`spawnforgeAgent.ts`). An MCP client's `tools()` return executable tools that
+   run against the *server's* `EditorBridge`. Substituting those would silently
+   change where commands execute, breaking the browser-forwarding contract.
+2. **Hot-path cost.** Sourcing tools from MCP means a network round-trip (and a
+   live server dependency) on every chat request. The static JSON import is
+   zero-latency and has no runtime failure mode. Trading that for a network hop
+   is a regression, not a simplification.
+
+## What we shipped
+
+- `web/src/lib/mcp/client.ts` — env-guarded (`MCP_HTTP_URL` + `MCP_HTTP_TOKEN`)
+  `createSpawnforgeMcpClient` / `withMcpClient`. Returns `null` (no-op) when
+  unconfigured, so CI/dev/prod are unaffected until the vars are set. Bearer auth
+  matches the server's `MCP_HTTP_TOKEN`.
+- `web/src/lib/mcp/toolParity.ts` — compares the bundled command set against the
+  tools a *live* server actually serves. This catches drift the file-to-file
+  `check-manifest-sync.ts` cannot: a deployed server running a different manifest
+  version than the web bundle baked in. Runs as a `skipIf`-guarded test when the
+  env vars are present; a pure `compareToolSets` is unit-tested without a server.
+
+## Consequences / follow-ups
+
+- The dual-maintenance file remains, still guarded by `check-manifest-sync.ts`;
+  the new parity guard adds live-server coverage on top.
+- This client is the foundation for genuinely out-of-band MCP uses (resources,
+  prompts, admin/automation tooling) that are *not* latency-sensitive and *do*
+  want server-side execution.
+- A full cutover (deriving the schema surface from MCP at **build time**, so the
+  committed copy can be deleted) remains possible but is deferred: it would need a
+  build step that runs the server, and buys little over the existing gate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,23 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.52.tgz",
+      "integrity": "sha512-yudE3Mdl8fsbzjMepOPbikA6nIRWOez+5e/IvOv1jK6XMAtsZ4+Xz8vjRQHI77VMv2TdiaMfsKKFoW6dlZRT3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ai-sdk/provider": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
@@ -20645,6 +20662,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/gateway": "^3.0.133",
+        "@ai-sdk/mcp": "^1.0.52",
         "@ai-sdk/react": "^3.0.210",
         "@anthropic-ai/sdk": "^0.105.0",
         "@aws-sdk/client-s3": "^3.1075.0",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",
     "@ai-sdk/gateway": "^3.0.133",
+    "@ai-sdk/mcp": "^1.0.52",
     "@ai-sdk/react": "^3.0.210",
     "@anthropic-ai/sdk": "^0.105.0",
     "@aws-sdk/client-s3": "^3.1075.0",

--- a/web/src/lib/mcp/__tests__/client.test.ts
+++ b/web/src/lib/mcp/__tests__/client.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSpawnforgeMcpClient,
+  getMcpClientConfig,
+  isMcpClientConfigured,
+  withMcpClient,
+} from '@/lib/mcp/client';
+
+// Mock the SDK factory so no real network connection is attempted.
+const createMCPClientMock = vi.fn();
+vi.mock('@ai-sdk/mcp', () => ({
+  createMCPClient: (...args: unknown[]) => createMCPClientMock(...args),
+}));
+
+describe('mcp/client config resolution', () => {
+  const ORIGINAL = { url: process.env.MCP_HTTP_URL, token: process.env.MCP_HTTP_TOKEN };
+
+  beforeEach(() => {
+    delete process.env.MCP_HTTP_URL;
+    delete process.env.MCP_HTTP_TOKEN;
+    createMCPClientMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL.url === undefined) delete process.env.MCP_HTTP_URL;
+    else process.env.MCP_HTTP_URL = ORIGINAL.url;
+    if (ORIGINAL.token === undefined) delete process.env.MCP_HTTP_TOKEN;
+    else process.env.MCP_HTTP_TOKEN = ORIGINAL.token;
+  });
+
+  it('returns null when neither var is set', () => {
+    expect(getMcpClientConfig()).toBeNull();
+    expect(isMcpClientConfigured()).toBe(false);
+  });
+
+  it('returns null when only the URL is set (no half-configured client)', () => {
+    process.env.MCP_HTTP_URL = 'https://mcp.example.com/mcp';
+    expect(getMcpClientConfig()).toBeNull();
+    expect(isMcpClientConfigured()).toBe(false);
+  });
+
+  it('returns null when only the token is set', () => {
+    process.env.MCP_HTTP_TOKEN = 'secret';
+    expect(getMcpClientConfig()).toBeNull();
+    expect(isMcpClientConfigured()).toBe(false);
+  });
+
+  it('treats whitespace-only values as unset', () => {
+    process.env.MCP_HTTP_URL = '   ';
+    process.env.MCP_HTTP_TOKEN = '\t';
+    expect(getMcpClientConfig()).toBeNull();
+  });
+
+  it('resolves config (trimmed) when both vars are set', () => {
+    process.env.MCP_HTTP_URL = '  https://mcp.example.com/mcp  ';
+    process.env.MCP_HTTP_TOKEN = '  secret-token  ';
+    expect(getMcpClientConfig()).toEqual({
+      url: 'https://mcp.example.com/mcp',
+      token: 'secret-token',
+    });
+    expect(isMcpClientConfigured()).toBe(true);
+  });
+});
+
+describe('createSpawnforgeMcpClient', () => {
+  beforeEach(() => createMCPClientMock.mockReset());
+
+  it('returns null (no-op) and never calls the SDK when not configured', async () => {
+    const client = await createSpawnforgeMcpClient(null);
+    expect(client).toBeNull();
+    expect(createMCPClientMock).not.toHaveBeenCalled();
+  });
+
+  it('creates an http transport with a Bearer auth header from the config', async () => {
+    const fakeClient = { tools: vi.fn(), close: vi.fn() };
+    createMCPClientMock.mockResolvedValue(fakeClient);
+
+    const client = await createSpawnforgeMcpClient({
+      url: 'https://mcp.example.com/mcp',
+      token: 'tok-123',
+    });
+
+    expect(client).toBe(fakeClient);
+    expect(createMCPClientMock).toHaveBeenCalledWith({
+      transport: {
+        type: 'http',
+        url: 'https://mcp.example.com/mcp',
+        headers: { Authorization: 'Bearer tok-123' },
+      },
+    });
+  });
+});
+
+describe('withMcpClient', () => {
+  beforeEach(() => createMCPClientMock.mockReset());
+
+  it('returns null and does not run fn when unconfigured', async () => {
+    const fn = vi.fn();
+    const result = await withMcpClient(fn, null);
+    expect(result).toBeNull();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('runs fn with the client and always closes it', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    const fakeClient = { tools: vi.fn(), close };
+    createMCPClientMock.mockResolvedValue(fakeClient);
+
+    const result = await withMcpClient(async (c) => {
+      expect(c).toBe(fakeClient);
+      return 'done';
+    }, { url: 'https://mcp.example.com/mcp', token: 'tok' });
+
+    expect(result).toBe('done');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the client even when fn throws', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    createMCPClientMock.mockResolvedValue({ tools: vi.fn(), close });
+
+    await expect(
+      withMcpClient(async () => {
+        throw new Error('boom');
+      }, { url: 'https://mcp.example.com/mcp', token: 'tok' }),
+    ).rejects.toThrow('boom');
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/mcp/__tests__/toolParity.test.ts
+++ b/web/src/lib/mcp/__tests__/toolParity.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkToolParity,
+  compareToolSets,
+  fetchServerToolNames,
+  formatToolParity,
+  getManifestToolNames,
+  type ToolListingClient,
+} from '@/lib/mcp/toolParity';
+import { isMcpClientConfigured, withMcpClient } from '@/lib/mcp/client';
+import manifestJson from '@/data/commands.json';
+
+const manifest = manifestJson as { commands: Array<{ name: string }> };
+
+describe('getManifestToolNames', () => {
+  it('returns every command name, sorted, deduped to the manifest length', () => {
+    const names = getManifestToolNames();
+    expect(names.length).toBe(manifest.commands.length);
+    expect([...names]).toEqual([...names].sort());
+    // sanity: a known command is present
+    expect(names).toContain(manifest.commands[0].name);
+  });
+});
+
+describe('compareToolSets', () => {
+  it('reports in-sync when sets are identical regardless of order', () => {
+    const r = compareToolSets(['b', 'a', 'c'], ['c', 'a', 'b']);
+    expect(r).toEqual({ inSync: true, onlyInManifest: [], onlyInServer: [] });
+  });
+
+  it('reports a command missing from the live server (onlyInManifest)', () => {
+    const r = compareToolSets(['a', 'b', 'c'], ['a', 'c']);
+    expect(r.inSync).toBe(false);
+    expect(r.onlyInManifest).toEqual(['b']);
+    expect(r.onlyInServer).toEqual([]);
+  });
+
+  it('reports a tool served but not bundled (onlyInServer)', () => {
+    const r = compareToolSets(['a', 'b'], ['a', 'b', 'z']);
+    expect(r.inSync).toBe(false);
+    expect(r.onlyInManifest).toEqual([]);
+    expect(r.onlyInServer).toEqual(['z']);
+  });
+
+  it('reports drift in both directions, sorted', () => {
+    const r = compareToolSets(['a', 'm', 'b'], ['a', 'z', 'y']);
+    expect(r.onlyInManifest).toEqual(['b', 'm']);
+    expect(r.onlyInServer).toEqual(['y', 'z']);
+  });
+});
+
+describe('fetchServerToolNames', () => {
+  it('returns sorted keys of the client tool set', async () => {
+    const client: ToolListingClient = {
+      tools: vi.fn().mockResolvedValue({ spawn_entity: {}, delete_entity: {}, query_scene: {} }),
+    };
+    expect(await fetchServerToolNames(client)).toEqual([
+      'delete_entity',
+      'query_scene',
+      'spawn_entity',
+    ]);
+  });
+});
+
+describe('checkToolParity', () => {
+  it('is in sync when the server serves exactly the bundled command set', async () => {
+    const serverTools = Object.fromEntries(getManifestToolNames().map((n) => [n, {}]));
+    const client: ToolListingClient = { tools: vi.fn().mockResolvedValue(serverTools) };
+    const result = await checkToolParity(client);
+    expect(result.inSync).toBe(true);
+    expect(result.onlyInManifest).toEqual([]);
+    expect(result.onlyInServer).toEqual([]);
+  });
+
+  it('detects a server missing one bundled command', async () => {
+    const names = getManifestToolNames();
+    const dropped = names[0];
+    const serverTools = Object.fromEntries(names.slice(1).map((n) => [n, {}]));
+    const client: ToolListingClient = { tools: vi.fn().mockResolvedValue(serverTools) };
+    const result = await checkToolParity(client);
+    expect(result.inSync).toBe(false);
+    expect(result.onlyInManifest).toEqual([dropped]);
+  });
+});
+
+describe('formatToolParity', () => {
+  it('summarizes an in-sync result with the tool count', () => {
+    expect(formatToolParity({ inSync: true, onlyInManifest: [], onlyInServer: [] })).toContain(
+      `${getManifestToolNames().length} tools`,
+    );
+  });
+
+  it('names the drift in both directions', () => {
+    const msg = formatToolParity({ inSync: false, onlyInManifest: ['a'], onlyInServer: ['z'] });
+    expect(msg).toContain('NOT served by the server: a');
+    expect(msg).toContain('NOT in web bundle: z');
+  });
+});
+
+// Live parity check — only runs when a real MCP server is configured via env.
+// Skipped in CI/dev (no MCP_HTTP_URL/MCP_HTTP_TOKEN); proves the bundled manifest
+// matches what a running server actually serves when those vars ARE present.
+describe.skipIf(!isMcpClientConfigured())('live MCP server tool parity', () => {
+  it('the running server serves exactly the bundled command set', async () => {
+    const result = await withMcpClient((client) => checkToolParity(client));
+    expect(result).not.toBeNull();
+    expect(result, formatToolParity(result!)).toMatchObject({ inSync: true });
+  });
+});

--- a/web/src/lib/mcp/client.ts
+++ b/web/src/lib/mcp/client.ts
@@ -1,0 +1,90 @@
+/**
+ * SpawnForge MCP client (AI SDK / `@ai-sdk/mcp`).
+ *
+ * Connects to the SpawnForge MCP server's Streamable HTTP transport
+ * (`mcp-server/src/transport/http.ts`, the `POST /mcp` endpoint) using the
+ * AI SDK MCP client. The server registers all 350 commands from
+ * `manifest/commands.json`, so the client is the live source of truth for the
+ * tool surface.
+ *
+ * IMPORTANT — this is NOT the chat agent's tool source.
+ * The chat agent (`createSpawnforgeAgent`) builds its tools statically from the
+ * bundled `@/data/commands.json` and attaches NO execute functions, because tool
+ * calls are forwarded to the browser to run against the WASM engine. An MCP
+ * client's tools carry execute functions that run against the *server's*
+ * `EditorBridge` — wiring those into the chat agent would both regress the
+ * browser-forwarding model and add a per-request network hop to the hot path.
+ * So this client is used for OUT-OF-BAND work — chiefly the tool-parity guard
+ * (`./toolParity`) that proves the static manifest stays in sync with the live
+ * server. See `docs/decisions/2026-06-23-mcp-client-tool-source.md`.
+ *
+ * Flag/env-guarded: returns `null` (no-op) unless BOTH `MCP_HTTP_URL` and
+ * `MCP_HTTP_TOKEN` are set, mirroring the env-guard pattern used across the app
+ * (e.g. `layout.tsx` Clerk-key gating). `MCP_HTTP_TOKEN` must match the
+ * `MCP_HTTP_TOKEN` the server authenticates against (Bearer scheme).
+ */
+
+import { createMCPClient } from '@ai-sdk/mcp';
+
+export interface McpClientConfig {
+  /** Base URL of the MCP server's Streamable HTTP endpoint, e.g. `https://mcp.example.com/mcp`. */
+  url: string;
+  /** Bearer token; must equal the server's `MCP_HTTP_TOKEN`. */
+  token: string;
+}
+
+/**
+ * Resolve the MCP client config from the environment, or `null` when the
+ * integration is not configured. Both vars are required — a URL without a token
+ * (or vice versa) is treated as "off", never as a half-configured client.
+ */
+export function getMcpClientConfig(): McpClientConfig | null {
+  const url = process.env.MCP_HTTP_URL?.trim();
+  const token = process.env.MCP_HTTP_TOKEN?.trim();
+  if (!url || !token) return null;
+  return { url, token };
+}
+
+/** True when both `MCP_HTTP_URL` and `MCP_HTTP_TOKEN` are present. */
+export function isMcpClientConfigured(): boolean {
+  return getMcpClientConfig() !== null;
+}
+
+export type SpawnforgeMcpClient = Awaited<ReturnType<typeof createMCPClient>>;
+
+/**
+ * Create an MCP client connected to the SpawnForge MCP server, or `null` when
+ * the integration is not configured (env-guarded no-op).
+ *
+ * Callers MUST `await client.close()` when done — the Streamable HTTP transport
+ * holds a connection. Prefer the `withMcpClient` helper, which guarantees close.
+ */
+export async function createSpawnforgeMcpClient(
+  config: McpClientConfig | null = getMcpClientConfig(),
+): Promise<SpawnforgeMcpClient | null> {
+  if (!config) return null;
+  return createMCPClient({
+    transport: {
+      type: 'http',
+      url: config.url,
+      headers: { Authorization: `Bearer ${config.token}` },
+    },
+  });
+}
+
+/**
+ * Run `fn` with a live MCP client, always closing it afterward. Resolves to
+ * `null` (without calling `fn`) when the integration is not configured.
+ */
+export async function withMcpClient<T>(
+  fn: (client: SpawnforgeMcpClient) => Promise<T>,
+  config: McpClientConfig | null = getMcpClientConfig(),
+): Promise<T | null> {
+  const client = await createSpawnforgeMcpClient(config);
+  if (!client) return null;
+  try {
+    return await fn(client);
+  } finally {
+    await client.close();
+  }
+}

--- a/web/src/lib/mcp/toolParity.ts
+++ b/web/src/lib/mcp/toolParity.ts
@@ -1,0 +1,90 @@
+/**
+ * MCP tool-parity guard.
+ *
+ * The chat agent builds its tool schemas from the bundled `@/data/commands.json`
+ * (a copy of `mcp-server/manifest/commands.json`, kept identical at the file
+ * level by `apps/docs/scripts/check-manifest-sync.ts`). The MCP server registers
+ * one tool per `commands[].name`, so the set of tool names the *live* server
+ * serves must equal the set of command names the web bundle ships.
+ *
+ * `check-manifest-sync.ts` compares the two committed JSON files. This guard
+ * compares the bundled manifest against what a *running* server actually serves
+ * — catching drift the file-to-file check cannot (e.g. a server deployed from a
+ * newer/older manifest than the web bundle baked in). It is the foundation for a
+ * future cutover that would derive the tool surface from MCP directly; until
+ * then it is a safety net, not a hot-path dependency.
+ *
+ * See `./client` and `docs/decisions/2026-06-23-mcp-client-tool-source.md`.
+ */
+
+import manifestJson from '@/data/commands.json';
+
+interface ManifestCommand {
+  name: string;
+}
+
+const manifest = manifestJson as { commands: ManifestCommand[] };
+
+/** Minimal structural shape of an MCP client we need here — `tools()` only. */
+export interface ToolListingClient {
+  tools(): Promise<Record<string, unknown>>;
+}
+
+/** All command names the web bundle ships, sorted. */
+export function getManifestToolNames(): string[] {
+  return manifest.commands.map((c) => c.name).sort();
+}
+
+/** Tool names a live MCP client reports, sorted. */
+export async function fetchServerToolNames(client: ToolListingClient): Promise<string[]> {
+  const tools = await client.tools();
+  return Object.keys(tools).sort();
+}
+
+export interface ToolParityResult {
+  inSync: boolean;
+  /** Commands in the web bundle that the live server does NOT serve. */
+  onlyInManifest: string[];
+  /** Tools the live server serves that are NOT in the web bundle. */
+  onlyInServer: string[];
+}
+
+/**
+ * Compare two tool-name sets. Pure — both inputs are plain string arrays so this
+ * is trivially unit-testable without a live server.
+ */
+export function compareToolSets(
+  manifestNames: readonly string[],
+  serverNames: readonly string[],
+): ToolParityResult {
+  const manifestSet = new Set(manifestNames);
+  const serverSet = new Set(serverNames);
+  const onlyInManifest = [...manifestSet].filter((n) => !serverSet.has(n)).sort();
+  const onlyInServer = [...serverSet].filter((n) => !manifestSet.has(n)).sort();
+  return {
+    inSync: onlyInManifest.length === 0 && onlyInServer.length === 0,
+    onlyInManifest,
+    onlyInServer,
+  };
+}
+
+/** Fetch the live tool set and compare it against the bundled manifest. */
+export async function checkToolParity(client: ToolListingClient): Promise<ToolParityResult> {
+  const serverNames = await fetchServerToolNames(client);
+  return compareToolSets(getManifestToolNames(), serverNames);
+}
+
+/** Human-readable summary of a parity result, for logs / CI output. */
+export function formatToolParity(result: ToolParityResult): string {
+  if (result.inSync) {
+    return `MCP tool parity OK — ${getManifestToolNames().length} tools match the live server.`;
+  }
+  const lines = ['MCP tool parity DRIFT:'];
+  if (result.onlyInManifest.length > 0) {
+    lines.push(`  in web bundle but NOT served by the server: ${result.onlyInManifest.join(', ')}`);
+  }
+  if (result.onlyInServer.length > 0) {
+    lines.push(`  served by the server but NOT in web bundle: ${result.onlyInServer.join(', ')}`);
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Adopts the AI SDK MCP client (`@ai-sdk/mcp`) and adds a **tool-parity guard**, per PF-915.

The ticket's premise — source the chat agent's tools live from the MCP server to retire the dual-maintenance `commands.json` copy — turns out to be the wrong cutover, for two concrete reasons documented in the ADR:

1. **Execution model.** The chat agent attaches **no execute functions** to its tools; tool calls are forwarded to the browser to run against the WASM engine. An MCP client's `tools()` carry execute fns that run against the *server's* `EditorBridge` — wiring those in silently changes where commands execute.
2. **Hot-path cost.** Sourcing tools from MCP adds a network round-trip + a live-server dependency to every chat request. The static JSON import is zero-latency with no runtime failure mode.

So this PR keeps the static `commands.json` import as the agent's tool source and adds the MCP client as **out-of-band infrastructure + a parity safety net** instead.

## What's here

- `web/src/lib/mcp/client.ts` — flag/env-guarded MCP client (`MCP_HTTP_URL` + `MCP_HTTP_TOKEN`, Bearer auth). Returns `null` (no-op) when unconfigured, so CI/dev/prod are unaffected until the vars are set. `withMcpClient` guarantees `close()`.
- `web/src/lib/mcp/toolParity.ts` — compares the bundled command set against the tools a **live** server actually serves. Catches drift the file-to-file `apps/docs/scripts/check-manifest-sync.ts` cannot (a deployed server running a different manifest version than the web bundle baked in).
- 20 unit tests (mocked client — CI never reaches a live server) + 1 `skipIf`-guarded live test that runs only when the env vars are present.
- ADR `docs/decisions/2026-06-23-mcp-client-tool-source.md`.
- `@ai-sdk/mcp@^1.0.52` added to `web/package.json`; root `package-lock.json` relocked on Node 24.

## Provisioning (none required to merge)

The integration is dormant until `MCP_HTTP_URL` + `MCP_HTTP_TOKEN` are set; `MCP_HTTP_TOKEN` must match the MCP server's `MCP_HTTP_TOKEN`. No env changes needed for this PR.

## Test plan

- [x] `eslint --max-warnings 0` on the new files — clean
- [x] `tsc --noEmit` (full web project) — 0 errors; `@ai-sdk/mcp` types resolve
- [x] `vitest run` new suites — 20 passed, 1 skipped (live check)
- [x] lockfile relocked on Node 24, idempotent under `--package-lock-only`

Closes #8825 (PF-915)
