### PR TITLE
ci: scope Release workflow concurrency per-job to stop transient failure notifications

### DIFF
--- a/.changeset/release-version-job-concurrency.md
+++ b/.changeset/release-version-job-concurrency.md
@@ -1,0 +1,7 @@
+---
+"web": patch
+---
+
+ci: scope the Release workflow's concurrency per-job so a rapid batch-merge no longer fires transient "Run Failed" notifications.
+
+The `Version Packages` job now uses `cancel-in-progress: true` (it is idempotent — it only recreates `changeset-release/main` from current main — so only the latest run is needed), while `Tag and Release` keeps `cancel-in-progress: false` so a version's git tag / GitHub Release is never cancelled mid-publish. Previously a single workflow-level `cancel-in-progress: false` ran every push in a batch to completion, multiplying the chance of the benign "No commits between main and changeset-release/main" error (when a version PR merges with no newer changesets) and `@changesets/get-github-info` GraphQL flakes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,26 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+# Concurrency is scoped per-job rather than workflow-wide:
+#   • Version Packages is idempotent — it only recreates changeset-release/main
+#     from the current state of main — so a rapid batch-merge needs just the
+#     LATEST run; earlier ones cancel (cancel-in-progress: true). This collapses
+#     a pile-up of pushes into one run and avoids the transient failure
+#     notifications ("No commits between main and changeset-release/main" when a
+#     version PR merges with no newer changesets queued, and GraphQL flakes in
+#     @changesets/get-github-info) that fire when many Release runs stack up.
+#   • Tag and Release must NEVER be cancelled mid-publish, or a version's git tag
+#     / GitHub Release could be silently skipped, so it serializes WITHOUT
+#     cancellation (cancel-in-progress: false). It is also idempotent (it checks
+#     for an existing tag/release first), so serializing is purely a safety net.
 
 jobs:
   release:
     name: Version Packages
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-version-packages-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -39,6 +51,9 @@ jobs:
   tag-release:
     name: Tag and Release
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-tag-release-${{ github.ref }}
+      cancel-in-progress: false
     # Detect the Version Packages commit. Uses startsWith to handle squash merges
     # that append the PR number (e.g. "chore: version packages (#123)").
     # head_commit.message is safe here — used in an `if:` expression, not a shell command.


### PR DESCRIPTION
## Summary
- The `Release` workflow runs on every push to `main`. During a rapid batch-merge it fires spurious "Run Failed" notifications because a single **workflow-level** `concurrency` with `cancel-in-progress: false` ran every push to completion, multiplying two benign-but-noisy failure modes: the `changesets/action` "No commits between main and changeset-release/main" empty-PR error, and transient `@changesets/get-github-info` GraphQL "Premature close" flakes. Neither breaks the release itself.
- Scope concurrency **per-job** instead:
  - `Version Packages` → `cancel-in-progress: true` — idempotent (only recreates `changeset-release/main` from current main), so a batch collapses to one run.
  - `Tag and Release` → `cancel-in-progress: false` — never cancellable mid-publish; also guards on an existing tag/release.

## Why this is safe
The two jobs sit in independent concurrency groups. Cancelling an intermediate `Version Packages` run cannot affect `Tag and Release`, which is gated on the `chore: version packages` commit message, checks out its own commit (no cross-job data dependency), and is idempotent. Reviewed and confirmed by the security and infra review board.

Closes #8848

## Test plan
- [x] `actionlint` clean on `release.yml`
- [x] YAML parses; both `concurrency` blocks at job scope (verified via `yaml.safe_load`)
- [x] No `run:`-shell interpolation of the new contexts (concurrency groups use `github.workflow`/`github.ref` in a YAML key only)
- [ ] Observe: next batch-merge produces at most one surviving `Version Packages` run; `Tag and Release` still tags each version-packages merge