### PR TITLE
ci: bump actions/upload-artifact v4 → v7 (off deprecated Node20)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -344,7 +344,7 @@ jobs:
         run: wasm-bindgen --target web --out-dir pkg-webgpu-runtime target/wasm32-unknown-unknown/release/forge_engine.wasm
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wasm-binaries
           path: |
@@ -415,7 +415,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: web/playwright-report/
@@ -423,7 +423,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-results
           path: web/test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -965,7 +965,7 @@ jobs:
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: blob-report-${{ strategy.job-index }}
           path: web/blob-report/
@@ -1044,7 +1044,7 @@ jobs:
 
       - name: Upload journey report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-journey-report
           path: web/playwright-report/
@@ -1165,7 +1165,7 @@ jobs:
 
       - name: Upload engine-smoke report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-engine-smoke-report
           path: web/playwright-report/
@@ -1205,7 +1205,7 @@ jobs:
         run: npx playwright merge-reports --reporter=html ./all-blob-reports
 
       - name: Upload merged report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-report
           path: web/playwright-report/

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
           path: web/coverage/
@@ -376,7 +376,7 @@ jobs:
           exit $FAILED
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wasm-binaries
           path: |


### PR DESCRIPTION
## Summary
- Bump all **9** hand-written `actions/upload-artifact` pins (`cd.yml` ×3, `ci.yml` ×4, `quality-gates.yml` ×2) from **v4.6.2** (`ea165f8`, deprecated **Node20** runtime) to **v7.0.1** (`043fb46d`, **Node24**).
- **`download-artifact` deliberately stays at v8.** The artifact format is stable across v4+, so the two actions need not share a major — the tree already runs `download@v8` + `upload@v4`. The only real constraint is keeping both off the Node20 runtime (removed from runners fall 2026), which this satisfies. (This retires the stale "must match @v4" rule, already corrected in `CLAUDE.md`.)

## Why
`upload-artifact@v4` runs on the deprecated Node20 runtime; GitHub-hosted runners default to Node24 (since 2026-06-16) and Node20 is slated for removal. Tracked in #8854.

## Compatibility (v4 → v7)
Drop-in for our usage — verified against the upstream release notes:
- **v5**: Node24 support only, no input changes.
- **v6**: Node24 default + runner floor ≥ 2.327.1 (GitHub-hosted `ubuntu-latest` already meets it).
- **v7**: adds an *optional* `archive` param that **defaults to the existing zip behavior**, plus internal ESM. No inputs removed or changed.

Our steps only use `name` / `path` / `retention-days`, all unchanged. The new v7 SHA matches what the gh-aw `*.lock.yml` files already pin independently.

Closes #8854

## Test plan
- [x] `scripts/check-actions-pinned.sh` — green (all actions SHA-pinned; new SHA is 40-hex with `# v7` comment)
- [x] All three workflows parse as valid YAML
- [x] `git diff` = exactly 9 changed lines across the 3 files; `download-artifact` untouched
- [x] No CI gate **wiring** touched (job names / `needs` / `if` / `permissions` / `CI Success` aggregate unchanged — only `uses:` SHA values)