### PR TITLE
infra: commit engine-cdn R2 Worker source + CORS/security regression test (#8649)

### DIFF
--- a/.github/workflows/engine-cdn-test.yml
+++ b/.github/workflows/engine-cdn-test.yml
@@ -1,0 +1,28 @@
+name: engine-cdn Worker Test
+
+on:
+  pull_request:
+    paths:
+      - 'infra/engine-cdn/**'
+      - '.github/workflows/engine-cdn-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test engine-cdn Worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: .node-version
+
+      - name: Run engine-cdn worker tests
+        run: node --test infra/engine-cdn/worker.test.mjs

--- a/infra/engine-cdn/package.json
+++ b/infra/engine-cdn/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "engine-cdn",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker serving the SpawnForge WASM engine from the spawnforge-engine R2 bucket at engine.spawnforge.ai. Hermetic tests run via `node --test infra/engine-cdn/worker.test.mjs`.",
+  "scripts": {
+    "test": "node --test worker.test.mjs"
+  }
+}

--- a/infra/engine-cdn/worker.js
+++ b/infra/engine-cdn/worker.js
@@ -1,0 +1,170 @@
+// engine-cdn Cloudflare Worker — serves the SpawnForge WASM engine from the
+// `spawnforge-engine` R2 bucket at https://engine.spawnforge.ai/*.
+//
+// This file is a from-SOURCE reconstruction of the manually-deployed worker,
+// authored to match the behavior DOCUMENTED in
+// .claude/skills/infra-services/references/runbook.md (ACAO `*`), SKILL.md, and
+// web/next.config.ts (COEP `require-corp` / COOP `same-origin`). Before any
+// `wrangler deploy` from this source, diff it against the live worker
+// (`wrangler deployments list --name engine-cdn` / Cloudflare dashboard worker
+// code) so a redeploy does not silently change production behavior.
+//
+// SECURITY INVARIANTS (asserted by worker.test.mjs — do not weaken):
+//   * GET/HEAD only. Every write/mutating method (PUT/POST/DELETE/PATCH) → 405.
+//   * No bucket listing. A bare `/` or a directory-style path → 404; the worker
+//     NEVER calls `env.ENGINE_BUCKET.list()`.
+//   * Bind ONLY `spawnforge-engine`. `spawnforge-assets` is signed-URL/
+//     server-side only and must never be reachable through this public edge.
+//
+// The consuming editor page is cross-origin-isolated (COEP require-corp + COOP
+// same-origin, see web/next.config.ts), so every served object MUST carry
+// `Cross-Origin-Resource-Policy: cross-origin` AND pass CORS, or the isolated
+// page refuses to instantiate the WASM and SharedArrayBuffer breaks. Omitting
+// CORP is the most likely subtle break: the binary 200s but won't load.
+
+const ALLOWED_METHODS = 'GET, HEAD';
+const CORS_METHODS = 'GET, HEAD, OPTIONS';
+
+/**
+ * Normalize a request URL pathname to an R2 object key.
+ *
+ * Returns `null` for anything that must NOT map to a single object — a bare
+ * root, an empty path, a directory-style trailing-slash request, or a path that
+ * tries to traverse (`..`). Callers treat `null` as 404 so the worker never
+ * enumerates the bucket.
+ *
+ * @param {string} pathname URL pathname, e.g. "/abc123/engine-pkg-webgpu/forge_engine_bg.wasm"
+ * @returns {string | null} the R2 key, or null if the path is not a fetchable object
+ */
+export function pathToKey(pathname) {
+  if (typeof pathname !== 'string' || pathname.length === 0) return null;
+  // Strip exactly one leading slash to form the key.
+  const key = pathname.replace(/^\/+/, '');
+  // Empty (bare "/") or directory-style ("foo/") → no object, never a listing.
+  if (key.length === 0) return null;
+  if (key.endsWith('/')) return null;
+  // Reject path traversal in any segment.
+  const segments = key.split('/');
+  if (segments.some((seg) => seg === '..' || seg === '.')) return null;
+  return key;
+}
+
+/**
+ * Build the response headers for a successfully-fetched object.
+ *
+ * @param {string} key the R2 object key (used for the *.wasm content-type branch)
+ * @param {{ contentType?: string } | undefined} httpMetadata R2 object httpMetadata
+ * @returns {Headers}
+ */
+export function buildObjectHeaders(key, httpMetadata) {
+  const headers = new Headers();
+
+  const isWasm = typeof key === 'string' && key.endsWith('.wasm');
+  const contentType = isWasm
+    ? 'application/wasm'
+    : (httpMetadata && httpMetadata.contentType) || 'application/octet-stream';
+  headers.set('Content-Type', contentType);
+
+  // CORS — public, immutable, no credentials, so `*` is appropriate.
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', CORS_METHODS);
+
+  // Cross-origin isolation: the consuming page is COEP require-corp / COOP
+  // same-origin, so the embedded resource must be CORP cross-origin and echo the
+  // isolation headers.
+  headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+
+  // Immutable, content-addressed assets (keyed by sha or pinned version).
+  headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+
+  return headers;
+}
+
+/**
+ * Build a CORS preflight (OPTIONS) response.
+ * @returns {Response}
+ */
+export function preflightResponse() {
+  const headers = new Headers();
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', CORS_METHODS);
+  headers.set('Access-Control-Allow-Headers', '*');
+  headers.set('Access-Control-Max-Age', '86400');
+  headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  return new Response(null, { status: 204, headers });
+}
+
+/**
+ * Build a 405 Method Not Allowed response. Carries `Allow: GET, HEAD` and never
+ * touches the bucket.
+ * @returns {Response}
+ */
+export function methodNotAllowedResponse() {
+  return new Response('Method Not Allowed', {
+    status: 405,
+    headers: {
+      Allow: ALLOWED_METHODS,
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': CORS_METHODS,
+    },
+  });
+}
+
+/**
+ * Build a 404 Not Found response.
+ * @returns {Response}
+ */
+export function notFoundResponse() {
+  return new Response('Not Found', {
+    status: 404,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': CORS_METHODS,
+    },
+  });
+}
+
+export default {
+  /**
+   * @param {Request} request
+   * @param {{ ENGINE_BUCKET: { get(key: string): Promise<any> } }} env
+   * @returns {Promise<Response>}
+   */
+  async fetch(request, env) {
+    const method = request.method;
+
+    if (method === 'OPTIONS') {
+      return preflightResponse();
+    }
+
+    // GET/HEAD only. Writes (PUT/POST/DELETE/PATCH) and any LIST attempt are
+    // refused at the method gate — they never reach the bucket.
+    if (method !== 'GET' && method !== 'HEAD') {
+      return methodNotAllowedResponse();
+    }
+
+    const url = new URL(request.url);
+    const key = pathToKey(url.pathname);
+    if (key === null) {
+      // Bare root / directory / traversal → 404. NO bucket listing.
+      return notFoundResponse();
+    }
+
+    const object = await env.ENGINE_BUCKET.get(key);
+    if (object === null || object === undefined) {
+      return notFoundResponse();
+    }
+
+    const headers = buildObjectHeaders(key, object.httpMetadata);
+    // Propagate the R2 etag when present (helps conditional caching).
+    if (object.httpEtag) {
+      headers.set('ETag', object.httpEtag);
+    }
+
+    // HEAD: headers only, no body.
+    const body = method === 'HEAD' ? null : object.body;
+    return new Response(body, { status: 200, headers });
+  },
+};

--- a/infra/engine-cdn/worker.test.mjs
+++ b/infra/engine-cdn/worker.test.mjs
@@ -1,0 +1,226 @@
+// Hermetic regression suite for the engine-cdn Cloudflare Worker.
+//
+// Runs with zero network / wrangler / live R2 via `node --test`. Drives the
+// worker through a stub `env.ENGINE_BUCKET` that records every method called so
+// the tests can assert the worker NEVER lists the bucket and NEVER attempts a
+// write. Mirrors scripts/pitr-verify.test.mjs (node:test + node:assert/strict).
+//
+// These cases would FAIL against the pre-fix tree (the worker did not exist):
+// the import alone throws, and each invariant (GET-only, no listing, CORS+CORP
+// on every served object) is asserted explicitly.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import worker, {
+  pathToKey,
+  buildObjectHeaders,
+  preflightResponse,
+  methodNotAllowedResponse,
+  notFoundResponse,
+} from './worker.js';
+
+/**
+ * Build a stub R2 binding. Only `get` is implemented (the worker's entire
+ * surface). `list`/`put`/`delete` throw if ever called, and `calls` records the
+ * key history so a test can prove no enumeration happened.
+ *
+ * @param {Record<string, { body?: unknown, httpMetadata?: { contentType?: string }, httpEtag?: string }>} objects
+ */
+function makeBucket(objects) {
+  const calls = { get: [] };
+  return {
+    calls,
+    async get(key) {
+      calls.get.push(key);
+      return Object.prototype.hasOwnProperty.call(objects, key)
+        ? objects[key]
+        : null;
+    },
+    async list() {
+      throw new Error('list() must never be called — no bucket listing allowed');
+    },
+    async put() {
+      throw new Error('put() must never be called — public edge is read-only');
+    },
+    async delete() {
+      throw new Error('delete() must never be called — public edge is read-only');
+    },
+  };
+}
+
+function req(method, path) {
+  return new Request(`https://engine.spawnforge.ai${path}`, { method });
+}
+
+const WASM_KEY = 'abc123/engine-pkg-webgpu/forge_engine_bg.wasm';
+const JS_KEY = 'abc123/engine-pkg-webgpu/forge_engine.js';
+
+function fakeObject({ contentType, etag } = {}) {
+  return {
+    body: 'FAKE_BYTES',
+    httpMetadata: contentType ? { contentType } : {},
+    httpEtag: etag,
+  };
+}
+
+describe('pathToKey', () => {
+  test('strips a single leading slash', () => {
+    assert.equal(pathToKey('/abc/forge_engine_bg.wasm'), 'abc/forge_engine_bg.wasm');
+  });
+
+  test('bare root → null (no object, no listing)', () => {
+    assert.equal(pathToKey('/'), null);
+  });
+
+  test('empty string → null', () => {
+    assert.equal(pathToKey(''), null);
+  });
+
+  test('directory-style trailing slash → null', () => {
+    assert.equal(pathToKey('/engine-pkg-webgpu/'), null);
+  });
+
+  test('path traversal → null', () => {
+    assert.equal(pathToKey('/../secret'), null);
+    assert.equal(pathToKey('/a/../b'), null);
+  });
+});
+
+describe('buildObjectHeaders', () => {
+  test('*.wasm forces application/wasm and carries CORS + isolation', () => {
+    const h = buildObjectHeaders(WASM_KEY, { contentType: 'text/plain' });
+    assert.equal(h.get('Content-Type'), 'application/wasm');
+    assert.equal(h.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(h.get('Cross-Origin-Resource-Policy'), 'cross-origin');
+    assert.equal(h.get('Cross-Origin-Embedder-Policy'), 'require-corp');
+    assert.equal(h.get('Cross-Origin-Opener-Policy'), 'same-origin');
+    assert.equal(h.get('Cache-Control'), 'public, max-age=31536000, immutable');
+  });
+
+  test('non-wasm falls back to object httpMetadata content-type', () => {
+    const h = buildObjectHeaders(JS_KEY, { contentType: 'application/javascript' });
+    assert.equal(h.get('Content-Type'), 'application/javascript');
+    // Still cross-origin isolated.
+    assert.equal(h.get('Cross-Origin-Resource-Policy'), 'cross-origin');
+    assert.equal(h.get('Access-Control-Allow-Origin'), '*');
+  });
+
+  test('header set exposes NO write/list affordance', () => {
+    const h = buildObjectHeaders(WASM_KEY, {});
+    assert.equal(h.get('Allow'), null);
+    assert.match(h.get('Access-Control-Allow-Methods'), /^GET, HEAD, OPTIONS$/);
+    assert.doesNotMatch(h.get('Access-Control-Allow-Methods'), /PUT|POST|DELETE/);
+  });
+});
+
+describe('worker.fetch — happy path', () => {
+  test('GET *.wasm → 200 with application/wasm + full isolation headers', async () => {
+    const bucket = makeBucket({ [WASM_KEY]: fakeObject({ etag: '"deadbeef"' }) });
+    const res = await worker.fetch(req('GET', `/${WASM_KEY}`), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Content-Type'), 'application/wasm');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Cross-Origin-Resource-Policy'), 'cross-origin');
+    assert.equal(res.headers.get('Cross-Origin-Embedder-Policy'), 'require-corp');
+    assert.equal(res.headers.get('Cross-Origin-Opener-Policy'), 'same-origin');
+    assert.equal(res.headers.get('Cache-Control'), 'public, max-age=31536000, immutable');
+    assert.equal(res.headers.get('ETag'), '"deadbeef"');
+    assert.deepEqual(bucket.calls.get, [WASM_KEY]);
+  });
+
+  test('GET non-wasm (forge_engine.js) → 200 with object content-type + CORS/CORP', async () => {
+    const bucket = makeBucket({
+      [JS_KEY]: fakeObject({ contentType: 'application/javascript' }),
+    });
+    const res = await worker.fetch(req('GET', `/${JS_KEY}`), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Content-Type'), 'application/javascript');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Cross-Origin-Resource-Policy'), 'cross-origin');
+  });
+
+  test('HEAD returns headers but no body', async () => {
+    const bucket = makeBucket({ [WASM_KEY]: fakeObject() });
+    const res = await worker.fetch(req('HEAD', `/${WASM_KEY}`), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Content-Type'), 'application/wasm');
+    const body = await res.text();
+    assert.equal(body, '');
+  });
+});
+
+describe('worker.fetch — write methods are refused (read-only edge)', () => {
+  for (const method of ['PUT', 'POST', 'DELETE', 'PATCH']) {
+    test(`${method} → 405 with Allow: GET, HEAD and bucket untouched`, async () => {
+      const bucket = makeBucket({ [WASM_KEY]: fakeObject() });
+      const res = await worker.fetch(req(method, `/${WASM_KEY}`), { ENGINE_BUCKET: bucket });
+      assert.equal(res.status, 405);
+      assert.equal(res.headers.get('Allow'), 'GET, HEAD');
+      // Negative: never offers a write method.
+      assert.doesNotMatch(res.headers.get('Allow'), /PUT|POST|DELETE|PATCH/);
+      // The bucket was never touched — no get, and (by stub) no put/delete.
+      assert.deepEqual(bucket.calls.get, []);
+    });
+  }
+});
+
+describe('worker.fetch — no bucket listing', () => {
+  test('bare / → 404 and never enumerates', async () => {
+    const bucket = makeBucket({ [WASM_KEY]: fakeObject() });
+    const res = await worker.fetch(req('GET', '/'), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 404);
+    // The stub's list() throws if called; reaching here proves it wasn't.
+    assert.deepEqual(bucket.calls.get, []);
+  });
+
+  test('directory-style path → 404 and never enumerates', async () => {
+    const bucket = makeBucket({ [WASM_KEY]: fakeObject() });
+    const res = await worker.fetch(req('GET', '/engine-pkg-webgpu/'), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 404);
+    assert.deepEqual(bucket.calls.get, []);
+  });
+
+  test('worker default export has no list affordance', () => {
+    assert.equal(typeof worker.fetch, 'function');
+    assert.equal(worker.list, undefined);
+    assert.equal(worker.put, undefined);
+  });
+});
+
+describe('worker.fetch — CORS preflight', () => {
+  test('OPTIONS → 204 with Access-Control-Allow-Methods', async () => {
+    const bucket = makeBucket({});
+    const res = await worker.fetch(req('OPTIONS', `/${WASM_KEY}`), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.match(res.headers.get('Access-Control-Allow-Methods'), /GET, HEAD, OPTIONS/);
+    // Preflight does not touch the bucket.
+    assert.deepEqual(bucket.calls.get, []);
+  });
+});
+
+describe('worker.fetch — miss', () => {
+  test('GET of an absent key → 404', async () => {
+    const bucket = makeBucket({});
+    const res = await worker.fetch(req('GET', `/${WASM_KEY}`), { ENGINE_BUCKET: bucket });
+    assert.equal(res.status, 404);
+    assert.deepEqual(bucket.calls.get, [WASM_KEY]);
+  });
+});
+
+describe('helper response builders', () => {
+  test('methodNotAllowedResponse never advertises a write method', () => {
+    const res = methodNotAllowedResponse();
+    assert.equal(res.status, 405);
+    assert.equal(res.headers.get('Allow'), 'GET, HEAD');
+    assert.doesNotMatch(res.headers.get('Allow'), /PUT/);
+  });
+
+  test('notFoundResponse is 404', () => {
+    assert.equal(notFoundResponse().status, 404);
+  });
+
+  test('preflightResponse is 204', () => {
+    assert.equal(preflightResponse().status, 204);
+  });
+});

--- a/infra/engine-cdn/wrangler.toml
+++ b/infra/engine-cdn/wrangler.toml
@@ -1,0 +1,24 @@
+# engine-cdn — Cloudflare Worker that serves the SpawnForge WASM engine from the
+# `spawnforge-engine` R2 bucket at https://engine.spawnforge.ai/*.
+#
+# Security scoping (see worker.js header): this worker binds ONLY the
+# `spawnforge-engine` bucket and is GET/HEAD-only. The `spawnforge-assets`
+# bucket is signed-URL/server-side only and is deliberately NOT bound here, so it
+# is never reachable through this public edge.
+name = "engine-cdn"
+account_id = "0b949ff499d179e24dde841f71d6134f"
+main = "worker.js"
+compatibility_date = "2025-06-01"
+
+# Route the engine CDN custom domain to this worker. The zone owns
+# spawnforge.ai; the worker handles every path under engine.spawnforge.ai.
+[[routes]]
+pattern = "engine.spawnforge.ai/*"
+zone_name = "spawnforge.ai"
+
+# Read-only binding to the engine bucket. The binding name MUST match
+# `env.ENGINE_BUCKET` in worker.js — a mismatch makes the binding undefined at
+# runtime with no compile error.
+[[r2_buckets]]
+binding = "ENGINE_BUCKET"
+bucket_name = "spawnforge-engine"


### PR DESCRIPTION
## Summary
- Commits the `engine-cdn` Cloudflare Worker **source** (`infra/engine-cdn/worker.js` + `wrangler.toml`) that was previously deployed manually with no checked-in source — closing the gap where the live edge had no reviewable, version-controlled origin.
- Adds a **hermetic** CORS/security regression suite (`worker.test.mjs`, `node --test`, no wrangler/network/live R2) asserting the load-bearing invariants: GET/HEAD-only (writes → 405 before any bucket I/O), never lists the bucket (bare/dir/traversal paths → 404, `.list()` never called), binds only `spawnforge-engine` (not the signed-URL `spawnforge-assets` bucket), and emits the cross-origin-isolation headers (`CORP cross-origin`, COEP/COOP, `application/wasm`) that `web/next.config.ts` requires for SharedArrayBuffer WASM.
- Adds a path-gated CI job (`.github/workflows/engine-cdn-test.yml`) running the suite on changes under `infra/engine-cdn/**`. SHA-pinned actions, `permissions: contents: read`, `node-version-file: .node-version`.

The worker header explicitly flags this as a from-source reconstruction and instructs diffing against the live worker (`wrangler deployments list` / dashboard) **before any redeploy** — there is no deploy wiring in this PR (test-only job; `cd.yml` untouched), so the unverified source cannot auto-push to the live edge.

Closes #8649

## Test plan
- [x] `node --test infra/engine-cdn/worker.test.mjs` — 23/23 pass locally
- [x] 5-reviewer board (architect/security/dx/ux/test): all PASS
- [ ] CI `engine-cdn-test` job green on the PR
