### PR TITLE
feat(chat): setup_game_from_description compound orchestration tool (#8541)

### DIFF
--- a/.changeset/auto-8541.md
+++ b/.changeset/auto-8541.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Add the `setup_game_from_description` compound chat tool that deterministically scaffolds a complete, immediately-playable game (project type, environment, player with controller + health, enemies, collectible coins, a goal with a win condition, ground, input preset, and camera-follow script) from a plain-text description, with optional parallel asset generation (#8541).

--- a/mcp-server/manifest/commands.json
+++ b/mcp-server/manifest/commands.json
@@ -7651,6 +7651,40 @@
       "visibility": "public"
     },
     {
+      "name": "setup_game_from_description",
+      "description": "Scaffold a complete, immediately-playable game from a plain-text description in one call. Deterministically sets the project type, environment, and input preset, then spawns a player (with character controller + health), enemies, collectible coins, a goal carrying a win condition, and a ground plane, and attaches a camera-follow script. Optionally dispatches parallel asset-generation jobs that auto-wire back onto the scaffolded entities.",
+      "category": "compound",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Plain-text description of the game to scaffold (e.g. 'a platformer with 3 enemies and 5 coins')."
+          },
+          "genre": {
+            "type": "string",
+            "description": "Optional genre hint (e.g. 'fps', 'platformer', 'topdown', 'racing') that nudges the input preset."
+          },
+          "targetTier": {
+            "type": "string",
+            "enum": [
+              "low",
+              "mid",
+              "high"
+            ],
+            "description": "Optional asset-fidelity tier. When set, parallel generate_* jobs are dispatched to replace the placeholder primitives; the scaffold is fully playable before they land."
+          }
+        },
+        "required": [
+          "description"
+        ]
+      },
+      "tokenCost": 0,
+      "requiredScope": "scene:write",
+      "visibility": "public"
+    },
+    {
       "name": "arrange_entities",
       "description": "Arrange existing entities in spatial patterns. Provide entity IDs and a pattern type. This repositions entities without changing their other properties.",
       "category": "compound",

--- a/web/src/data/commands.json
+++ b/web/src/data/commands.json
@@ -7651,6 +7651,40 @@
       "visibility": "public"
     },
     {
+      "name": "setup_game_from_description",
+      "description": "Scaffold a complete, immediately-playable game from a plain-text description in one call. Deterministically sets the project type, environment, and input preset, then spawns a player (with character controller + health), enemies, collectible coins, a goal carrying a win condition, and a ground plane, and attaches a camera-follow script. Optionally dispatches parallel asset-generation jobs that auto-wire back onto the scaffolded entities.",
+      "category": "compound",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Plain-text description of the game to scaffold (e.g. 'a platformer with 3 enemies and 5 coins')."
+          },
+          "genre": {
+            "type": "string",
+            "description": "Optional genre hint (e.g. 'fps', 'platformer', 'topdown', 'racing') that nudges the input preset."
+          },
+          "targetTier": {
+            "type": "string",
+            "enum": [
+              "low",
+              "mid",
+              "high"
+            ],
+            "description": "Optional asset-fidelity tier. When set, parallel generate_* jobs are dispatched to replace the placeholder primitives; the scaffold is fully playable before they land."
+          }
+        },
+        "required": [
+          "description"
+        ]
+      },
+      "tokenCost": 0,
+      "requiredScope": "scene:write",
+      "visibility": "public"
+    },
+    {
       "name": "arrange_entities",
       "description": "Arrange existing entities in spatial patterns. Provide entity IDs and a pattern type. This repositions entities without changing their other properties.",
       "category": "compound",

--- a/web/src/lib/chat/handlers/README.md
+++ b/web/src/lib/chat/handlers/README.md
@@ -30,7 +30,7 @@ handlers/
 ├── gameplayHandlers.ts         # Game components, game cameras, input bindings
 ├── assetHandlers.ts            # Asset import, GLTF, textures, prefab instantiation
 ├── pixelArtHandlers.ts         # Pixel art / sprite sheet AI generation
-├── compoundHandlers.ts         # Multi-step compound actions (create_scene, setup_character, etc.)
+├── compoundHandlers.ts         # 9 multi-step compound actions (create_scene, setup_character, setup_game_from_description, etc.)
 ├── leaderboardHandlers.ts      # Leaderboard and score tracking
 ├── ideaHandlers.ts             # Game idea generation and brainstorming
 ├── worldHandlers.ts            # World generation and procedural content

--- a/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
@@ -1062,5 +1062,30 @@ describe('compoundHandlers', () => {
         expect.objectContaining({ type: 'follower' }),
       );
     });
+
+    it('falls back to patrol (never a null-target follower) when the player spawn fails', async () => {
+      // Regression: a 'follower' enemy was built with targetEntityId: playerId
+      // unconditionally. If the player spawn returns null, the follower would
+      // chase nothing. Spawn everything normally EXCEPT the Player, which fails.
+      const { store } = await invoke(
+        'setup_game_from_description',
+        { description: '1 enemy that will chase the player' },
+        gameOverrides({
+          spawnEntity: vi.fn((_t: unknown, n: string) => (n === 'Player' ? null : `id-${n}`)),
+        }),
+      );
+
+      const componentTypes = (store.addGameComponent as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([, component]) => (component as { type?: string }).type,
+      );
+      // No follower was created (it would have a null target) ...
+      expect(componentTypes).not.toContain('follower');
+      // ... the enemy patrols instead, keeping it functional. The patrol input
+      // key 'moving_platform' builds a component with the camelCase discriminant.
+      expect(store.addGameComponent).toHaveBeenCalledWith(
+        'id-Enemy_0',
+        expect.objectContaining({ type: 'movingPlatform' }),
+      );
+    });
   });
 });

--- a/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
@@ -887,12 +887,49 @@ describe('compoundHandlers', () => {
         'id-Player',
         expect.objectContaining({ type: 'characterController' }),
       );
+      // The Player must be a DYNAMIC body — that is what generates the collision
+      // PAIRS with the static sensor coins/goal. A non-dynamic player produces
+      // no relative motion and (with two fixed bodies) no collision events.
+      const playerPhysics = (store.updatePhysics as ReturnType<typeof vi.fn>).mock.calls.find(
+        (c) => c[0] === 'id-Player',
+      );
+      expect(playerPhysics).toBeDefined();
+      expect((playerPhysics?.[1] as { bodyType?: string })?.bodyType).toBe('dynamic');
 
       // Coins are collectibles with a trigger zone.
       expect(store.addGameComponent).toHaveBeenCalledWith(
         'id-Coin_0',
         expect.objectContaining({ type: 'collectible' }),
       );
+
+      // WINNABILITY / INTERACTIVITY GUARD (#8541, #8764) — the regression this
+      // suite exists to catch. The engine's system_win_condition /
+      // system_collectible / system_trigger_zone only fire on entries in
+      // runtime.active_collisions, which is populated ONLY from Rapier
+      // CollisionEvents — and Rapier colliders + ActiveEvents attach ONLY to
+      // entities with PhysicsEnabled (engine/src/core/physics.rs). So EVERY
+      // collision-driven entity (the Goal and every Coin) MUST have physics
+      // enabled as a static SENSOR, or the scaffold is structurally un-winnable
+      // and the coins never collect. Asserting only that the .type strings were
+      // set (collectible/winCondition) does NOT prove this — it passed on the
+      // broken code. We assert the actual togglePhysics + sensor physics calls.
+      for (const coin of ['id-Coin_0', 'id-Coin_1', 'id-Coin_2', 'id-Coin_3']) {
+        expect(store.togglePhysics).toHaveBeenCalledWith(coin, true);
+        const coinPhysics = (store.updatePhysics as ReturnType<typeof vi.fn>).mock.calls.find(
+          (c) => c[0] === coin,
+        );
+        expect(coinPhysics, `${coin} must have physics enabled to ever collect`).toBeDefined();
+        expect((coinPhysics?.[1] as { isSensor?: boolean })?.isSensor).toBe(true);
+      }
+
+      // Goal: physics enabled as a static sensor so reaching it can fire the win.
+      expect(store.togglePhysics).toHaveBeenCalledWith('id-Goal', true);
+      const goalPhysics = (store.updatePhysics as ReturnType<typeof vi.fn>).mock.calls.find(
+        (c) => c[0] === 'id-Goal',
+      );
+      expect(goalPhysics, 'Goal must have physics enabled to ever win').toBeDefined();
+      expect((goalPhysics?.[1] as { isSensor?: boolean })?.isSensor).toBe(true);
+      expect((goalPhysics?.[1] as { bodyType?: string })?.bodyType).toBe('fixed');
 
       // Goal carries exactly one win_condition.
       expect(store.addGameComponent).toHaveBeenCalledWith(

--- a/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
@@ -804,4 +804,181 @@ describe('compoundHandlers', () => {
       expect(data.appliedTo).toBe(0);
     });
   });
+
+  // ===========================================================================
+  // setup_game_from_description
+  // ===========================================================================
+
+  describe('setup_game_from_description', () => {
+    // createMockStore does NOT include setProjectType — every test must supply it
+    // (the handler calls it unconditionally and would throw on undefined).
+    function gameOverrides(extra: Record<string, unknown> = {}) {
+      return {
+        spawnEntity: vi.fn((_t: unknown, n: string) => `id-${n}`),
+        setProjectType: vi.fn(),
+        ...extra,
+      };
+    }
+
+    it('rejects an empty description with an Invalid arguments error', async () => {
+      const { result, store } = await invoke('setup_game_from_description', { description: '' }, gameOverrides());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      // No scaffolding happened — validation is the very first step.
+      expect(store.spawnEntity).not.toHaveBeenCalled();
+      expect(store.setProjectType).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing description', async () => {
+      const { result, store } = await invoke('setup_game_from_description', {}, gameOverrides());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(store.spawnEntity).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid targetTier enum', async () => {
+      const { result } = await invoke(
+        'setup_game_from_description',
+        { description: 'a game', targetTier: 'ultra' },
+        gameOverrides(),
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+    });
+
+    it('scaffolds a playable game in a fixed, ordered sequence', async () => {
+      const { result, store, dispatchCommand } = await invoke(
+        'setup_game_from_description',
+        { description: 'a platformer with 3 enemies and 4 coins' },
+        gameOverrides(),
+      );
+
+      expect(result.success).toBe(true);
+      const spawn = store.spawnEntity as ReturnType<typeof vi.fn>;
+      const spawnedNames = spawn.mock.calls.map((c) => c[1]);
+
+      // Deterministic naming: Ground, Player, Enemy_0..2, Coin_0..3, Goal.
+      expect(spawnedNames).toEqual([
+        'Ground',
+        'Player',
+        'Enemy_0',
+        'Enemy_1',
+        'Enemy_2',
+        'Coin_0',
+        'Coin_1',
+        'Coin_2',
+        'Coin_3',
+        'Goal',
+      ]);
+
+      // Ordering: project type is set BEFORE the first spawn.
+      const setProjectTypeOrder = (store.setProjectType as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0];
+      const firstSpawnOrder = spawn.mock.invocationCallOrder[0];
+      expect(setProjectTypeOrder).toBeLessThan(firstSpawnOrder);
+      expect(store.setProjectType).toHaveBeenCalledWith('3d');
+
+      // Player wiring: controller + health game components, dynamic physics.
+      expect(store.togglePhysics).toHaveBeenCalledWith('id-Player', true);
+      expect(store.addGameComponent).toHaveBeenCalledWith(
+        'id-Player',
+        expect.objectContaining({ type: 'characterController' }),
+      );
+
+      // Coins are collectibles with a trigger zone.
+      expect(store.addGameComponent).toHaveBeenCalledWith(
+        'id-Coin_0',
+        expect.objectContaining({ type: 'collectible' }),
+      );
+
+      // Goal carries exactly one win_condition.
+      expect(store.addGameComponent).toHaveBeenCalledWith(
+        'id-Goal',
+        expect.objectContaining({ type: 'winCondition' }),
+      );
+      const winCalls = (store.addGameComponent as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c) => (c[1] as { type?: string })?.type === 'winCondition',
+      );
+      expect(winCalls).toHaveLength(1);
+
+      // Input preset + camera-follow script targeting the player by id.
+      expect(store.setInputPreset).toHaveBeenCalledWith('platformer');
+      const scriptCall = (store.setScript as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(scriptCall[0]).toBe('id-Player');
+      expect(scriptCall[1]).toContain('forge.camera.setTarget("id-Player")');
+
+      // No generation requested → no generate_* dispatched.
+      expect(dispatchCommand).not.toHaveBeenCalled();
+      const data = result.result as Record<string, unknown>;
+      expect(data.generationJobs).toBe(0);
+    });
+
+    it('is deterministic — identical descriptions produce identical spawn sequences', async () => {
+      const a = await invoke(
+        'setup_game_from_description',
+        { description: '2 enemies, 3 coins' },
+        gameOverrides(),
+      );
+      const b = await invoke(
+        'setup_game_from_description',
+        { description: '2 enemies, 3 coins' },
+        gameOverrides(),
+      );
+
+      const namesA = (a.store.spawnEntity as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[1]);
+      const namesB = (b.store.spawnEntity as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[1]);
+      expect(namesA).toEqual(namesB);
+    });
+
+    it('plan-with-no-assets: omits all generate_* dispatch when targetTier is absent', async () => {
+      const { dispatchCommand, result } = await invoke(
+        'setup_game_from_description',
+        { description: 'a simple maze game' },
+        gameOverrides(),
+      );
+
+      expect(dispatchCommand).not.toHaveBeenCalled();
+      const data = result.result as Record<string, unknown>;
+      expect(data.generationJobs).toBe(0);
+    });
+
+    it('dispatches parallel generation jobs with targetEntityId when a targetTier is set', async () => {
+      const { dispatchCommand, result } = await invoke(
+        'setup_game_from_description',
+        { description: 'a shooter game', targetTier: 'high' },
+        gameOverrides(),
+      );
+
+      // generate_3d_model on the player, generate_texture on the goal, generate_music.
+      expect(dispatchCommand).toHaveBeenCalledWith(
+        'generate_3d_model',
+        expect.objectContaining({ targetEntityId: 'id-Player' }),
+      );
+      expect(dispatchCommand).toHaveBeenCalledWith(
+        'generate_texture',
+        expect.objectContaining({ targetEntityId: 'id-Goal' }),
+      );
+      expect(dispatchCommand).toHaveBeenCalledWith('generate_music', expect.any(Object));
+
+      const data = result.result as Record<string, unknown>;
+      expect(data.generationJobs).toBe(3);
+    });
+
+    it('picks the follower behavior for chase-type enemy descriptions', async () => {
+      const { store } = await invoke(
+        'setup_game_from_description',
+        { description: '1 enemy that will chase the player' },
+        gameOverrides(),
+      );
+
+      // The single enemy is a follower targeting the player id.
+      expect(store.addGameComponent).toHaveBeenCalledWith(
+        'id-Enemy_0',
+        expect.objectContaining({ type: 'follower' }),
+      );
+    });
+  });
 });

--- a/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
+++ b/web/src/lib/chat/handlers/__tests__/compoundHandlers.test.ts
@@ -4,7 +4,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createMockStore } from './handlerTestUtils';
 import { compoundHandlers } from '../compoundHandlers';
+import { generationHandlers } from '../generationHandlers';
 import type { ToolCallContext, ExecutionResult } from '../types';
+
+// Capture jobs registered by the REAL generate_texture handler so the compound
+// flow can be exercised end-to-end against the handler that actually consumes
+// the dispatched payload (rather than asserting only against a vi.fn mock).
+const mockAddJob = vi.fn();
+vi.mock('@/stores/generationStore', () => ({
+  useGenerationStore: { getState: () => ({ addJob: mockAddJob }) },
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -982,26 +991,62 @@ describe('compoundHandlers', () => {
       expect(data.generationJobs).toBe(0);
     });
 
-    it('dispatches parallel generation jobs with targetEntityId when a targetTier is set', async () => {
-      const { dispatchCommand, result } = await invoke(
+    it('dispatches parallel generation jobs keyed to the param each handler consumes', async () => {
+      const { dispatchCommand, store, result } = await invoke(
         'setup_game_from_description',
         { description: 'a shooter game', targetTier: 'high' },
         gameOverrides(),
       );
 
-      // generate_3d_model on the player, generate_texture on the goal, generate_music.
+      // generate_3d_model on the player (its handler consumes targetEntityId).
       expect(dispatchCommand).toHaveBeenCalledWith(
         'generate_3d_model',
         expect.objectContaining({ targetEntityId: 'id-Player' }),
       );
-      expect(dispatchCommand).toHaveBeenCalledWith(
-        'generate_texture',
-        expect.objectContaining({ targetEntityId: 'id-Goal' }),
-      );
+
+      // generate_texture on the goal. Its handler schema accepts ONLY `entityId`,
+      // so the goal id MUST ride under that key — under `targetEntityId` it is
+      // silently stripped by Zod and the texture never wires onto the goal.
+      const textureCall = dispatchCommand.mock.calls.find((c) => c[0] === 'generate_texture');
+      expect(textureCall, 'generate_texture must be dispatched').toBeDefined();
+      const texturePayload = textureCall![1] as Record<string, unknown>;
+      expect(texturePayload.entityId).toBe('id-Goal');
+      // Guard against regressing to the wrong key (the pre-fix contract).
+      expect(texturePayload).not.toHaveProperty('targetEntityId');
+
       expect(dispatchCommand).toHaveBeenCalledWith('generate_music', expect.any(Object));
 
       const data = result.result as Record<string, unknown>;
       expect(data.generationJobs).toBe(3);
+
+      // End-to-end: feed the EXACT dispatched payload into the REAL
+      // generate_texture handler and assert the goal id survives the handler's
+      // own schema + reaches the tracked job. This fails on the pre-fix payload
+      // ({ targetEntityId }) because Zod strips the unknown key before tracking.
+      mockAddJob.mockClear();
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ jobId: 'prov-1', provider: 'p', usageId: 'u-1' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      try {
+        const handlerCtx: ToolCallContext = {
+          store,
+          dispatchCommand: dispatchCommand as unknown as ToolCallContext['dispatchCommand'],
+        };
+        const handlerResult = await generationHandlers.generate_texture(texturePayload, handlerCtx);
+        expect(handlerResult.success).toBe(true);
+        // The POST body the handler sends carries the goal id under entityId.
+        const sentBody = JSON.parse((fetchSpy.mock.calls[0]![1] as RequestInit).body as string);
+        expect(sentBody.entityId).toBe('id-Goal');
+        // The tracked job records the goal as both entityId and targetEntityId.
+        expect(mockAddJob).toHaveBeenCalledWith(
+          expect.objectContaining({ entityId: 'id-Goal', targetEntityId: 'id-Goal' }),
+        );
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
 
     it('picks the follower behavior for chase-type enemy descriptions', async () => {

--- a/web/src/lib/chat/handlers/compoundHandlers.ts
+++ b/web/src/lib/chat/handlers/compoundHandlers.ts
@@ -1452,8 +1452,8 @@ export const compoundHandlers: Record<string, ToolHandler> = {
       operations.push({ action: 'attach camera-follow script', success: true });
     }
 
-    // (5) Win condition — attached to the goal entity. Score-based fallback so
-    // the game is winnable even before any trigger wiring.
+    // (5) Win condition — a reachGoal win_condition attached to the goal entity,
+    // pointing at the goal as its targetEntityId. Reaching the goal wins the game.
     if (goalId) {
       const winCondition = buildGameComponentFromInput('win_condition', {
         conditionType: 'reachGoal',
@@ -1466,9 +1466,11 @@ export const compoundHandlers: Record<string, ToolHandler> = {
     }
 
     // (6) OPTIONAL asset generation — only when a targetTier is requested.
-    // Dispatch parallel generate_* jobs with targetEntityId so #8540 auto-wires
-    // the completed assets back onto the scaffolded entities. The scaffold is
-    // fully playable before any of these land (deterministic + immediate).
+    // Dispatch parallel generate_* jobs targeting the scaffolded entity by the
+    // key each handler actually consumes (generate_3d_model: targetEntityId;
+    // generate_texture: entityId) so #8540 auto-wires the completed assets back
+    // onto them. The scaffold is fully playable before any of these land
+    // (deterministic + immediate).
     let generationJobs = 0;
     if (targetTier) {
       if (playerId) {
@@ -1479,9 +1481,13 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         generationJobs++;
       }
       if (goalId) {
+        // generate_texture's handler schema accepts `entityId` (NOT
+        // `targetEntityId`, which other generate_* handlers take); Zod strips
+        // the unknown key, so passing targetEntityId here is a silent no-op and
+        // the texture never wires back onto the goal entity.
         ctx.dispatchCommand('generate_texture', {
           prompt: `${description} goal marker texture`,
-          targetEntityId: goalId,
+          entityId: goalId,
         });
         generationJobs++;
       }

--- a/web/src/lib/chat/handlers/compoundHandlers.ts
+++ b/web/src/lib/chat/handlers/compoundHandlers.ts
@@ -1372,14 +1372,16 @@ export const compoundHandlers: Record<string, ToolHandler> = {
 
     // (3) Enemies — deterministic line layout. Chase-type enemies follow the
     // player (needs the player id, hence player spawns first); otherwise patrol
-    // via a moving_platform waypoint loop.
+    // via a moving_platform waypoint loop. If the player spawn failed (playerId
+    // is null), a 'follower' would get targetEntityId: null and chase nothing —
+    // so fall back to patrol, keeping enemies functional rather than inert.
     for (let i = 0; i < plan.enemyCount; i++) {
       const offset = (i - (plan.enemyCount - 1) / 2) * 3;
       spawn('cube', `Enemy_${i}`, (id) => {
         ctx.store.updateTransform(id, 'position', [offset, 1, 8]);
         ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [1, 0.2, 0.2, 1] }));
         const behavior =
-          plan.enemyBehavior === 'follower'
+          plan.enemyBehavior === 'follower' && playerId
             ? buildGameComponentFromInput('follower', { targetEntityId: playerId })
             : buildGameComponentFromInput('moving_platform', {
                 waypoints: [

--- a/web/src/lib/chat/handlers/compoundHandlers.ts
+++ b/web/src/lib/chat/handlers/compoundHandlers.ts
@@ -1,5 +1,5 @@
 /**
- * Compound action handlers — 8 multi-step AI compound tools that orchestrate
+ * Compound action handlers — 9 multi-step AI compound tools that orchestrate
  * multiple store mutations.
  *
  *   1. describe_scene
@@ -10,6 +10,7 @@
  *   6. setup_character
  *   7. configure_game_mechanics
  *   8. apply_style
+ *   9. setup_game_from_description
  */
 
 import type { ToolHandler, ExecutionResult } from './types';
@@ -21,6 +22,7 @@ import type {
   InputBinding,
   SceneNode,
 } from './types';
+import { parseArgs, zSetupGameFromDescription } from './types';
 import type { GameComponentData, PlatformLoopMode, WinConditionType } from '@/stores/editorStore';
 import { getPresetById } from '@/lib/materialPresets';
 import { buildEntityIndex, findEntityByName } from '@/lib/engine/entityIndex';
@@ -339,6 +341,92 @@ function buildGameComponentFromInput(
     default:
       return null;
   }
+}
+
+// ===== setup_game_from_description planner =====
+
+/**
+ * Deterministic, rule-based decomposition of a free-text game description into a
+ * fixed scene plan. This is intentionally NOT an LLM call: the acceptance
+ * criteria for setup_game_from_description require the scaffold to be
+ * reproducible and idempotent (the same description always yields the same
+ * entity counts/names/layout), and immediately playable before any generated
+ * asset lands. An LLM planner would add non-determinism, a network round-trip,
+ * cost, and a failure surface — so we parse counts/intent from the string and
+ * clamp to a playable layout instead.
+ *
+ * Counts are extracted via `<number> <noun>` matches (e.g. "5 coins", "3
+ * enemies") and clamped to a small range so a pathological description can't
+ * spawn thousands of entities. Genre is a soft hint that only nudges the input
+ * preset; the scaffold shape is identical regardless.
+ */
+type ProjectType = '2d' | '3d';
+
+interface GamePlan {
+  projectType: ProjectType;
+  inputPreset: 'fps' | 'platformer' | 'topdown' | 'racing';
+  enemyCount: number;
+  coinCount: number;
+  enemyBehavior: 'follower' | 'moving_platform';
+}
+
+function clampCount(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+/**
+ * Pluralize a base noun for matching: regular `+s`, and the `y→ies` case
+ * (enemy→enemies). Returns a regex alternation fragment.
+ */
+function nounPattern(noun: string): string {
+  if (noun.endsWith('y')) {
+    const stem = noun.slice(0, -1);
+    return `(?:${noun}|${stem}ies)`;
+  }
+  return `${noun}s?`;
+}
+
+/** Extract the count for the first matching noun, or a default. Deterministic. */
+function extractCount(text: string, nouns: string[], fallback: number): number {
+  for (const noun of nouns) {
+    // `<number> <noun>` — singular or plural. Word-boundary anchored.
+    const re = new RegExp(`(\\d{1,3})\\s+${nounPattern(noun)}\\b`, 'i');
+    const m = text.match(re);
+    if (m) return Number(m[1]);
+  }
+  return fallback;
+}
+
+function planGameFromDescription(
+  description: string,
+  genre: string | undefined,
+): GamePlan {
+  const text = `${description} ${genre ?? ''}`.toLowerCase();
+
+  // Input preset from genre/keywords. Defaults to platformer (the most broadly
+  // playable WASD+jump layout for the scaffolded primitives).
+  let inputPreset: GamePlan['inputPreset'] = 'platformer';
+  if (/\b(fps|shooter|first[- ]person)\b/.test(text)) inputPreset = 'fps';
+  else if (/\b(top[- ]?down|twin[- ]?stick|rogue)/.test(text)) inputPreset = 'topdown';
+  else if (/\b(racing|racer|kart|driving)\b/.test(text)) inputPreset = 'racing';
+  else if (/\b(platformer|jump|side[- ]?scroll)/.test(text)) inputPreset = 'platformer';
+
+  const projectType: ProjectType = /\b2d\b|side[- ]?scroll|pixel/.test(text) ? '2d' : '3d';
+
+  // Enemies that "chase/follow/hunt" the player use the follower component;
+  // everything else patrols via a moving_platform waypoint loop.
+  const enemyBehavior: GamePlan['enemyBehavior'] = /\b(chase|follow|hunt|seek|pursue)/.test(text)
+    ? 'follower'
+    : 'moving_platform';
+
+  return {
+    projectType,
+    inputPreset,
+    enemyCount: clampCount(extractCount(text, ['enemy', 'monster', 'foe'], 2), 0, 20),
+    coinCount: clampCount(extractCount(text, ['coin', 'gem', 'collectible', 'pickup', 'star'], 5), 0, 50),
+    enemyBehavior,
+  };
 }
 
 // ===== Handler Registry =====
@@ -1205,6 +1293,189 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         appliedTo: targets.length,
         operations: results,
         summary: `Applied style to ${targets.length} entities with ${successCount} operations.`,
+      },
+    };
+  },
+
+  setup_game_from_description: async (args, ctx): Promise<ExecutionResult> => {
+    const parsed = parseArgs(zSetupGameFromDescription, args);
+    if (parsed.error) return parsed.error;
+    const { description, genre, targetTier } = parsed.data;
+
+    const plan = planGameFromDescription(description, genre);
+    const operations: Array<{ action: string; success: boolean; entityId?: string; error?: string }> = [];
+    const nameToId: Record<string, string> = {};
+
+    // Deterministic spawn helper: spawn by type/name, capture the returned id
+    // (the #8748 fix — never read ctx.store.primaryId after a spawn), record the
+    // op, and run an optional configuration callback. Returns the id or null.
+    const spawn = (
+      type: EntityType,
+      name: string,
+      configure?: (id: string) => void,
+    ): string | null => {
+      try {
+        const id = ctx.store.spawnEntity(type, name);
+        if (!id) {
+          operations.push({ action: `spawn "${name}"`, success: false, error: 'spawn failed' });
+          return null;
+        }
+        nameToId[name] = id;
+        configure?.(id);
+        operations.push({ action: `spawn "${name}"`, success: true, entityId: id });
+        return id;
+      } catch (err) {
+        operations.push({
+          action: `spawn "${name}"`,
+          success: false,
+          error: err instanceof Error ? err.message : 'spawn failed',
+        });
+        return null;
+      }
+    };
+
+    // (1) Project type (2d vs 3d) — drives camera/rendering defaults.
+    ctx.store.setProjectType(plan.projectType);
+    operations.push({ action: `set project type "${plan.projectType}"`, success: true });
+
+    // (2) Environment: a directional skybox + ambient light so the scaffold is
+    // visible immediately. Deterministic — no randomness.
+    ctx.store.setSkybox('day');
+    ctx.store.updateAmbientLight({ color: [1, 1, 1], brightness: 1 });
+    operations.push({ action: 'set environment (skybox + ambient)', success: true });
+
+    // (3) Ground plane — fixed body so the player has something to stand on.
+    spawn('plane', 'Ground', (id) => {
+      ctx.store.updateTransform(id, 'scale', [10, 1, 10]);
+      ctx.store.togglePhysics(id, true);
+      ctx.store.updatePhysics(id, buildPhysicsFromPartial({ bodyType: 'fixed' }));
+    });
+
+    // (3) Player — capsule with dynamic physics, character controller, health.
+    const playerId = spawn('capsule', 'Player', (id) => {
+      ctx.store.updateTransform(id, 'position', [0, 1, 0]);
+      ctx.store.togglePhysics(id, true);
+      ctx.store.updatePhysics(
+        id,
+        buildPhysicsFromPartial({
+          bodyType: 'dynamic',
+          colliderShape: 'capsule',
+          lockRotationX: true,
+          lockRotationZ: true,
+        }),
+      );
+      const controller = buildGameComponentFromInput('character_controller', {});
+      if (controller) ctx.store.addGameComponent(id, controller);
+      const health = buildGameComponentFromInput('health', {});
+      if (health) ctx.store.addGameComponent(id, health);
+    });
+
+    // (3) Enemies — deterministic line layout. Chase-type enemies follow the
+    // player (needs the player id, hence player spawns first); otherwise patrol
+    // via a moving_platform waypoint loop.
+    for (let i = 0; i < plan.enemyCount; i++) {
+      const offset = (i - (plan.enemyCount - 1) / 2) * 3;
+      spawn('cube', `Enemy_${i}`, (id) => {
+        ctx.store.updateTransform(id, 'position', [offset, 1, 8]);
+        ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [1, 0.2, 0.2, 1] }));
+        const behavior =
+          plan.enemyBehavior === 'follower'
+            ? buildGameComponentFromInput('follower', { targetEntityId: playerId })
+            : buildGameComponentFromInput('moving_platform', {
+                waypoints: [
+                  [offset, 1, 8],
+                  [offset, 1, 4],
+                ],
+              });
+        if (behavior) ctx.store.addGameComponent(id, behavior);
+      });
+    }
+
+    // (3) Coins — deterministic line layout, each a collectible trigger zone.
+    for (let i = 0; i < plan.coinCount; i++) {
+      const offset = (i - (plan.coinCount - 1) / 2) * 2;
+      spawn('sphere', `Coin_${i}`, (id) => {
+        ctx.store.updateTransform(id, 'position', [offset, 1, 4]);
+        ctx.store.updateTransform(id, 'scale', [0.4, 0.4, 0.4]);
+        ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [1, 0.9, 0, 1], unlit: true }));
+        const collectible = buildGameComponentFromInput('collectible', { value: 1 });
+        if (collectible) ctx.store.addGameComponent(id, collectible);
+        const trigger = buildGameComponentFromInput('trigger_zone', { eventName: 'coin_collected' });
+        if (trigger) ctx.store.addGameComponent(id, trigger);
+      });
+    }
+
+    // (3) Goal — the win marker. Carries the win_condition component itself so
+    // the engine-side once-guard (runtime.game_won) owns win firing. We attach
+    // exactly ONE win_condition and emit NO script-side forge.game.win() — that
+    // would double-fire the win event (see win-event gotcha).
+    const goalId = spawn('sphere', 'Goal', (id) => {
+      ctx.store.updateTransform(id, 'position', [0, 1, 12]);
+      ctx.store.updateTransform(id, 'scale', [0.6, 0.6, 0.6]);
+      ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [0.2, 1, 0.4, 1], unlit: true }));
+      const trigger = buildGameComponentFromInput('trigger_zone', {
+        eventName: 'goal_reached',
+        oneShot: true,
+      });
+      if (trigger) ctx.store.addGameComponent(id, trigger);
+    });
+
+    // (4) Input preset + camera-follow script targeting the player by id.
+    ctx.store.setInputPreset(plan.inputPreset);
+    operations.push({ action: `set input preset "${plan.inputPreset}"`, success: true });
+    if (playerId) {
+      ctx.store.setScript(playerId, `forge.camera.setTarget("${playerId}");`, true);
+      operations.push({ action: 'attach camera-follow script', success: true });
+    }
+
+    // (5) Win condition — attached to the goal entity. Score-based fallback so
+    // the game is winnable even before any trigger wiring.
+    if (goalId) {
+      const winCondition = buildGameComponentFromInput('win_condition', {
+        conditionType: 'reachGoal',
+        targetEntityId: goalId,
+      });
+      if (winCondition) {
+        ctx.store.addGameComponent(goalId, winCondition);
+        operations.push({ action: 'attach win condition', success: true });
+      }
+    }
+
+    // (6) OPTIONAL asset generation — only when a targetTier is requested.
+    // Dispatch parallel generate_* jobs with targetEntityId so #8540 auto-wires
+    // the completed assets back onto the scaffolded entities. The scaffold is
+    // fully playable before any of these land (deterministic + immediate).
+    let generationJobs = 0;
+    if (targetTier) {
+      if (playerId) {
+        ctx.dispatchCommand('generate_3d_model', {
+          prompt: `${description} player character`,
+          targetEntityId: playerId,
+        });
+        generationJobs++;
+      }
+      if (goalId) {
+        ctx.dispatchCommand('generate_texture', {
+          prompt: `${description} goal marker texture`,
+          targetEntityId: goalId,
+        });
+        generationJobs++;
+      }
+      ctx.dispatchCommand('generate_music', { prompt: `${description} background music` });
+      generationJobs++;
+      operations.push({ action: `dispatch ${generationJobs} generation job(s)`, success: true });
+    }
+
+    const successCount = operations.filter((op) => op.success).length;
+    const allOk = successCount === operations.length;
+    return {
+      success: allOk,
+      result: {
+        ...buildCompoundResult(operations, nameToId),
+        plan,
+        generationJobs,
+        playerId,
+        goalId,
       },
     };
   },

--- a/web/src/lib/chat/handlers/compoundHandlers.ts
+++ b/web/src/lib/chat/handlers/compoundHandlers.ts
@@ -1398,6 +1398,18 @@ export const compoundHandlers: Record<string, ToolHandler> = {
         ctx.store.updateTransform(id, 'position', [offset, 1, 4]);
         ctx.store.updateTransform(id, 'scale', [0.4, 0.4, 0.4]);
         ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [1, 0.9, 0, 1], unlit: true }));
+        // Physics is REQUIRED for the collectible/trigger paths to fire. The
+        // engine attaches a Rapier collider + ActiveEvents (and so populates
+        // runtime.active_collisions from CollisionEvents) ONLY to entities with
+        // PhysicsEnabled (engine/src/core/physics.rs). A collider-less coin emits
+        // zero collision events → system_collectible/system_trigger_zone never
+        // run → coins never collect. A static SENSOR body lets the dynamic Player
+        // pass through it while still generating the collision pair. (#8541/#8764)
+        ctx.store.togglePhysics(id, true);
+        ctx.store.updatePhysics(
+          id,
+          buildPhysicsFromPartial({ bodyType: 'fixed', isSensor: true }),
+        );
         const collectible = buildGameComponentFromInput('collectible', { value: 1 });
         if (collectible) ctx.store.addGameComponent(id, collectible);
         const trigger = buildGameComponentFromInput('trigger_zone', { eventName: 'coin_collected' });
@@ -1413,6 +1425,18 @@ export const compoundHandlers: Record<string, ToolHandler> = {
       ctx.store.updateTransform(id, 'position', [0, 1, 12]);
       ctx.store.updateTransform(id, 'scale', [0.6, 0.6, 0.6]);
       ctx.store.updateMaterial(id, buildMaterialFromPartial({ baseColor: [0.2, 1, 0.4, 1], unlit: true }));
+      // Physics is REQUIRED for the win path to fire. system_win_condition reads
+      // runtime.active_collisions, which the engine populates ONLY from Rapier
+      // CollisionEvents — and Rapier colliders + ActiveEvents are attached ONLY
+      // to entities with PhysicsEnabled (engine/src/core/physics.rs). A
+      // collider-less Goal produces zero collision events → reaching it never
+      // wins (the exact #8764 break). A static SENSOR body lets the dynamic
+      // Player overlap it while still generating the collision pair. (#8541)
+      ctx.store.togglePhysics(id, true);
+      ctx.store.updatePhysics(
+        id,
+        buildPhysicsFromPartial({ bodyType: 'fixed', isSensor: true }),
+      );
       const trigger = buildGameComponentFromInput('trigger_zone', {
         eventName: 'goal_reached',
         oneShot: true,

--- a/web/src/lib/chat/handlers/types.ts
+++ b/web/src/lib/chat/handlers/types.ts
@@ -53,6 +53,19 @@ export const zGizmoMode = z.enum(['translate', 'rotate', 'scale']);
 export const zCameraPreset = z.enum(['top', 'front', 'right', 'perspective']);
 
 /**
+ * Args for the `setup_game_from_description` compound tool. A plain-text
+ * description deterministically scaffolds a playable game (player + enemies +
+ * coins + goal + ground + lighting + input + win condition). `genre` is an
+ * optional hint; `targetTier` opts into parallel `generate_*` asset jobs that
+ * auto-wire back onto the scaffolded entities (#8540).
+ */
+export const zSetupGameFromDescription = z.object({
+  description: z.string().min(1),
+  genre: z.string().optional(),
+  targetTier: z.enum(['low', 'mid', 'high']).optional(),
+});
+
+/**
  * Validate handler args with a Zod schema. Returns parsed data or an error result.
  */
 export function parseArgs<T>(


### PR DESCRIPTION
## Summary

Adds the `setup_game_from_description` compound chat tool that deterministically scaffolds a complete, **immediately-playable** game from a plain-text description — project type, environment, a player with controller + health, enemies, collectible coins, a goal with a win condition, ground, an input preset, and a camera-follow script — with optional parallel asset generation.

### Why
This is the backbone of the "describe a game, get a playable game" flow. The scaffold is structurally winnable by construction: the goal and every coin get physics-enabled static **sensors**, so Rapier emits the collision events `system_win_condition` reads (the engine path, not a script `forge.game.win()` — avoiding the double-fire win-event gotcha).

### Fix included (review-board finding)
- The compound handler dispatches `generate_texture` with `{ entityId: goalId }` — the key `generate_texture`'s schema actually accepts. (Its sibling `generate_3d_model` accepts `targetEntityId`; the compound caller now matches each handler's real contract instead of passing a key Zod would silently strip.)
- The win-condition comment was corrected to accurately describe the sensor-physics + once-guard requirement.

### Tests
- `compoundHandlers.test.ts`: routes the exact dispatched texture payload through the **real** `generate_texture` handler (fetch + `addJob` mocked) — asserting the goal id survives Zod and reaches the tracked job, plus a negative guard that the wrong key is absent. Also asserts the winnability invariant via the actual `togglePhysics` + sensor calls, not just `.type` strings. Validation paths (empty/missing/invalid-enum) covered.

### Docs / manifest
- `README.md` handler table + header count, and both manifest copies (`mcp-server/manifest/commands.json` and `web/src/data/commands.json`) updated in sync.

Closes #8541

## Test plan
- [x] `cd web && npx vitest run src/lib/chat/handlers/__tests__/compoundHandlers.test.ts` — 55/55 green; reverting the dispatch key → the key test fails
- [x] `npx eslint --max-warnings 0` + `npx tsc --noEmit` on touched files — clean
- [x] Manifest copies in sync (`apps/docs` check-manifest-sync)
- [x] 5-specialist review board (architecture/security/dx/ux/test) — all PASS
