### PR TITLE
chore(ai): bump premium/deep tier to Opus 4.8

### DIFF
--- a/.changeset/opus-4-8-premium-tier.md
+++ b/.changeset/opus-4-8-premium-tier.md
@@ -1,0 +1,9 @@
+---
+"web": minor
+---
+
+ai: bump the premium/deep model tier from Opus 4.7 to Opus 4.8.
+
+`AI_MODEL_PREMIUM` / `GATEWAY_MODEL_PREMIUM` (and the `AI_MODEL_DEEP` / `GATEWAY_MODEL_DEEP` aliases that follow them) now resolve to `claude-opus-4-8`, so the premium chat path and the deep-generation tier (GDD, world builder, cutscene — gated behind `NEXT_PUBLIC_USE_DEEP_GENERATION`) route to Opus 4.8. Same `$5/$25` per-1M pricing and 1M context as 4.7; no API or env changes.
+
+Also updates the Vercel AI Gateway `MODEL_MAP` key so the gateway premium lookup resolves the new id (a stale key would have silently downgraded the premium path to Sonnet *after* billing at the premium tier).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ cd web && npm run db:push              # Push schema to Neon (dev only)
 Required: `.env.local` with `DATABASE_URL`, `CLERK_SECRET_KEY`, `STRIPE_SECRET_KEY`, `UPSTASH_REDIS_REST_URL`.
 
 Optional feature flags (all default off):
-- `NEXT_PUBLIC_USE_DEEP_GENERATION=true` — route GDD, world builder, and cutscene generators to Opus 4.7 (`AI_MODEL_DEEP`) instead of Sonnet 4.6. See `docs/decisions/2026-05-01-opus-deep-tier.md`. Any value other than the exact string `"true"` leaves the flag off.
+- `NEXT_PUBLIC_USE_DEEP_GENERATION=true` — route GDD, world builder, and cutscene generators to Opus 4.8 (`AI_MODEL_DEEP`) instead of Sonnet 4.6. See `docs/decisions/2026-05-01-opus-deep-tier.md`. Any value other than the exact string `"true"` leaves the flag off.
 
 ## Key Architecture Rules
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -122,7 +122,7 @@ UPSTASH_REDIS_REST_TOKEN=xxx
 
 # -----------------------------------------------------------------------------
 # AI Deep-Generation Tier — optional, default off
-# Routes GDD, world builder, and cutscene generators to Opus 4.7 (AI_MODEL_DEEP)
+# Routes GDD, world builder, and cutscene generators to Opus 4.8 (AI_MODEL_DEEP)
 # when set to exactly "true". Any other value (including "1", "on") keeps the
 # primary tier (Sonnet 4.6). See docs/decisions/2026-05-01-opus-deep-tier.md.
 # Safe to expose client-side: only toggles which model string is sent to

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -62,14 +62,14 @@ vi.mock('@/lib/chat/docContext', () => ({
 vi.mock('@/lib/ai/models', () => ({
   AI_MODEL_PRIMARY: 'claude-sonnet-4-6',
   AI_MODEL_FAST: 'claude-haiku-4-5-20251001',
-  AI_MODEL_PREMIUM: 'claude-opus-4-7',
+  AI_MODEL_PREMIUM: 'claude-opus-4-8',
   GATEWAY_MODEL_CHAT: 'anthropic/claude-sonnet-4-6',
   GATEWAY_MODEL_FAST: 'anthropic/claude-haiku-4-5',
-  GATEWAY_MODEL_PREMIUM: 'anthropic/claude-opus-4-7',
+  GATEWAY_MODEL_PREMIUM: 'anthropic/claude-opus-4-8',
   isPremiumModel: vi.fn((model: string | undefined | null) => {
     if (!model) return false;
     const bare = model.includes('/') ? model.split('/').slice(1).join('/') : model;
-    return bare === 'claude-opus-4-7';
+    return bare === 'claude-opus-4-8';
   }),
 }));
 
@@ -878,7 +878,7 @@ describe('POST /api/chat', () => {
       } as never);
 
       const res = await POST(
-        makeRequest({ ...validBody(), model: 'claude-opus-4-7' }),
+        makeRequest({ ...validBody(), model: 'claude-opus-4-8' }),
       );
       expect(res.status).toBe(403);
       const body = await res.json();
@@ -897,7 +897,7 @@ describe('POST /api/chat', () => {
       } as never);
 
       const res = await POST(
-        makeRequest({ ...validBody(), model: 'anthropic/claude-opus-4-7' }),
+        makeRequest({ ...validBody(), model: 'anthropic/claude-opus-4-8' }),
       );
       expect(res.status).toBe(403);
       expect(createSpawnforgeAgent).not.toHaveBeenCalled();
@@ -911,11 +911,11 @@ describe('POST /api/chat', () => {
       } as never);
 
       const res = await POST(
-        makeRequest({ ...validBody(), model: 'claude-opus-4-7' }),
+        makeRequest({ ...validBody(), model: 'claude-opus-4-8' }),
       );
       await res.text();
       expect(createSpawnforgeAgent).toHaveBeenCalledWith(
-        expect.objectContaining({ model: 'claude-opus-4-7' }),
+        expect.objectContaining({ model: 'claude-opus-4-8' }),
       );
     });
 

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -336,13 +336,13 @@ export async function POST(request: NextRequest) {
     return Response.json({ error: 'messages array required' }, { status: 400 });
   }
 
-  // Premium model gate: claude-opus-4-7 is restricted to Pro tier. Reject
+  // Premium model gate: claude-opus-4-8 is restricted to Pro tier. Reject
   // before billing so non-Pro users requesting premium are not charged the
   // estimated cost. The gate only blocks the model — it does not silently
   // downgrade, so the client gets an explicit signal to update its UI.
   if (isPremiumModel(model) && auth.ctx.user.tier !== 'pro') {
     return Response.json(
-      { error: 'The premium model (Opus 4.7) requires a Pro subscription.' },
+      { error: 'The premium model (Opus 4.8) requires a Pro subscription.' },
       { status: 403 },
     );
   }
@@ -568,7 +568,7 @@ export async function POST(request: NextRequest) {
   // Tier gate: thinking mode (10k extra tokens per step) restricted to creator/pro,
   // consistent with the systemOverride gate. Prevents amplified token burn on free tiers.
   const canUseThinking = auth.ctx.user.tier === 'creator' || auth.ctx.user.tier === 'pro';
-  // Use the route's translated modelId (e.g. 'anthropic/claude-opus-4-7' for
+  // Use the route's translated modelId (e.g. 'anthropic/claude-opus-4-8' for
   // the gateway) when available, falling back to the bare canonical model.
   // Without this, the gateway path silently downgrades unmapped premium IDs to
   // Sonnet inside createSpawnforgeAgent — but billing already deducted at the

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -18,7 +18,7 @@ interface ModelOption {
 const MODEL_OPTIONS: ModelOption[] = [
   { value: AI_MODEL_PRIMARY, label: 'Sonnet 4.5' },
   { value: AI_MODEL_FAST, label: 'Haiku 4.5' },
-  { value: AI_MODEL_PREMIUM, label: 'Opus 4.7 (Pro)', requiresPro: true },
+  { value: AI_MODEL_PREMIUM, label: 'Opus 4.8 (Pro)', requiresPro: true },
 ];
 
 export function ChatInput() {

--- a/web/src/lib/ai/__tests__/aiSdkAdapter.test.ts
+++ b/web/src/lib/ai/__tests__/aiSdkAdapter.test.ts
@@ -33,9 +33,9 @@ vi.mock('@/lib/ai/models', () => ({
   AI_MODELS: {
     chat: 'claude-sonnet-4.5',
     fast: 'claude-haiku-4-5',
-    deep: 'claude-opus-4-7',
+    deep: 'claude-opus-4-8',
     gatewayChat: 'anthropic/claude-sonnet-4.6',
-    gatewayDeep: 'anthropic/claude-opus-4-7',
+    gatewayDeep: 'anthropic/claude-opus-4-8',
   },
 }));
 
@@ -454,12 +454,12 @@ describe('streamViaSdk — provider selection', () => {
     expect(anthropic).not.toHaveBeenCalled();
   });
 
-  it('routes Opus deep-tier model through gateway as anthropic/claude-opus-4-7', async () => {
+  it('routes Opus deep-tier model through gateway as anthropic/claude-opus-4-8', async () => {
     await collectEvents(
-      streamViaSdk(gatewayRoute, simpleMessages, { model: 'claude-opus-4-7' }),
+      streamViaSdk(gatewayRoute, simpleMessages, { model: 'claude-opus-4-8' }),
     );
 
-    expect(gateway).toHaveBeenCalledWith('anthropic/claude-opus-4-7');
+    expect(gateway).toHaveBeenCalledWith('anthropic/claude-opus-4-8');
     expect(anthropic).not.toHaveBeenCalled();
   });
 

--- a/web/src/lib/ai/deepTier.ts
+++ b/web/src/lib/ai/deepTier.ts
@@ -1,7 +1,7 @@
 /**
  * Deep-generation tier helpers.
  *
- * Gate the Opus 4.7 quality tier behind a feature flag so rollout can be
+ * Gate the Opus 4.8 quality tier behind a feature flag so rollout can be
  * canaried without a deploy. When `NEXT_PUBLIC_USE_DEEP_GENERATION=true`,
  * deep-generation surfaces (GDD, world builder, cutscenes) route to
  * AI_MODEL_DEEP. Otherwise they fall back to AI_MODEL_PRIMARY.

--- a/web/src/lib/ai/models.ts
+++ b/web/src/lib/ai/models.ts
@@ -30,14 +30,14 @@ export const AI_MODEL_FAST = 'claude-haiku-4-5-20251001';
  * in the chat body). The chat route enforces the gate at request time so
  * lower tiers cannot self-promote by passing this string.
  */
-export const AI_MODEL_PREMIUM = 'claude-opus-4-7';
+export const AI_MODEL_PREMIUM = 'claude-opus-4-8';
 
 /**
  * Deep model for highest-quality single-shot generations where latency
  * is secondary to output fidelity (GDD authoring, world building, cutscenes).
  * Routed via the feature flag helper in `deepTier.ts`. Falls back to
  * AI_MODEL_PRIMARY when the flag is off. Aliases AI_MODEL_PREMIUM — same
- * Opus 4.7 model, separate semantic role (deep generators vs. user request).
+ * Opus 4.8 model, separate semantic role (deep generators vs. user request).
  */
 export const AI_MODEL_DEEP = AI_MODEL_PREMIUM;
 
@@ -52,7 +52,7 @@ export const GATEWAY_MODEL_CHAT = 'anthropic/claude-sonnet-4-6' as const;
 export const GATEWAY_MODEL_FAST = 'anthropic/claude-haiku-4-5' as const;
 
 /** Premium chat model via Vercel AI Gateway (Pro tier only) */
-export const GATEWAY_MODEL_PREMIUM = 'anthropic/claude-opus-4-7' as const;
+export const GATEWAY_MODEL_PREMIUM = 'anthropic/claude-opus-4-8' as const;
 
 /** Deep chat model via Vercel AI Gateway — alias of GATEWAY_MODEL_PREMIUM */
 export const GATEWAY_MODEL_DEEP = GATEWAY_MODEL_PREMIUM;
@@ -72,7 +72,7 @@ export const AI_MODELS = {
   chat: AI_MODEL_PRIMARY,
   /** Fast/cheap model — reviews, quick analysis, behavior trees */
   fast: AI_MODEL_FAST,
-  /** Premium model — Pro tier only, highest quality (Opus 4.7) */
+  /** Premium model — Pro tier only, highest quality (Opus 4.8) */
   premium: AI_MODEL_PREMIUM,
   /** Deep model — highest-quality generation for GDD, world building, cutscenes */
   deep: AI_MODEL_DEEP,
@@ -97,8 +97,8 @@ export type AiModelKey = keyof typeof AI_MODELS;
 /**
  * True when the model identifier names a premium-tier (Pro-only) model.
  *
- * Accepts both bare canonical IDs (`claude-opus-4-7`) and gateway-format
- * IDs (`anthropic/claude-opus-4-7`). Compares against a known set rather
+ * Accepts both bare canonical IDs (`claude-opus-4-8`) and gateway-format
+ * IDs (`anthropic/claude-opus-4-8`). Compares against a known set rather
  * than a substring so future Opus minor revisions must be opted in
  * explicitly — prevents accidental routing of new models that might be
  * priced differently.

--- a/web/src/lib/providers/backends/__tests__/vercelGateway.test.ts
+++ b/web/src/lib/providers/backends/__tests__/vercelGateway.test.ts
@@ -101,10 +101,10 @@ describe('vercelGatewayBackend', () => {
     it('maps premium and fast Anthropic models so they do not silently downgrade', async () => {
       // Regression for PR #8508 Sentry CRITICAL: missing entries here would
       // cause the gateway to fall back to DEFAULT_MODELS.chat (Sonnet) for
-      // Pro users requesting the premium model — billed for Opus 4.7 but
+      // Pro users requesting the premium model — billed for Opus 4.8 but
       // routed to Sonnet 4.6.
       const { vercelGatewayBackend } = await import('@/lib/providers/backends/vercelGateway');
-      expect(vercelGatewayBackend.resolveModelId('claude-opus-4-7')).toBe('anthropic/claude-opus-4-7');
+      expect(vercelGatewayBackend.resolveModelId('claude-opus-4-8')).toBe('anthropic/claude-opus-4-8');
       expect(vercelGatewayBackend.resolveModelId('claude-haiku-4-5')).toBe('anthropic/claude-haiku-4-5');
       expect(vercelGatewayBackend.resolveModelId('claude-haiku-4-5-20251001')).toBe('anthropic/claude-haiku-4-5');
     });

--- a/web/src/lib/providers/backends/vercelGateway.ts
+++ b/web/src/lib/providers/backends/vercelGateway.ts
@@ -25,7 +25,7 @@ const MODEL_MAP: Record<string, string> = {
   // tier by the time we reach the agent factory.
   'claude-sonnet-4-6': 'anthropic/claude-sonnet-4-6',
   'claude-opus-4': 'anthropic/claude-opus-4',
-  'claude-opus-4-7': 'anthropic/claude-opus-4-7',
+  'claude-opus-4-8': 'anthropic/claude-opus-4-8',
   'claude-haiku-3-5': 'anthropic/claude-haiku-3-5',
   'claude-haiku-4-5': 'anthropic/claude-haiku-4-5',
   'claude-haiku-4-5-20251001': 'anthropic/claude-haiku-4-5',


### PR DESCRIPTION
## Summary
- Bump the premium/deep model tier from Opus 4.7 → **Opus 4.8** (`AI_MODEL_PREMIUM` / `GATEWAY_MODEL_PREMIUM`, plus the `AI_MODEL_DEEP` / `GATEWAY_MODEL_DEEP` aliases that follow them). This covers the premium chat path and the deep-generation tier (GDD, world builder, cutscene — gated behind `NEXT_PUBLIC_USE_DEEP_GENERATION`).
- **Gateway fix (caught in review, beyond the original scope):** update the Vercel AI Gateway `MODEL_MAP` key so the gateway premium lookup resolves `claude-opus-4-8`. A stale key would have missed the map and **silently downgraded the premium path to Sonnet _after_ billing at the premium tier** — the map's own comment documents exactly this failure mode.
- Refresh the 3 affected test suites and every stale "Opus 4.7" reference in product comments, `web/.env.example`, `CLAUDE.md`, and the model-picker label.

Same `$5/$25` per-1M pricing and 1M context as 4.7. **No** API, package.json, or lockfile changes. Sampling-param audit confirmed clean: no premium/deep generation path sets `temperature`/`top_p`/`top_k` (which Opus 4.x rejects with HTTP 400); the only non-default `temperature` in the AI tree runs on Haiku, not Opus.

Closes #8857

## Test plan
- [x] `tsc --noEmit` — clean (whole project)
- [x] `vitest run` on `models` / `aiSdkAdapter` / `vercelGateway` / `chat route` suites — green
- [x] `eslint --max-warnings 0` on all 8 touched source/test files — zero warnings