### PR TITLE
fix(ci): unblock Changesets release PR (lockfile relock + work-item exemption)

### DIFF
--- a/.github/workflows/pr-workitem-check.yml
+++ b/.github/workflows/pr-workitem-check.yml
@@ -14,10 +14,14 @@ jobs:
   require-work-item:
     name: Require Linked Work Item
     # Exempt automation PRs with no taskboard ticket: dependabot bumps and the
-    # Changesets "Version Packages" PR (github-actions[bot] on changeset-release/main).
+    # Changesets "Version Packages" PR. The release exemption requires BOTH the
+    # github-actions[bot] author AND the changeset-release/main branch — keying on
+    # the branch name alone would let any contributor bypass the gate by naming
+    # their branch changeset-release/main (the PR author login is set by GitHub
+    # and is not contributor-controllable, so the conjunction is safe).
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]'
-      && github.head_ref != 'changeset-release/main'
+      && !(github.event.pull_request.user.login == 'github-actions[bot]' && github.head_ref == 'changeset-release/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/pr-workitem-check.yml
+++ b/.github/workflows/pr-workitem-check.yml
@@ -13,7 +13,11 @@ permissions:
 jobs:
   require-work-item:
     name: Require Linked Work Item
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    # Exempt automation PRs with no taskboard ticket: dependabot bumps and the
+    # Changesets "Version Packages" PR (github-actions[bot] on changeset-release/main).
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && npm install --package-lock-only",
     "changeset:publish": "changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

The Changesets "Version Packages" PR (#8836) — the first one ever created, after the GitHub Actions PR-creation toggle was enabled — fails two **required** gates because the release flow had never been exercised end-to-end. Both are real release-pipeline bugs:

- **Lockfile Sync (fail):** root `changeset:version` was `changeset version`, which bumps `web` / `packages/ui` / `mcp-server` package.json versions + writes CHANGELOGs but never regenerates the single root `package-lock.json`. The gate regenerates the lockfile and diffs → fail. Merging as-is would break `npm ci` on main (the single-root-lockfile gotcha that broke main twice). Fix: append `&& npm install --package-lock-only` so the version PR carries the relocked lockfile (runs on `.node-version`/Node 24 in CI, matching the gate).
- **Require Linked Work Item (fail):** `pr-workitem-check.yml` exempted only `dependabot[bot]`. The Version Packages PR is authored by `github-actions[bot]` on `changeset-release/main` and legitimately has no taskboard ticket. Fix: also skip the gate when `github.head_ref == 'changeset-release/main'`.

After this merges, Release re-runs on main, force-updates `changeset-release/main`, and the regenerated Version Packages PR passes Lockfile Sync + CI Success and skips the work-item gate. (Chromatic baseline acceptance stays a separate manual step.)

Closes #8837

## Test plan
- [ ] CI green on this PR (Lockfile Sync untouched here — only the script + a workflow `if:` change).
- [ ] After merge: Release workflow re-runs, #8836 (or its successor) shows Lockfile Sync ✅ and Require Linked Work Item skipped.