### PR TITLE
feat(chat): orchestrate generation tools in game-creation workflow + targetEntityId alias (#8546)

### DIFF
--- a/.changeset/auto-8546.md
+++ b/.changeset/auto-8546.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Steer the chat agent to orchestrate the AI generation tools (generate_3d_model / generate_texture / generate_music / generate_skybox) in the correct game-creation order — idea, generate assets, spawn, script, win condition, playtest — so character-led prompts queue real generated assets instead of bare primitives (#8546)

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -764,6 +764,44 @@ describe('POST /api/chat', () => {
       expect(blocks[1]?.text).toContain('## Scene\nEmpty');
     });
 
+    it('steers the agent to orchestrate generate_* tools in the game-creation workflow (#8546)', async () => {
+      // The base system prompt must teach the agent to drive the asset-generation
+      // pipeline (idea → generated assets → spawn → script → win condition →
+      // playtest) so a request like "make a 3D platformer about a frog" queues a
+      // generate_3d_model job instead of dropping a bare cube.
+      const res = await POST(makeRequest(validBody()));
+      await res.text(); // drain stream
+      const call = vi.mocked(createSpawnforgeAgent).mock.calls.at(-1)?.[0];
+      const blocks = (call?.instructions ?? []) as Array<{ text: string; tier?: string }>;
+      const basePrompt = blocks[0]?.text ?? '';
+
+      // Generation tools are named so the model knows to call them.
+      expect(basePrompt).toContain('generate_3d_model');
+      expect(basePrompt).toContain('generate_texture');
+      expect(basePrompt).toContain('generate_music');
+      expect(basePrompt).toContain('generate_skybox');
+      // The entity-id pattern that wires a generated asset onto a placeholder.
+      expect(basePrompt).toContain('targetEntityId');
+      // The win condition + playtest steps that make the game completable.
+      expect(basePrompt).toContain('win_condition');
+      expect(basePrompt).toMatch(/playtest|press Play/i);
+
+      // Ordering: the asset-generation guidance precedes the win-condition step,
+      // which precedes the playtest step (idea → assets → … → win → playtest).
+      const genIdx = basePrompt.indexOf('generate_3d_model');
+      const winIdx = basePrompt.indexOf('win_condition');
+      const playtestIdx = basePrompt.search(/playtest|press Play/i);
+      expect(genIdx).toBeGreaterThanOrEqual(0);
+      expect(winIdx).toBeGreaterThan(genIdx);
+      expect(playtestIdx).toBeGreaterThan(winIdx);
+
+      // Prompt-cache invariant: the base block stays static and long-tier with no
+      // per-user nonce — adding nondeterminism here would blow the cache for every
+      // user and leak the per-session marker into the cached prefix.
+      expect(blocks[0]?.tier).toBe('long');
+      expect(basePrompt).not.toContain('<!-- session:');
+    });
+
     it('counts sceneContext.length toward the MAX_INPUT_CHARS budget', async () => {
       // sceneContext alone is well under 2M, but combined with messages
       // the total exceeds the 2M MAX_INPUT_CHARS guard. Without summing

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -128,15 +128,17 @@ You have access to 350 MCP commands across 41 categories. Key categories include
 
 ## Game Creation Workflow
 1. **Plan the scene** - Identify what entities are needed (player, enemies, environment, collectibles, lights)
-2. **Spawn entities** - Use spawn_entity with types: cube, sphere, cylinder, plane, cone, torus, capsule
-3. **Position everything** - Use update_transform to place entities (position [x,y,z], rotation, scale)
-4. **Add materials** - Use update_material for colors, metallic/roughness, emissive glow, textures
-5. **Set up lighting** - Spawn lights, configure ambient light, add shadows
-6. **Add physics** - Use set_physics for rigid bodies (dynamic/static/kinematic), colliders, gravity
-7. **Write scripts** - Use set_script with TypeScript to add game logic (movement, AI, scoring)
-8. **Add audio** - Attach sounds, configure spatial audio, set up audio buses
-9. **Add particles** - Fire, smoke, sparkles for visual effects
-10. **Test** - User clicks Play to test, Stop to return to editing
+2. **Generate AI assets for characters and key props** - For named characters and signature props (the frog hero, the boss, the treasure), spawn a placeholder primitive first, then call generate_3d_model with \`targetEntityId\` set to that placeholder's id so the generated model swaps in when ready. Use generate_texture / generate_pbr_maps (\`targetEntityId\`) to skin a surface, generate_skybox for the environment backdrop, and generate_music (\`targetEntityId\` for spatial source, or scene-wide) for soundtrack. **Heuristic:** characters and key props → generated assets; ground, walls, platforms, and abstract gameplay shapes → plain primitives (faster, no credits, no wait). Don't generate a model for a floor.
+3. **Spawn entities** - Use spawn_entity with types: cube, sphere, cylinder, plane, cone, torus, capsule
+4. **Position everything** - Use update_transform to place entities (position [x,y,z], rotation, scale)
+5. **Add materials** - Use update_material for colors, metallic/roughness, emissive glow, textures
+6. **Set up lighting** - Spawn lights, configure ambient light, add shadows
+7. **Add physics** - Use set_physics for rigid bodies (dynamic/static/kinematic), colliders, gravity
+8. **Write scripts** - Use set_script with TypeScript to add game logic (movement, AI, scoring)
+9. **Add audio** - Attach sounds, configure spatial audio, set up audio buses
+10. **Add particles** - Fire, smoke, sparkles for visual effects
+11. **Define a win condition** - Use add_game_component with componentType \`win_condition\` (and a matching lose/objective component) so the game is actually winnable — a game with no win condition can never be completed.
+12. **Test (playtest)** - User clicks Play to test, Stop to return to editing. After building, tell the user to press Play to playtest.
 
 ## Scripting API (forge.*)
 Scripts run in a sandboxed TypeScript environment with these APIs:
@@ -220,6 +222,18 @@ function onUpdate(dt) {
   }
 }
 \`\`\`
+
+## Example: Asset-Driven Game Creation (end-to-end orchestration)
+For a request like "make me a 3D platformer about a frog", orchestrate the generate_* and setup tools in this order — do NOT just drop a bare cube for the hero:
+1. **Idea → plan** - A frog hero, floating platforms, a goal flag, jump-to-reach gameplay.
+2. **Spawn placeholders** - spawn_entity cube named "Frog" for the hero; spawn plain primitive planes/cubes for the platforms and ground (these stay primitives — no generated assets for gameplay geometry).
+3. **Generate the hero asset** - generate_3d_model with prompt "cartoon frog character" and \`targetEntityId\` = the Frog placeholder's id, so the model swaps onto that entity when the job finishes (the entity keeps its transform, physics, and scripts).
+4. **Skin / dress the scene** - generate_texture or generate_pbr_maps with \`targetEntityId\` to texture a signature surface; generate_skybox for the backdrop.
+5. **Soundtrack** - generate_music with \`targetEntityId\` for a spatial source on the hero, or scene-wide for background music.
+6. **Physics & scripts on the placeholder** - set_physics (dynamic) and set_script on the Frog entity now; they apply to the same entity the generated model lands on.
+7. **Win condition** - add_game_component with componentType \`win_condition\` (e.g. reach the goal flag) so the level can be completed.
+8. **Playtest** - tell the user to press Play to test the frog, Stop to return to editing.
+Generate assets concurrently where possible (each generate_* job runs async with its own usageId); keep building the scene while jobs are in flight rather than blocking on each one.
 
 ## Tips
 - Always use get_scene_graph first to see what entities exist and their IDs

--- a/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/generationHandlers.test.ts
@@ -310,6 +310,32 @@ describe('generationHandlers', () => {
         autoPlace: false,
       }));
     });
+
+    // #8546 — the game-creation system prompt calls generate_texture with
+    // `targetEntityId`. The handler must treat it as an alias for `entityId`
+    // (these assertions fail on pre-fix code where targetEntityId was ignored).
+    it('resolves targetEntityId to the same dispatch as entityId', async () => {
+      mockFetchSuccess();
+      await invoke('generate_texture', { prompt: 'grass', targetEntityId: 'e1' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.entityId).toBe('e1');
+      expect(mockAddJob).toHaveBeenCalledWith(expect.objectContaining({
+        entityId: 'e1',
+        targetEntityId: 'e1',
+        autoPlace: true,
+      }));
+    });
+
+    it('targetEntityId takes precedence over entityId when both present', async () => {
+      mockFetchSuccess();
+      await invoke('generate_texture', { prompt: 'grass', entityId: 'old', targetEntityId: 'e1' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.entityId).toBe('e1');
+      expect(mockAddJob).toHaveBeenCalledWith(expect.objectContaining({
+        entityId: 'e1',
+        targetEntityId: 'e1',
+      }));
+    });
   });
 
   // =========================================================================
@@ -331,6 +357,30 @@ describe('generationHandlers', () => {
     it('fails without prompt', async () => {
       const { result } = await invoke('generate_pbr_maps', {});
       expect(result.success).toBe(false);
+    });
+
+    // #8546 — generate_pbr_maps must accept `targetEntityId` (the name the
+    // system prompt uses) as an alias for `entityId`. Fails on pre-fix code.
+    it('resolves targetEntityId to the same dispatch as entityId', async () => {
+      mockFetchSuccess();
+      await invoke('generate_pbr_maps', { prompt: 'metal surface', targetEntityId: 'e1' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.entityId).toBe('e1');
+      expect(mockAddJob).toHaveBeenCalledWith(expect.objectContaining({
+        entityId: 'e1',
+        targetEntityId: 'e1',
+      }));
+    });
+
+    it('targetEntityId takes precedence over entityId when both present', async () => {
+      mockFetchSuccess();
+      await invoke('generate_pbr_maps', { prompt: 'metal', entityId: 'old', targetEntityId: 'e1' });
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.entityId).toBe('e1');
+      expect(mockAddJob).toHaveBeenCalledWith(expect.objectContaining({
+        entityId: 'e1',
+        targetEntityId: 'e1',
+      }));
     });
   });
 

--- a/web/src/lib/chat/handlers/generationHandlers.ts
+++ b/web/src/lib/chat/handlers/generationHandlers.ts
@@ -208,6 +208,11 @@ export const generationHandlers: Record<string, ToolHandler> = {
     const p = parseArgs(z.object({
       prompt: z.string().min(1),
       entityId: z.string().min(1).optional(),
+      // `targetEntityId` is the canonical name used by the game-creation system
+      // prompt and the other generate_* tools. Accept it as an alias for
+      // `entityId` (additive, backward-compatible) so skinning is not silently
+      // dropped when the agent follows the prompt. (#8546)
+      targetEntityId: z.string().min(1).optional(),
       resolution: z.string().optional(),
       style: z.string().optional(),
       tiling: z.boolean().optional(),
@@ -226,9 +231,12 @@ export const generationHandlers: Record<string, ToolHandler> = {
     }
     const materialSlot: MaterialSlot | undefined = rawSlot as MaterialSlot | undefined;
 
+    // `targetEntityId` takes precedence; `entityId` kept working for any caller.
+    const effectiveEntityId = p.data.targetEntityId ?? p.data.entityId;
+
     const result = await generateFetch('/api/generate/texture', {
       prompt: enrichPrompt(p.data.prompt, 'texture', ctx.store),
-      entityId: p.data.entityId,
+      entityId: effectiveEntityId,
       resolution: p.data.resolution ?? '1024',
       style: p.data.style ?? 'realistic',
       tiling: p.data.tiling ?? false,
@@ -243,10 +251,10 @@ export const generationHandlers: Record<string, ToolHandler> = {
       type: 'texture',
       prompt: p.data.prompt,
       provider: (data.provider as string) ?? DIRECT_CAPABILITY_PROVIDER.texture,
-      entityId: p.data.entityId,
+      entityId: effectiveEntityId,
       usageId: data.usageId as string | undefined,
-      autoPlace: p.data.autoPlace ?? !!p.data.entityId,
-      targetEntityId: p.data.entityId,
+      autoPlace: p.data.autoPlace ?? !!effectiveEntityId,
+      targetEntityId: effectiveEntityId,
       materialSlot,
     });
 
@@ -263,13 +271,19 @@ export const generationHandlers: Record<string, ToolHandler> = {
     const p = parseArgs(z.object({
       prompt: z.string().min(1),
       entityId: z.string().min(1).optional(),
+      // `targetEntityId` alias — matches the game-creation system prompt and the
+      // other generate_* tools so PBR skinning is not silently dropped. (#8546)
+      targetEntityId: z.string().min(1).optional(),
       maps: z.unknown().optional(),
     }), args);
     if (p.error) return p.error;
 
+    // `targetEntityId` takes precedence; `entityId` kept working for any caller.
+    const effectiveEntityId = p.data.targetEntityId ?? p.data.entityId;
+
     const result = await generateFetch('/api/generate/texture', {
       prompt: enrichPrompt(p.data.prompt, 'texture', ctx.store),
-      entityId: p.data.entityId,
+      entityId: effectiveEntityId,
       maps: p.data.maps,
     });
     if (!result.ok) return { success: false, error: result.error };
@@ -282,8 +296,9 @@ export const generationHandlers: Record<string, ToolHandler> = {
       type: 'texture',
       prompt: p.data.prompt,
       provider: (data.provider as string) ?? DIRECT_CAPABILITY_PROVIDER.texture,
-      entityId: p.data.entityId,
+      entityId: effectiveEntityId,
       usageId: data.usageId as string | undefined,
+      targetEntityId: effectiveEntityId,
     });
 
     return {


### PR DESCRIPTION
## Summary

Steers the chat agent to **orchestrate** the AI generation tools in the correct game-creation order — idea → generate assets → spawn → script → win condition → playtest — so a character-led prompt ("make a platformer with a knight") queues real generated assets (`generate_3d_model` / `generate_texture` / `generate_music` / `generate_skybox`) instead of dropping bare primitives.

### Changes
- `web/src/app/api/chat/route.ts`: the system prompt now describes the generation-tool workflow and the order to apply it, and uses the param contract each handler actually accepts (so generated assets auto-wire onto the entity they belong to).
- `web/src/lib/chat/handlers/generationHandlers.ts`: `generate_texture` and `generate_pbr_maps` now accept a `targetEntityId` alias alongside `entityId` (`effectiveEntityId = targetEntityId ?? entityId`), matching the sibling generation handlers — closing the silent no-op where a `targetEntityId`-shaped call had its entity id stripped by Zod and the texture never landed.

### Tests
- `generationHandlers.test.ts`: 4 real-handler tests proving both `entityId` and `targetEntityId` resolve to the same tracked-job target, and that the texture/PBR maps reach the entity.
- `route.test.ts`: asserts the orchestration guidance is present in the assembled system prompt.

Closes #8546

## Test plan
- [x] `cd web && npx vitest run src/lib/chat/handlers/__tests__/generationHandlers.test.ts src/app/api/chat/__tests__/route.test.ts` — green
- [x] `npx eslint --max-warnings 0` + `npx tsc --noEmit` on touched files — clean
- [x] 5-specialist review board (architecture/security/dx/ux/test) — all PASS
