### PR TITLE
ci: retry changeset version to silence transient Release 'Run Failed' notifications

### DIFF
--- a/.changeset/changeset-version-graphql-retry.md
+++ b/.changeset/changeset-version-graphql-retry.md
@@ -1,0 +1,7 @@
+---
+"web": patch
+---
+
+ci: retry `changeset version` in the Release workflow so a transient GitHub GraphQL flake no longer fires a spurious "Run Failed" notification.
+
+The changelog generator (`@changesets/changelog-github`) fetches PR/author info from the GitHub GraphQL API per changeset; under load that request intermittently fails with `Invalid response body ... Premature close`, aborting the Version Packages job even though the release itself is unaffected. The `changeset:version` npm script now runs `scripts/changeset-version.sh`, which retries `changeset version` (changesets applies no files on that error, so a re-run is idempotent) before relocking — keeping the changelog's PR links while making the step resilient to the flake. Complements the per-job concurrency fix in #8849.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "changeset": "changeset",
-    "changeset:version": "changeset version && npm install --package-lock-only",
+    "changeset:version": "bash scripts/changeset-version.sh",
     "changeset:publish": "changeset publish"
   },
   "devDependencies": {

--- a/scripts/__tests__/changeset-version.test.sh
+++ b/scripts/__tests__/changeset-version.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/changeset-version.sh — the retry wrapper behind the
+# `changeset:version` npm script invoked by the Release workflow.
+#
+# The wrapper retries `changeset version` (which intermittently aborts on a
+# transient GitHub GraphQL flake during @changesets/changelog-github changelog
+# generation) before relocking the root lockfile. The boundary logic this suite
+# pins — exact attempt count, exit NON-ZERO after exhaustion, and crucially NOT
+# relocking when `changeset version` never succeeds — is exactly the kind of
+# silent exit-code bug the repo's "every scripts/ entry gets a co-located
+# *.test.sh" convention exists to catch.
+#
+# It drives the REAL script in a throwaway sandbox: a stub
+# ./node_modules/.bin/changeset that fails a configurable number of times then
+# succeeds, a stub `npm` on PATH that records whether (and how) the relock ran,
+# and a stub `sleep` so the backoff is instant. Then it asserts on the exit
+# code, the changeset call count, and the relock invocation.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../changeset-version.sh"
+NPM_ARGS_OUT="$(mktemp)"
+FAILURES=0
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+
+# Assert actual == expected without the `A && B || C` footgun (SC2015).
+check() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    pass "$desc"
+  else
+    fail "$desc — expected '$expected', got '$actual'"
+  fi
+}
+
+[ -f "$SCRIPT" ] || { echo "script not found: $SCRIPT"; exit 1; }
+
+# Run the real script in a sandbox. Args: <fail_count> <attempts>.
+# The changeset stub exits 1 for its first <fail_count> calls, then 0.
+# Echoes one line: "<exit_code> <changeset_calls> <npm_called: yes|no>" and
+# copies the npm stub's recorded args to $NPM_ARGS_OUT for inspection.
+run_case() {
+  local fail_count="$1" attempts="$2"
+  local dir; dir="$(mktemp -d)"
+  mkdir -p "$dir/node_modules/.bin" "$dir/fakebin"
+
+  cat > "$dir/node_modules/.bin/changeset" <<EOF
+#!/usr/bin/env bash
+calls_file="$dir/changeset.calls"
+n=\$(( \$(cat "\$calls_file" 2>/dev/null || echo 0) + 1 ))
+echo "\$n" > "\$calls_file"
+if [ "\$n" -le $fail_count ]; then
+  echo "stub changeset: simulated GraphQL flake (attempt \$n)" >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "$dir/node_modules/.bin/changeset"
+
+  cat > "$dir/fakebin/npm" <<EOF
+#!/usr/bin/env bash
+echo "\$*" > "$dir/npm.args"
+exit 0
+EOF
+  chmod +x "$dir/fakebin/npm"
+
+  # Instant backoff so the suite does not actually wait 5/10/15s.
+  cat > "$dir/fakebin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$dir/fakebin/sleep"
+
+  local exit_code
+  ( cd "$dir" && PATH="$dir/fakebin:$PATH" CHANGESET_VERSION_ATTEMPTS="$attempts" \
+      bash "$SCRIPT" >/dev/null 2>&1 )
+  exit_code=$?
+
+  local calls npm_called
+  calls="$(cat "$dir/changeset.calls" 2>/dev/null || echo 0)"
+  if [ -f "$dir/npm.args" ]; then npm_called="yes"; else npm_called="no"; fi
+  cp "$dir/npm.args" "$NPM_ARGS_OUT" 2>/dev/null || : > "$NPM_ARGS_OUT"
+
+  echo "$exit_code $calls $npm_called"
+  rm -rf "$dir"
+}
+
+echo "=== changeset-version.sh retry-wrapper tests ==="
+
+# 1. Every attempt fails → exit non-zero, called exactly $attempts times, and
+#    the relock must NOT run (we never produced a valid version bump).
+read -r ec calls npm_called <<< "$(run_case 9 2)"
+check "all-fail: exits non-zero" "1" "$ec"
+check "all-fail: retried exactly 2 times" "2" "$calls"
+check "all-fail: relock NOT run on failure" "no" "$npm_called"
+
+# 2. Succeeds on the first attempt → exit 0, called once (no needless retry),
+#    relock run with --package-lock-only.
+read -r ec calls npm_called <<< "$(run_case 0 4)"
+check "success: exits 0" "0" "$ec"
+check "success: called once" "1" "$calls"
+check "success: relock run" "yes" "$npm_called"
+if grep -q -- "--package-lock-only" "$NPM_ARGS_OUT"; then
+  pass "success: relock used --package-lock-only"
+else
+  fail "success: relock missing --package-lock-only (got: $(cat "$NPM_ARGS_OUT"))"
+fi
+
+# 3. Fails once, then succeeds → exit 0, called twice, relock run. Proves the
+#    retry actually recovers the transient flake rather than just masking it.
+read -r ec calls npm_called <<< "$(run_case 1 4)"
+check "retry-then-succeed: exits 0" "0" "$ec"
+check "retry-then-succeed: called twice" "2" "$calls"
+check "retry-then-succeed: relock run" "yes" "$npm_called"
+
+rm -f "$NPM_ARGS_OUT"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "$FAILURES test(s) failed."
+  exit 1
+fi

--- a/scripts/changeset-version.sh
+++ b/scripts/changeset-version.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Wraps `changeset version` with bounded retries, then relocks the root
+# package-lock.json. This is the command behind the `changeset:version` npm
+# script, invoked only by the Release workflow's changesets/action step.
+#
+# Why retries: the changelog generator (@changesets/changelog-github, set in
+# .changeset/config.json) makes a GitHub GraphQL request PER changeset to enrich
+# each CHANGELOG entry with PR/author links. Under load that request
+# intermittently fails with:
+#   error Failed to parse data from GitHub
+#   error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
+# which aborts `changeset version` (exit 1) and fails the Release run, firing a
+# spurious "Run Failed" notification even though the release itself is unaffected.
+#
+# Why a retry is safe: on that error changesets escapes and applies NO files
+# ("We have escaped applying the changesets, and no files should have been
+# affected"), so the changeset files are untouched and re-running is idempotent.
+# A second attempt almost always succeeds once the transient GraphQL blip clears.
+#
+# This keeps the GitHub changelog links (vs. dropping changelog-github for the
+# network-free default) while making the step resilient to the flake.
+set -euo pipefail
+
+attempts="${CHANGESET_VERSION_ATTEMPTS:-4}"
+changeset_bin="./node_modules/.bin/changeset"
+
+for attempt in $(seq 1 "$attempts"); do
+  if "$changeset_bin" version; then
+    break
+  fi
+  if [ "$attempt" -eq "$attempts" ]; then
+    echo "::error::changeset version failed after ${attempts} attempts" >&2
+    exit 1
+  fi
+  delay=$((attempt * 5))
+  echo "::warning::changeset version attempt ${attempt}/${attempts} failed (likely a transient GitHub GraphQL flake); retrying in ${delay}s" >&2
+  sleep "$delay"
+done
+
+npm install --package-lock-only

--- a/scripts/changeset-version.sh
+++ b/scripts/changeset-version.sh
@@ -20,7 +20,16 @@
 #
 # This keeps the GitHub changelog links (vs. dropping changelog-github for the
 # network-free default) while making the step resilient to the flake.
+#
+# ESCAPE HATCH: set CHANGESET_VERSION_ATTEMPTS=N to override the default 4
+# attempts — e.g. `CHANGESET_VERSION_ATTEMPTS=1 npm run changeset:version` to
+# fail fast when reproducing a non-transient changeset error locally.
 set -euo pipefail
+
+# Resolve to the repo root so `./node_modules/.bin/changeset` and the relock
+# work regardless of the caller's cwd (npm already runs us from root; this makes
+# a manual `bash scripts/changeset-version.sh` from a subdir behave too).
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 attempts="${CHANGESET_VERSION_ATTEMPTS:-4}"
 changeset_bin="./node_modules/.bin/changeset"
@@ -30,7 +39,7 @@ for attempt in $(seq 1 "$attempts"); do
     break
   fi
   if [ "$attempt" -eq "$attempts" ]; then
-    echo "::error::changeset version failed after ${attempts} attempts" >&2
+    echo "::error::changeset version failed after ${attempts} attempts (see the changesets output above for the underlying error)" >&2
     exit 1
   fi
   delay=$((attempt * 5))


### PR DESCRIPTION
## Summary

The `Release` workflow keeps firing spurious "Run Failed" notifications on `main`. The per-job concurrency fix (#8849) cut the *number* of runs but not the per-run failure: each surviving Version Packages run intermittently aborts on a transient GitHub GraphQL flake during changelog generation.

`changeset version` invokes `@changesets/changelog-github` (set in `.changeset/config.json`), which makes a GitHub GraphQL request **per changeset** to enrich CHANGELOG entries with PR/author links. Under batch-merge load that request intermittently fails with:

```
error Failed to parse data from GitHub
error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
```

That aborts `changeset version` (exit 1) and fails the run — even though the release itself is unaffected (v0.3.0 published fine via `Tag and Release`).

## Fix

`changeset:version` now runs `scripts/changeset-version.sh`, which wraps `changeset version` in a bounded retry (4 attempts, 5/10/15s backoff) before relocking. The retry is safe: on that error changesets escapes and applies **no** files (verified against `@changesets/apply-release-plan` — the GraphQL call precedes every disk write), so a re-run is idempotent. This keeps the changelog's PR links (vs. dropping `changelog-github` for the network-free default) while making the step resilient to the flake. Complements the per-job concurrency fix in #8849.

- `scripts/changeset-version.sh` — retry wrapper; `cd`s to repo root, documents the `CHANGESET_VERSION_ATTEMPTS` escape hatch, points the exhaustion error at the changesets output.
- `scripts/__tests__/changeset-version.test.sh` — co-located unit test (repo convention) driving the real script through stubs: all-fail (relock NOT run), success-on-first (relock with `--package-lock-only`), retry-then-succeed.

Closes #8848

## Test plan
- [x] `bash scripts/__tests__/changeset-version.test.sh` — 10/10 pass
- [x] `shellcheck scripts/changeset-version.sh scripts/__tests__/changeset-version.test.sh` — clean
- [x] Lockfile Sync unaffected (scripts-field-only edit, no dependency change)
- [x] 5-reviewer board: security, infra-devops, code-reviewer, dx-guardian, validator — all PASS