### PR TITLE
chore(deps): deps wave 2026-06-27 (stripe 22.3 + sentry 10.62 Logs scrubber, posthog/vitest/playwright)

### DIFF
--- a/.changeset/deps-wave-2026-06-27.md
+++ b/.changeset/deps-wave-2026-06-27.md
@@ -1,0 +1,12 @@
+---
+"web": patch
+---
+
+deps: routine dependency wave (2026-06-27 changelog review).
+
+- `stripe` 22.2.3 → 22.3.0 — the SDK rolls its pinned `ApiVersion` literal to `2026-06-24.dahlia`, so the hardcoded literal in `stripe-client.ts` (and the billing route tests / webhook comment) moves in lockstep. Prevents a silent `tsc` break on the next relock.
+- `@sentry/nextjs` 10.59 → 10.62 — pins `streamGenAiSpans: false` and `enableTruncation: true` on the AI integrations so the 10.61 default flips don't newly stream untruncated `gen_ai` spans (span-volume/cost stays flat; opting in is a deliberate observability decision).
+- Security (Boy-Scout, surfaced reviewing the Sentry bump): all three `Sentry.init` configs set `enableLogs: true`, which routes `Sentry.logger.*` through a separate `beforeSendLog` pipeline that the existing `scrubSentryEvent` (wired only to `beforeSend`/`beforeSendTransaction`) never touched — a stray log could ship a prompt / BYOK key / PII unredacted. Added `scrubSentryLog` (reuses the same `scrubString`/`deepScrub` redaction core) and wired `beforeSendLog: scrubSentryLog` in server, edge, and client configs, with a regression guard tying `enableLogs: true` to the scrubber. It also handles two `@sentry/core` quirks: `logger.fmt` messages are boxed `String` objects shipped via `String(message)` after the hook (scrubbed via the rendered body), and the scope `username` is flattened into a `user.name` attribute that the key regex misses (`user.name`/`user.username` redacted explicitly, `user.id` kept for correlation).
+- `posthog-js` 1.392 → 1.395, `@playwright/test` 1.61.0 → 1.61.1, and the `vitest` floor `^4.1.8 → ^4.1.9` (already resolved at 4.1.9) — routine drop-in bug-fix bumps.
+
+`@clerk/nextjs` 7.5.9 is intentionally **not** in this wave: it is override-pinned in the root `package.json` alongside `@clerk/shared ^4.14.0`, and 7.5.9 pulls `@clerk/shared 4.22.0`, so bumping clerk without coordinating the shared/backend/react override subtree corrupts lockfile resolution. It needs a dedicated upgrade PR.

--- a/.claude/rules/gotchas.md
+++ b/.claude/rules/gotchas.md
@@ -88,7 +88,7 @@ These are lower-frequency gotchas moved from CLAUDE.md. The most common ones rem
 - **Schema changes need migrations** — `db:push` works in dev but production needs `ALTER TABLE`.
 - **IV/crypto changes need migration path** — Changing parameters breaks existing stored data.
 - **`experimental.sri` is incompatible with Vercel CDN** — Do NOT re-enable.
-- **Stripe v22 API version** — On `22.2.0`, API version `2026-05-27.dahlia` (the SDK pins its `ApiVersion` literal; `apiVersion` in `stripe-client.ts` MUST match the installed SDK or tsc fails). No `decimal_string` fields used — all amounts are integer cents. When bumping `stripe`, update the literal in `stripe-client.ts` + the 3 billing route tests (status/portal/checkout) + the webhook `route.ts` comment.
+- **Stripe v22 API version** — On `22.3.0`, API version `2026-06-24.dahlia` (the SDK pins its `ApiVersion` literal; `apiVersion` in `stripe-client.ts` MUST match the installed SDK or tsc fails). No `decimal_string` fields used — all amounts are integer cents. When bumping `stripe`, update the literal in `stripe-client.ts` + the 3 billing route tests (status/portal/checkout) + the webhook `route.ts` comment.
 - **Max 5-7 fixes per builder dispatch** — Agents rushing through 25+ lists introduce anti-patterns.
 - **GraphQL rate limit exhaustion** — Use `gh issue list` (REST) for sync, not `gh project item-list` (GraphQL).
 - **Taskboard `localProjectId` drifts** — Verify sync config against `curl http://localhost:3010/api/projects`.

--- a/.claude/skills/capability-review/references/capability-map.md
+++ b/.claude/skills/capability-review/references/capability-map.md
@@ -81,7 +81,7 @@ Per-provider inventory for `capability-review`. For each provider: the **changel
 ### Stripe — `stripe`
 - Releases: https://github.com/stripe/stripe-node/releases · API changelog: https://docs.stripe.com/changelog
 - Pricing: https://stripe.com/pricing (+ Tax, Radar, Billing as separate line items)
-- We currently wire: Checkout, subscriptions (4 tiers), webhooks, atomic-CTE refunds, customer portal. SDK `22.x`, API `2026-05-27.dahlia` (pinned literal in `stripe-client.ts`).
+- We currently wire: Checkout, subscriptions (4 tiers), webhooks, atomic-CTE refunds, customer portal. SDK `22.x`, API `2026-06-24.dahlia` (pinned literal in `stripe-client.ts`).
 - Opportunity surface: **Billing meters / usage-based** (token overage billing), Tax, Radar (fraud), entitlements API, adaptive pricing, portal config.
 - Grep markers: `stripe.checkout`, `stripe.subscriptions`, `stripe.billing.meters` / `billing/meters`, `stripe.tax` / `automatic_tax`, `radar`, `entitlements`.
 

--- a/.claude/skills/changelog-review/SKILL.md
+++ b/.claude/skills/changelog-review/SKILL.md
@@ -21,8 +21,8 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 | System | Changelog Source | Current Version |
 |--------|-----------------|-----------------|
 | Vercel Platform | https://vercel.com/changelog | N/A (platform) |
-| Sentry | https://github.com/getsentry/sentry-javascript/releases | @sentry/nextjs ^10.48.0 |
-| PostHog | https://github.com/PostHog/posthog-js/releases | posthog-js ^1.367.0 |
+| Sentry | https://github.com/getsentry/sentry-javascript/releases | @sentry/nextjs ^10.62.0 |
+| PostHog | https://github.com/PostHog/posthog-js/releases | posthog-js ^1.395.0 |
 | Anthropic (Claude API) | https://docs.anthropic.com/en/docs/about-claude/models | AI SDK provider |
 | Cloudflare | https://developers.cloudflare.com/changelog/ | R2 + Workers |
 | Upstash | https://github.com/upstash/redis-js/releases | @upstash/redis ^1.37.0 |
@@ -36,7 +36,7 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 |---------|-----------------|-----------------|
 | Next.js | https://github.com/vercel/next.js/releases | ^16.2.3 |
 | Clerk | https://github.com/clerk/javascript/releases | @clerk/nextjs ^7.0.12 |
-| Stripe | https://github.com/stripe/stripe-node/releases | stripe ^22.0.1 |
+| Stripe | https://github.com/stripe/stripe-node/releases | stripe ^22.3.0 |
 | AI SDK | https://github.com/vercel/ai/releases | ai ^6.0.158 |
 | Drizzle ORM | https://github.com/drizzle-team/drizzle-orm/releases | drizzle-orm 0.45.2 |
 | Neon Serverless | https://github.com/neondatabase/serverless/releases | @neondatabase/serverless ^1.0.2 |
@@ -48,8 +48,8 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 | Library | Changelog Source | Current Version |
 |---------|-----------------|-----------------|
 | TypeScript | https://github.com/microsoft/TypeScript/releases | typescript ^6 |
-| Vitest | https://github.com/vitest-dev/vitest/releases | vitest ^4.1.4 |
-| Playwright | https://github.com/microsoft/playwright/releases | @playwright/test ^1.59.1 |
+| Vitest | https://github.com/vitest-dev/vitest/releases | vitest ^4.1.9 |
+| Playwright | https://github.com/microsoft/playwright/releases | @playwright/test ^1.61.1 |
 | ESLint | https://github.com/eslint/eslint/releases | eslint ^9 |
 | Tailwind CSS | https://github.com/tailwindlabs/tailwindcss/releases | tailwindcss ^4 |
 | Turborepo | https://github.com/vercel/turborepo/releases | turbo ^2.5.4 |
@@ -186,4 +186,4 @@ GitHub is a primary dependency (CI/CD, issue tracking, PR workflows, CLI). Check
 
 ## References
 
-- See [version-pins.md](references/version-pins.md) — Documents all version pins with the upgrade blockers: stripe ^20.4.1, wasm-bindgen =0.2.108, Next.js 16.x, Bevy 0.18, upload/download-artifact v4. Includes an upgrade decision matrix and pre-upgrade audit checklists for each pinned dependency
+- See [version-pins.md](references/version-pins.md) — Documents all version pins with the upgrade blockers: stripe ^22.3.0, wasm-bindgen =0.2.108, Next.js 16.x, Bevy 0.18, upload/download-artifact v4. Includes an upgrade decision matrix and pre-upgrade audit checklists for each pinned dependency

--- a/.claude/skills/changelog-review/references/version-pins.md
+++ b/.claude/skills/changelog-review/references/version-pins.md
@@ -6,9 +6,11 @@ Documenting why specific dependencies are pinned and what must be audited before
 
 ## JavaScript / Node
 
-### stripe — `22.0.1`, API version `2026-03-25.dahlia`
+### stripe — `22.3.0`, API version `2026-06-24.dahlia`
 
-**Upgraded from** `^20.4.1` in PR #8136. v21 `decimal_string` changes and v22 callback/ES6 class changes were non-issues — all amounts use integer cents, no callbacks, ESM imports.
+**Upgraded from** `^20.4.1` in PR #8136 (v21 `decimal_string` and v22 callback/ES6-class changes were non-issues — all amounts use integer cents, no callbacks, ESM imports). Bumped `22.2.x → 22.3.0` in the 2026-06-27 changelog-review wave.
+
+**ApiVersion moves in lockstep with the SDK.** stripe-node pins an `ApiVersion` literal (`22.3.0` → `2026-06-24.dahlia`); the hardcoded string must stay in sync across FIVE sites. Four are code, where a mismatch breaks `tsc`: `web/src/lib/billing/stripe-client.ts` (single source) plus the 3 billing route tests (`checkout`/`portal`/`status`). The fifth is the `web/src/app/api/stripe/webhook/route.ts` comment — it must track the literal but does not affect compilation.
 
 **Before future upgrades:**
 1. Check for new `apiVersion` string — update `web/src/lib/billing/stripe-client.ts` (single source)
@@ -82,13 +84,13 @@ Documenting why specific dependencies are pinned and what must be audited before
 
 | Dependency | Current | Upgrade Risk | Recommended Action |
 |-----------|---------|-------------|-------------------|
-| `stripe` | 22.0.1 | LOW | Centralized in `stripe-client.ts`, check apiVersion string |
+| `stripe` | 22.3.0 | LOW | Centralized in `stripe-client.ts`, check apiVersion string |
 | `wasm-bindgen` | =0.2.108 | HIGH (CLI must match) | Only upgrade as a coordinated Rust+CLI change |
 | `next` | 16.x | MEDIUM | Check migration guide, test E2E |
 | `bevy` | 0.18 | HIGH (API churn) | Only on planned engine upgrade sprint |
 | `@clerk/nextjs` | ^7.0.12 | LOW-MEDIUM | Check for auth() API changes |
 | `drizzle-orm` | 0.45.2 | LOW | Check migration query syntax |
-| `vitest` | ^4.1.4 | LOW | Check for workspace config changes |
+| `vitest` | ^4.1.9 | LOW | Check for workspace config changes |
 | `zod` | ^4.3.6 | LOW | Already on v4 |
 
 ---

--- a/.claude/skills/changelog-review/scripts/check-deps.sh
+++ b/.claude/skills/changelog-review/scripts/check-deps.sh
@@ -79,7 +79,7 @@ done
 
 echo ""
 echo "--- Notes ---"
-echo "  'stripe' is pinned at ^20.4.1 — v21 has breaking changes (see references/version-pins.md)"
+echo "  'stripe' is on ^22.3.0 (API version 2026-06-24.dahlia) — the SDK pins its ApiVersion literal, so any major/minor bump must update apiVersion in stripe-client.ts + the 3 billing route tests + the webhook route comment (see references/version-pins.md)"
 echo "  'wasm-bindgen' Rust dep is pinned at =0.2.108 — cannot upgrade without full WASM rebuild"
 echo "  'next' upgrades may require E2E test updates for hydration dialog selectors"
 echo ""

--- a/.claude/skills/stripe-webhooks/SKILL.md
+++ b/.claude/skills/stripe-webhooks/SKILL.md
@@ -31,4 +31,4 @@ neon-http driver throws. Use `getNeonSql()` → `neonSql.transaction([...stateme
 ## References
 - `web/src/app/api/stripe/webhook/route.ts` — the live webhook handler implementing the patterns above
 - `web/src/lib/tokens/service.ts` — `refundTokens()` idempotency + balance deduction
-- Stripe API version is pinned to `2026-05-27.dahlia` in `web/src/lib/billing/stripe-client.ts` (must match the installed SDK)
+- Stripe API version is pinned to `2026-06-24.dahlia` in `web/src/lib/billing/stripe-client.ts` (must match the installed SDK)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4359,13 +4359,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4382,18 +4382,18 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.36.0.tgz",
-      "integrity": "sha512-ZZA1AgSVDpk+S1y+HBqzQwavMoJk/mJ050TYqj9BpcH3lw6Pxcb9cjN4PobAjtGIIAyFirKNU249vnj4Q3rgXg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.38.0.tgz",
+      "integrity": "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "^1.391.0"
+        "@posthog/types": "^1.391.1"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.391.0",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.0.tgz",
-      "integrity": "sha512-oJ6jkqVMq+T4ax9F0rUllJc0KHpSgpaMwTNYWkE70iBiyXDVyhcNBmYnNKzSODgpzsaQNI6VfK8JrRYbkSJZZw==",
+      "version": "1.391.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.391.1.tgz",
+      "integrity": "sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==",
       "license": "MIT"
     },
     "node_modules/@project-forge/mcp-server": {
@@ -5541,28 +5541,28 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.60.0.tgz",
-      "integrity": "sha512-20vzPKGrmupJPCaWd+soCOLkZRwKZxt0AVF4XGPNoGp7D7wVPRlHf+FWwVMx+rRRkahKupFefM2D9YoiUiBeag==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.62.0.tgz",
+      "integrity": "sha512-uJi0yPssB3Nt/cZ8/S8opW42gaM59/6IyNtPFYD7C0ciudi/nIo5QMVpCYBBI3jnKFOIQLlsMT4pDlOLuxxNuQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.60.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/feedback": "10.60.0",
-        "@sentry/replay": "10.60.0",
-        "@sentry/replay-canvas": "10.60.0"
+        "@sentry/browser-utils": "10.62.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/feedback": "10.62.0",
+        "@sentry/replay": "10.62.0",
+        "@sentry/replay-canvas": "10.62.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.60.0.tgz",
-      "integrity": "sha512-YhdPeMJnMaKVi5NQ2tD9RJ2AxU7cav5khmiMHFppmbP3I3Os2EHVaQjAVb6/ePAINr/d5mj5SxpnWmFX17iXsg==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.62.0.tgz",
+      "integrity": "sha512-mS9HVVuWIdye9o0xUGFmzNOBqktF4n5kugrF8NCOYYDrr5ZV8Cx7BlquHQn5UpCeViVhZtcDlEm4iOK7++Px7A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.60.0"
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
@@ -5834,42 +5834,42 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.60.0.tgz",
-      "integrity": "sha512-szN7ccOJAEaLb1BBQzCQhABGMTJmKNUk0G2sc7rWhajeXoZoMKIbNkI9RvJrFuV69cbad/d/BKGBjbpJhySAzw==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.62.0.tgz",
+      "integrity": "sha512-tV69fMg2sS5DUFmQSnS7Jd5qJAp0izxwcsvBVz2ieTM9VMRi99IfOSYW9UYr3p1yfuksk41kefN5PEbeedUE+A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.60.0.tgz",
-      "integrity": "sha512-RcGUgaI8yrIXunhNLpdNLsBUJIDvnEGDRmFhC5v0oMltoGtovrIqrEhPXEiSWQvNB0x4q33ejkLeJRJoSDOp2w==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.62.0.tgz",
+      "integrity": "sha512-d0BVjJVny6qpBgGJgWL0fbcoQHjtD3z3R8EK/KzTS3RO92JX5n3A536n5D/rh0gZFgcIwiUzBXegmyPOSQn9ng==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.60.0"
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.60.0.tgz",
-      "integrity": "sha512-7QModZzPQ6UpNeLaqZfCm2v/nNaR+9za+YkQ/t5Hj6gOZTmac+UUFcDpzSMsL1/WyuIL4pVYLv4p2Ti4BqQsnQ==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.62.0.tgz",
+      "integrity": "sha512-JyxKNruI/yx8/YoxR/MG0IYg/zPBY9LSeUUbWPWN4jPFOD9e5/cQh4GtdY6tFWcWl2262PS7me8mbTH0J2jjzg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry/browser-utils": "10.60.0",
+        "@sentry/browser-utils": "10.62.0",
         "@sentry/bundler-plugin-core": "^5.3.0",
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/node": "10.60.0",
-        "@sentry/opentelemetry": "10.60.0",
-        "@sentry/react": "10.60.0",
-        "@sentry/vercel-edge": "10.60.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/node": "10.62.0",
+        "@sentry/opentelemetry": "10.62.0",
+        "@sentry/react": "10.62.0",
+        "@sentry/vercel-edge": "10.62.0",
         "@sentry/webpack-plugin": "^5.3.0",
         "rollup": "^4.60.3",
         "stacktrace-parser": "^0.1.11"
@@ -6251,19 +6251,19 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.60.0.tgz",
-      "integrity": "sha512-u//paUrkKaCr0oNn7r7UulGydkYMSkU1wQOIpG/P/jf7psZWnyXhgeszHzUfZXo6pCdxXG9z9viPvzGjqPQN7A==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.62.0.tgz",
+      "integrity": "sha512-4hoU67bJY0o3irEDMZu2UIztAOsvEqFkLXA7EUKl1LXMA3Ba1Lb32OUVqlsTypiEInSDs/BtM+aAFKojZ3P3Fw==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/node-core": "10.60.0",
-        "@sentry/opentelemetry": "10.60.0",
-        "@sentry/server-utils": "10.60.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/node-core": "10.62.0",
+        "@sentry/opentelemetry": "10.62.0",
+        "@sentry/server-utils": "10.62.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6271,14 +6271,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.60.0.tgz",
-      "integrity": "sha512-aXi9ixvP+hgUZPPZCRwMNHgY2I0gkSeoAKAUuysDJhWDmrygwfGdlkbGmmtW6PQjtMYFx69Igt5btvhjEBoJTw==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.62.0.tgz",
+      "integrity": "sha512-V7rDgbxViiHU0OpcFEDp3l41IFvWTasKHfXw8SQ6yIgtZ8VpFqmz2TR5N7X85iIOmWIvK5HV0yp0eDdsly0+rA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0",
-        "@sentry/opentelemetry": "10.60.0",
+        "@sentry/core": "10.62.0",
+        "@sentry/opentelemetry": "10.62.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6310,13 +6310,13 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.60.0.tgz",
-      "integrity": "sha512-gl+2NVH+9RmTu7pd9kV1tKif+Th+p9tmnXR1l3Sb3Wqo1ir5FaNMKrloWEKMXjnepii9EJUrEHdSC+i8NoexxQ==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.62.0.tgz",
+      "integrity": "sha512-nFwBgtjfwgY8P5lAuQFWfAsQW1MXxuQ6kR/HtBs+A6julqwGGS2QnQ65OCWMzz6IqDEL/pRgT1405/gU+OXU3A==",
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0"
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
@@ -6328,13 +6328,13 @@
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.60.0.tgz",
-      "integrity": "sha512-ALRIDOj7T1Vk9t9IyI12Tq2t3MKoV2F/mKn140AiUBk3WzQhq2gXQUFpcsaDYA2FBsrYoYc6qdqrny6mMbA0Xg==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.62.0.tgz",
+      "integrity": "sha512-PChimVpY0wzs3H/hJqyl87/ITTHwIZWTSY68QoENZyLnp7DvLcFiZYub/gFws1pzDPhtIQXVLU72fbmUjT5PSg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.60.0",
-        "@sentry/core": "10.60.0"
+        "@sentry/browser": "10.62.0",
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
@@ -6344,42 +6344,42 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.60.0.tgz",
-      "integrity": "sha512-j+w774BP1p+v/ga1hJAJSn0cXgTiB2VWwQCAxukF7AEXscny/OCXzTTsaPxdovw9kDHI641vKV+/yixLV2nKIQ==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.62.0.tgz",
+      "integrity": "sha512-rWp4hBhZOmdQhisxcKzAwTGiRk/LvWnNaElWe7nbRhjsM/usp2095yfjq4iJ47v9MtO7xxY6eUz++fLBycqXKg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.60.0",
-        "@sentry/core": "10.60.0"
+        "@sentry/browser-utils": "10.62.0",
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.60.0.tgz",
-      "integrity": "sha512-mYyQRJbhRRaqUkRvkJZyqt9AWdomh4108LOAph1YJvV1jW7tKYPPFNAUveJd7YkYCyhUOtekN0DKNJveK802qA==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.62.0.tgz",
+      "integrity": "sha512-CzPAxmpe5US/ABGA1TzpjFKOFZN5uqlzrRh/uM9/daVuzLVKIAQ0XRNxo/PPEXvlDm/PoMdI5L0qIODuIKnyyw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.60.0",
-        "@sentry/replay": "10.60.0"
+        "@sentry/core": "10.62.0",
+        "@sentry/replay": "10.62.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.60.0.tgz",
-      "integrity": "sha512-SX+MzWM3nz5ttKT48rlfktm0ERyIpDLma+b6pYeWgW2oFHKcpIu0g0qMGJrZs4lKM3MlgV7IqLa4texMqTp9kQ==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.62.0.tgz",
+      "integrity": "sha512-S5szsj6kKBhxw97b2HA98fYp/PpWXvSizlisEzb2rnL4IH6RAJ8wP05/fnth8pSywTH+gtUu+i6Wn8e8rX5HvA==",
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.15.0",
         "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
         "@apm-js-collab/tracing-hooks": "^0.10.0",
         "@sentry/conventions": "^0.12.0",
-        "@sentry/core": "10.60.0",
+        "@sentry/core": "10.62.0",
         "magic-string": "~0.30.0"
       },
       "engines": {
@@ -6387,13 +6387,13 @@
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "10.60.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.60.0.tgz",
-      "integrity": "sha512-Ti7LR4Fm61IBSMQsOE9IkM//yQqffg7UUl898geqXEN3hq50J79OwNENAjDsXwsrP90220pHGj1rT+Dsrci6iw==",
+      "version": "10.62.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.62.0.tgz",
+      "integrity": "sha512-p9gtIRywc6X2JOSh8WGLXCbY8969EDIF+dcejGbbQO9ekRzyREcJIxbJxfofUsynVO6dpEUi5Eayl71JhYwcPQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@sentry/core": "10.60.0"
+        "@sentry/core": "10.62.0"
       },
       "engines": {
         "node": ">=18"
@@ -16997,13 +16997,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -17016,9 +17016,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -17118,13 +17118,13 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.393.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.393.0.tgz",
-      "integrity": "sha512-BNu62XUNkFEIq7ZQJwvgtZIgWUfn0HozVcYHO8P1WMq2Crx+d+/l7TJsO6YHf3aUUiJn+L8L8NX7XgFZxW3/tw==",
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.395.0.tgz",
+      "integrity": "sha512-5iTb00CGt2eQUUiBQysQiX89RAbCN6wK2sDNzvs9zv0alaY8mJ0ZySrUD3LQ+XyLhgM5pCpacBuUwChqiYDLDw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@posthog/core": "^1.36.0",
-        "@posthog/types": "^1.391.0",
+        "@posthog/core": "^1.38.0",
+        "@posthog/types": "^1.391.1",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
@@ -18844,9 +18844,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "22.2.3",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.2.3.tgz",
-      "integrity": "sha512-9lrggvLtjO4Ef5WXH4t50ckHJcJgTD72xFB+KJgZCSszAH9zMV1BqU6PwmWbRLdcdX7LK6PbErBapiGK7pIb+g==",
+      "version": "22.3.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.0.tgz",
+      "integrity": "sha512-ypO6xjVrMWs9SmIMeHr8naCx3dAQ0clxMdUTxn7Ejd7hmY9meBGfE+N4pVHkf9sUNebAHp6uJo6mV3GxDIc2cA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20672,7 +20672,7 @@
         "@google/generative-ai": "^0.24.1",
         "@monaco-editor/react": "^4.7.0",
         "@neondatabase/serverless": "^1.1.0",
-        "@sentry/nextjs": "^10.59.0",
+        "@sentry/nextjs": "^10.62.0",
         "@spawnforge/ui": "*",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
@@ -20689,13 +20689,13 @@
         "lucide-react": "^1.0.1",
         "next": "^16.2.9",
         "next-intl": "^4.13.0",
-        "posthog-js": "^1.392.0",
+        "posthog-js": "^1.395.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
-        "stripe": "^22.2.3",
+        "stripe": "^22.3.0",
         "svix": "^1.96.0",
         "web-vitals": "^5.1.0",
         "zod": "^4.4.3",
@@ -20705,7 +20705,7 @@
         "@axe-core/playwright": "^4.11.3",
         "@electric-sql/pglite": "^0.5.3",
         "@next/bundle-analyzer": "^16.2.9",
-        "@playwright/test": "^1.61.0",
+        "@playwright/test": "^1.61.1",
         "@swc/helpers": "^0.5.23",
         "@tailwindcss/postcss": "^4.3.1",
         "@testing-library/dom": "^10.4.1",
@@ -20725,7 +20725,7 @@
         "portless": "^0.14.0",
         "tailwindcss": "^4",
         "typescript": "^6",
-        "vitest": "^4.1.8"
+        "vitest": "^4.1.9"
       },
       "engines": {
         "node": ">=24 <25"

--- a/web/instrumentation-client.ts
+++ b/web/instrumentation-client.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { configureSentryFingerprinting, scrubSentryEvent } from '@/lib/monitoring/sentryConfig';
+import { configureSentryFingerprinting, scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentryConfig';
 
 const DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 const IS_PROD = process.env.NODE_ENV === 'production';
@@ -37,6 +37,10 @@ if (DSN) {
     enableLogs: true,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
+    // Sentry Logs bypass beforeSend/scrubSentryEvent — scrub them on their own
+    // pipeline so a stray Sentry.logger.* call can't leak secrets/PII (see
+    // sentry.server.config.ts for the full rationale).
+    beforeSendLog: scrubSentryLog,
 
     integrations: [
       Sentry.browserTracingIntegration(),

--- a/web/package.json
+++ b/web/package.json
@@ -60,7 +60,7 @@
     "@google/generative-ai": "^0.24.1",
     "@monaco-editor/react": "^4.7.0",
     "@neondatabase/serverless": "^1.1.0",
-    "@sentry/nextjs": "^10.59.0",
+    "@sentry/nextjs": "^10.62.0",
     "@spawnforge/ui": "*",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
@@ -77,13 +77,13 @@
     "lucide-react": "^1.0.1",
     "next": "^16.2.9",
     "next-intl": "^4.13.0",
-    "posthog-js": "^1.392.0",
+    "posthog-js": "^1.395.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
-    "stripe": "^22.2.3",
+    "stripe": "^22.3.0",
     "svix": "^1.96.0",
     "web-vitals": "^5.1.0",
     "zod": "^4.4.3",
@@ -93,7 +93,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@electric-sql/pglite": "^0.5.3",
     "@next/bundle-analyzer": "^16.2.9",
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "^1.61.1",
     "@swc/helpers": "^0.5.23",
     "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/dom": "^10.4.1",
@@ -113,7 +113,7 @@
     "portless": "^0.14.0",
     "tailwindcss": "^4",
     "typescript": "^6",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.9"
   },
   "optionalDependencies": {
     "@types/trusted-types": "^2.0.7"

--- a/web/sentry.edge.config.ts
+++ b/web/sentry.edge.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { configureSentryFingerprinting, scrubSentryEvent } from '@/lib/monitoring/sentryConfig';
+import { configureSentryFingerprinting, scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentryConfig';
 
 const DSN = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
 const IS_PROD = process.env.NODE_ENV === 'production';
@@ -35,6 +35,10 @@ if (DSN) {
     enableLogs: true,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
+    // Sentry Logs bypass beforeSend/scrubSentryEvent — scrub them on their own
+    // pipeline so a stray Sentry.logger.* call can't leak secrets/PII (see
+    // sentry.server.config.ts for the full rationale).
+    beforeSendLog: scrubSentryLog,
   });
 
   configureSentryFingerprinting();

--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { configureSentryFingerprinting, scrubSentryEvent } from '@/lib/monitoring/sentryConfig';
+import { configureSentryFingerprinting, scrubSentryEvent, scrubSentryLog } from '@/lib/monitoring/sentryConfig';
 
 const DSN = process.env.SENTRY_DSN ?? process.env.NEXT_PUBLIC_SENTRY_DSN;
 const IS_PROD = process.env.NODE_ENV === 'production';
@@ -39,8 +39,19 @@ if (DSN) {
       stackFrameVariables: false,
     },
     enableLogs: true,
+    // 10.61 flipped `streamGenAiSpans` ON by default (gen_ai prompt/completion spans
+    // streamed as separate untruncated v2 envelope items). Pin it OFF to preserve the
+    // pre-bump behavior and keep span volume/cost flat — opting in is a deliberate
+    // observability decision to make alongside the dedicated LLM-observability work,
+    // not a silently-inherited upstream default.
+    streamGenAiSpans: false,
     beforeSend: scrubSentryEvent,
     beforeSendTransaction: scrubSentryEvent,
+    // `enableLogs` routes Sentry.logger.* through a SEPARATE pipeline that
+    // beforeSend/beforeSendTransaction (and thus scrubSentryEvent) never touch.
+    // scrubSentryLog closes that channel so a stray log call can't ship a
+    // prompt/BYOK key/PII unredacted. Keep this wired wherever enableLogs is on.
+    beforeSendLog: scrubSentryLog,
 
     integrations: [
       // Captures AI token usage, model IDs, latency, and errors for every
@@ -49,11 +60,14 @@ if (DSN) {
       Sentry.anthropicAIIntegration({
         recordInputs: !IS_PROD,
         recordOutputs: !IS_PROD,
+        // 10.61 flipped the truncation default OFF; restore it so the dev/preview
+        // spans (where recordInputs/Outputs are on) stay size-capped as before.
+        enableTruncation: true,
       }),
       // Captures AI SDK (Vercel AI) spans: model name, token usage, latency,
       // and tool call traces for every streamText/generateText call.
       // Requires experimental_telemetry: { isEnabled: true } on each call.
-      Sentry.vercelAIIntegration(),
+      Sentry.vercelAIIntegration({ enableTruncation: true }),
       // Auto-collects runtime health metrics: RSS, heap, CPU, event loop.
       // Enabled on Vercel production + preview only.
       ...(process.env.VERCEL_ENV === 'production' || process.env.VERCEL_ENV === 'preview'

--- a/web/src/app/api/billing/checkout/route.test.ts
+++ b/web/src/app/api/billing/checkout/route.test.ts
@@ -194,7 +194,7 @@ describe('POST /api/billing/checkout', () => {
     const { POST } = await import('./route');
     await POST(makeReq({ tier: 'hobbyist' }));
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-05-27.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-06-24.dahlia');
   });
 
   it('does not enable automatic_tax when STRIPE_TAX_ENABLED is unset (no-op guard)', async () => {

--- a/web/src/app/api/billing/portal/route.test.ts
+++ b/web/src/app/api/billing/portal/route.test.ts
@@ -118,7 +118,7 @@ describe('POST /api/billing/portal', () => {
     const { POST } = await import('./route');
     await POST(makeReq());
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-05-27.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-06-24.dahlia');
   });
 
   it('pins the portal configuration id from STRIPE_PORTAL_CONFIGURATION_ID', async () => {

--- a/web/src/app/api/billing/status/route.test.ts
+++ b/web/src/app/api/billing/status/route.test.ts
@@ -124,7 +124,7 @@ describe('GET /api/billing/status', () => {
     const { GET } = await import('./route');
     await GET(makeReq());
 
-    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-05-27.dahlia');
+    expect(capturedStripeOpts.value?.apiVersion).toBe('2026-06-24.dahlia');
   });
 
   it('returns subscriptionStatus from Stripe', async () => {

--- a/web/src/app/api/stripe/webhook/route.ts
+++ b/web/src/app/api/stripe/webhook/route.ts
@@ -191,7 +191,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
       if (!customerId) break;
 
       // v22 (dahlia) nests subscription under invoice.parent; pre-dahlia uses top-level invoice.subscription.
-      // Keep both reads until Dashboard webhook endpoint is confirmed on 2026-05-27.dahlia.
+      // Keep both reads until Dashboard webhook endpoint is confirmed on 2026-06-24.dahlia.
       const subField = invoice.parent?.subscription_details?.subscription
         ?? (invoice as unknown as { subscription?: string | { id: string } | null }).subscription
         ?? null;

--- a/web/src/lib/__tests__/sentry-regressions.test.ts
+++ b/web/src/lib/__tests__/sentry-regressions.test.ts
@@ -465,3 +465,55 @@ describe('F03/F04 (#8778): Sentry dataCollection opt-out must stay exhaustive', 
     },
   );
 });
+
+describe('Sentry Logs scrubber gap: enableLogs requires beforeSendLog: scrubSentryLog', () => {
+  /**
+   * `enableLogs: true` routes `Sentry.logger.*` calls through a SEPARATE
+   * delivery pipeline (`beforeSendLog`) that `beforeSend` / `beforeSendTransaction`
+   * — and therefore `scrubSentryEvent` — never touch. Without a `beforeSendLog`
+   * scrubber, a stray log call could ship a prompt, BYOK key, or PII unredacted,
+   * bypassing the F03/F04 posture. This guard ties the requirement to its trigger:
+   * ANY init config that turns logs on must also wire the log scrubber. All three
+   * configs currently enable logs, so all three must carry it.
+   */
+  const CONFIG_FILES = [
+    'sentry.server.config.ts',
+    'sentry.edge.config.ts',
+    'instrumentation-client.ts',
+  ] as const;
+
+  function stripComments(src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  }
+
+  async function readConfig(file: string): Promise<string> {
+    const fs = await import('fs');
+    const path = await import('path');
+    const raw = fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8');
+    return stripComments(raw);
+  }
+
+  it.each(CONFIG_FILES)(
+    '%s wires beforeSendLog: scrubSentryLog whenever it enables logs',
+    async (file) => {
+      const content = await readConfig(file);
+      if (content.includes('enableLogs: true')) {
+        expect(
+          content,
+          `${file} enables Sentry Logs but does not route them through scrubSentryLog — Sentry.logger.* would bypass scrubSentryEvent`,
+        ).toContain('beforeSendLog: scrubSentryLog');
+      }
+    },
+  );
+
+  it('keeps the conditional guard non-vacuous (at least one config still enables logs)', async () => {
+    // If a future edit turned logs OFF in every config, the conditional guard
+    // above would pass vacuously and silently stop protecting anything. Assert
+    // the trigger is still live so the guard keeps biting; today all three enable
+    // logs.
+    const enabled = await Promise.all(
+      CONFIG_FILES.map(async (f) => (await readConfig(f)).includes('enableLogs: true')),
+    );
+    expect(enabled.filter(Boolean).length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/lib/billing/stripe-client.ts
+++ b/web/src/lib/billing/stripe-client.ts
@@ -3,5 +3,5 @@ import Stripe from 'stripe';
 export function getStripe(): Stripe {
   const key = process.env.STRIPE_SECRET_KEY;
   if (!key) throw new Error('STRIPE_SECRET_KEY environment variable is not set');
-  return new Stripe(key, { apiVersion: '2026-05-27.dahlia' });
+  return new Stripe(key, { apiVersion: '2026-06-24.dahlia' });
 }

--- a/web/src/lib/monitoring/__tests__/sentryConfig.test.ts
+++ b/web/src/lib/monitoring/__tests__/sentryConfig.test.ts
@@ -21,6 +21,7 @@ import {
   isWasmError,
   isGenerationError,
   scrubEvent,
+  scrubSentryLog,
   scrubString,
   deepScrub,
 } from '../sentryConfig';
@@ -647,5 +648,95 @@ describe('scrubString — false-positive & linearity guards (audit review)', () 
     // unbounded quantifier; the RFC-bounded patterns return promptly and unchanged.
     const long = 'a'.repeat(100_000);
     expect(scrubString(long)).toBe(long);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scrubSentryLog — beforeSendLog hook
+// Sentry Logs (enableLogs) bypass beforeSend / scrubEvent entirely, so the log
+// body + structured attributes must be scrubbed on their own pipeline.
+// ---------------------------------------------------------------------------
+
+describe('scrubSentryLog', () => {
+  it('redacts secret-looking values in the log message', () => {
+    const log = scrubSentryLog({
+      level: 'error',
+      message: 'generation failed for key=sk-ant-api03-AbCdEf0123456789xyz',
+    });
+    expect(log.message).toBe('generation failed for key=[REDACTED_API_KEY]');
+  });
+
+  it('redacts PII (email + IP) in the log message', () => {
+    const log = scrubSentryLog({
+      level: 'info',
+      message: 'user nolantj@live.com from 192.168.1.42',
+    });
+    expect(log.message).toBe('user [REDACTED_EMAIL] from [REDACTED_IP]');
+  });
+
+  it('redacts sensitive keys and secret values in structured attributes', () => {
+    const log = scrubSentryLog({
+      level: 'warning',
+      message: 'request rejected',
+      attributes: {
+        apiKey: 'sk-ant-api03-anything',
+        note: 'retry from 10.0.0.1',
+        prompt: 'contact nolantj@live.com',
+      },
+    });
+    const attrs = log.attributes as Record<string, string>;
+    expect(attrs.apiKey).toBe('[REDACTED]'); // sensitive key → value redacted wholesale
+    expect(attrs.note).toBe('retry from [REDACTED_IP]'); // innocuous key → value scrubbed
+    expect(attrs.prompt).toBe('contact [REDACTED_EMAIL]');
+  });
+
+  it('leaves a clean log untouched and returns the same object (mutates in place)', () => {
+    const input = { level: 'info', message: 'spawn_entity ok at frame 12' };
+    const out = scrubSentryLog(input);
+    expect(out).toBe(input); // same reference — drop-in for Sentry's beforeSendLog
+    expect(out.message).toBe('spawn_entity ok at frame 12');
+  });
+
+  it('tolerates a log with no attributes', () => {
+    const input: { level: string; message: string; attributes?: Record<string, unknown> } = {
+      level: 'debug',
+      message: 'tick',
+    };
+    const log = scrubSentryLog(input);
+    expect(log.attributes).toBeUndefined();
+  });
+
+  it('redacts a parameterized (boxed String) fmt message — the rendered body the SDK ships', () => {
+    // `Sentry.logger.fmt`…`` returns a boxed String object (typeof 'object'), not
+    // a primitive, and the SDK ships `String(message)` as the body AFTER
+    // beforeSendLog. A plain `typeof === 'string'` guard would skip it and leak
+    // the interpolated PII. Mirror the real shape (boxed String + template props).
+    const boxed = Object.assign(new String('gen failed for nolantj@live.com from 192.168.1.42'), {
+      __sentry_template_string__: 'gen failed for %s from %s',
+      __sentry_template_values__: ['nolantj@live.com', '192.168.1.42'],
+    });
+    const out = scrubSentryLog({ level: 'error', message: boxed as unknown as string });
+    expect(String(out.message)).toBe('gen failed for [REDACTED_EMAIL] from [REDACTED_IP]');
+  });
+
+  it('redacts user.name / user.username attributes the SDK flattens from scope (PII parity with scrubEvent)', () => {
+    // The SDK copies the active scope's `username` into a `user.name` log
+    // attribute; deepScrub's key regex catches `user.email` but not `user.name`,
+    // so it must be redacted explicitly — matching scrubEvent's `delete username`.
+    const out = scrubSentryLog({
+      level: 'info',
+      message: 'authenticated',
+      attributes: {
+        'user.id': 'u_123',
+        'user.email': 'nolantj@live.com',
+        'user.name': 'tristan_nolan',
+        'user.username': 'tristan_nolan',
+      },
+    });
+    const attrs = out.attributes as Record<string, string>;
+    expect(attrs['user.name']).toBe('[REDACTED]');
+    expect(attrs['user.username']).toBe('[REDACTED]');
+    expect(attrs['user.email']).toBe('[REDACTED]'); // sensitive key → redacted by deepScrub
+    expect(attrs['user.id']).toBe('u_123'); // kept for correlation, as in scrubEvent
   });
 });

--- a/web/src/lib/monitoring/sentryConfig.ts
+++ b/web/src/lib/monitoring/sentryConfig.ts
@@ -372,6 +372,63 @@ export function configureSentryFingerprinting(): void {
  */
 export const scrubSentryEvent = scrubEvent;
 
+/**
+ * `beforeSendLog` hook for every Sentry.init that sets `enableLogs: true`.
+ *
+ * Sentry Logs (`Sentry.logger.*`) travel through a SEPARATE delivery pipeline
+ * from events — `beforeSend` / `beforeSendTransaction` (and therefore
+ * {@link scrubEvent}) never see a log. Without this hook a stray
+ * `Sentry.logger.info(prompt)` / `logger.error('key=' + apiKey)` would ship the
+ * value unredacted, bypassing the F03/F04 scrubbing posture. Scrub the log body
+ * and structured attributes here, reusing the same {@link scrubString} value
+ * patterns and {@link deepScrub} key/value redaction as the event path.
+ *
+ * Two SDK-specific traps are handled explicitly:
+ *   - `Sentry.logger.fmt`…`` returns a boxed `String` object (`typeof 'object'`),
+ *     NOT a primitive; the SDK renders `String(message)` into the transmitted log
+ *     body AFTER this hook runs, so a plain `typeof === 'string'` guard would let
+ *     the interpolated value (PII / a key) through. Coerce + scrub the rendered
+ *     form for any non-string message.
+ *   - the active scope's `username` is flattened by the SDK into a `user.name`
+ *     attribute, which {@link deepScrub}'s key regex does not match (it catches
+ *     `user.email`, not `name`) — redacted here for PII parity with
+ *     {@link scrubEvent}'s `delete user.username`. `user.id` is kept for
+ *     correlation, as in {@link scrubEvent}.
+ *
+ * Mutates in place and returns the same log (generic so it stays a drop-in for
+ * Sentry's `beforeSendLog`, which is typed `(log: Log) => Log | null`, without
+ * importing the non-exported `Log` type).
+ */
+function scrubLog<T extends { message?: unknown; attributes?: Record<string, unknown> }>(log: T): T {
+  if (typeof log.message === 'string') {
+    // `scrubString` returns a plain `string`; the cast restores the caller's
+    // (possibly branded `ParameterizedString`) message type — required, not
+    // redundant.
+    log.message = scrubString(log.message) as T['message'];
+  } else if (log.message != null) {
+    // `logger.fmt`…`` messages are boxed `String` objects; the SDK ships
+    // `String(message)` as the body after this hook, so scrub the rendered form.
+    // (The template values are also copied to `sentry.message.parameter.N`
+    // attributes, scrubbed by deepScrub below — this closes the rendered-body path.)
+    log.message = scrubString(String(log.message)) as T['message'];
+  }
+  if (log.attributes) {
+    const attrs = deepScrub(log.attributes) as Record<string, unknown>;
+    for (const key of ['user.name', 'user.username']) {
+      if (key in attrs) attrs[key] = REDACTED;
+    }
+    log.attributes = attrs as T['attributes'];
+  }
+  return log;
+}
+
+/**
+ * `beforeSendLog` hook for every Sentry.init with logs enabled. Re-exported
+ * under a stable name so the init files import a single symbol (mirrors
+ * {@link scrubSentryEvent}).
+ */
+export const scrubSentryLog = scrubLog;
+
 // Export helpers for unit testing
 export {
   fingerprintEvent,
@@ -385,6 +442,7 @@ export {
   isWasmError,
   isGenerationError,
   scrubEvent,
+  scrubLog,
   scrubString,
   deepScrub,
 };


### PR DESCRIPTION
## Summary

Routine dependency wave from the 2026-06-27 changelog review. Five drop-in bumps, relocked on Node 24 to the `npm install --package-lock-only` fixed point so the **Lockfile Sync** gate stays green.

| Package | From | To | Notes |
|---------|------|-----|-------|
| `stripe` | 22.2.3 | 22.3.0 | SDK rolls its pinned `ApiVersion` literal `2026-05-27.dahlia` → `2026-06-24.dahlia` |
| `@sentry/nextjs` | 10.59 | 10.62 | pin two 10.61 AI defaults (see below) |
| `posthog-js` | 1.392 | 1.395 | bug-fix patch |
| `@playwright/test` | 1.61.0 | 1.61.1 | bug-fix patch |
| `vitest` floor | ^4.1.8 | ^4.1.9 | already resolved at 4.1.9 |

### Stripe — ApiVersion lockstep
stripe-node 22.3.0 pins its `ApiVersion` literal to `2026-06-24.dahlia`. Per the repo gotcha, the hardcoded literal moves in lockstep across `stripe-client.ts`, the 3 billing route tests (checkout/portal/status), and the webhook `route.ts` comment — otherwise `tsc` breaks on the next relock. All four sites updated; 27 billing route tests pass.

### Sentry — preserve pre-10.61 gen_ai behavior (cost-neutral)
Sentry 10.61 flipped two AI-instrumentation defaults: `streamGenAiSpans` ON and `enableTruncation` OFF. To keep span volume / cost flat, `sentry.server.config.ts` now pins `streamGenAiSpans: false` (top-level) and `enableTruncation: true` on `anthropicAIIntegration` + `vercelAIIntegration`. PII stays off via the existing `dataCollection.genAI: { inputs: false, outputs: false }` block. Opting into streamed gen_ai spans is a deliberate observability decision to make alongside the dedicated LLM-observability work, not a silent default flip.

### Sentry — close the Logs scrubber gap (security, Boy-Scout)
Surfaced while reviewing the Sentry bump: all three `Sentry.init` configs (`sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation-client.ts`) set `enableLogs: true`. Sentry Logs travel through a **separate** delivery pipeline (`beforeSendLog`) that `beforeSend` / `beforeSendTransaction` — and therefore the existing `scrubSentryEvent` — never intercept, so a stray `Sentry.logger.*` call could ship a prompt, BYOK provider key, or PII unredacted, bypassing the F03/F04 posture. Added `scrubSentryLog` to `sentryConfig.ts` (reuses the same `scrubString` + `deepScrub` redaction core as `scrubSentryEvent`) and wired `beforeSendLog: scrubSentryLog` in all three configs.

`scrubLog` closes two SDK-specific traps confirmed against the installed `@sentry/core` source: (1) `Sentry.logger.fmt\`…\`` returns a **boxed `String` object**, not a primitive, and the SDK ships `String(message)` as the rendered body *after* `beforeSendLog` — so a `typeof === 'string'` guard alone would skip it and leak the interpolated value; the non-string branch now scrubs the stringified body. (2) The active scope's `username` is flattened by the SDK into a `user.name` log attribute; `deepScrub`'s key regex catches `user.email` but not `user.name`, so both `user.name` and `user.username` attributes are now redacted explicitly — restoring parity with `scrubEvent`'s `delete user.username` (`user.id` is kept for correlation, matching `scrubEvent`).

A regression guard (`sentry-regressions.test.ts`) ties the requirement to its trigger — any config with `enableLogs: true` must wire the scrubber — plus a non-vacuity check, and `sentryConfig.test.ts` covers the redaction behavior: secret/PII in plain + boxed-`String` fmt messages, structured attributes (incl. the `user.name`/`user.username` flatten), clean-log pass-through, and missing-attributes tolerance.

### Boy-Scout
- `version-pins.md`: refreshed the stale Stripe entry (matrix row `22.0.1` → `22.3.0`) and corrected the lockstep-sites count (FOUR → FIVE: four code sites where a mismatch breaks `tsc`, plus the webhook comment, which must track the literal but doesn't affect compilation).
- `changelog-review/SKILL.md` + `version-pins.md` tracking tables: refreshed the "current version" rows for the five packages this wave bumps (`@sentry/nextjs`, `posthog-js`, `stripe`, `vitest`, `@playwright/test`) so the next `/changelog-review` compares against the correct baselines. Unrelated stale rows left for a dedicated table refresh.
- Stale Stripe pins across the rest of the `changelog-review` skill: `SKILL.md`'s References blurb (`stripe ^20.4.1` → `^22.3.0`) and the `check-deps.sh` Notes line (`^20.4.1` "v21 has breaking changes" → the current `^22.3.0` / API `2026-06-24.dahlia` lockstep note). `check-deps.sh` is `shellcheck`-clean. Only the *historical* `version-pins.md:11` "Upgraded from `^20.4.1` in PR #8136" reference remains, by design.

### Lockfile note
The `package-lock.json` diff is the 5 bumped packages + their transitives (0 added, 0 removed; the `@clerk/*` subtree and `next` are untouched). It also normalizes a handful of stray `"peer": true` markers that a prior Node-25 relock left on `main` — the Node-24 `--package-lock-only` regen (which the gate uses) strips them, so the committed lockfile is the gate's fixed point.

## Deferred — `@clerk/nextjs` 7.5.9 (NOT in this wave)
Clerk is override-pinned in the root `package.json` alongside `@clerk/shared ^4.14.0`. 7.5.9 pulls `@clerk/shared 4.22.0`, so bumping clerk without coordinating the shared/backend/react override subtree drops clerk from lockfile resolution. It needs a dedicated upgrade PR — tracked under #8856 (kept open for the clerk + Next-relock remnant).

Closes #8852
Closes #8853

## Test plan
- [x] `tsc --noEmit` clean (validates the Stripe literal + Sentry option names against the installed SDKs)
- [x] `eslint --max-warnings 0` clean on all changed source files
- [x] 183 targeted tests pass on vitest 4.1.9 (27 billing route + `scrubSentryLog` behavior incl. boxed-`String` fmt + `user.name`/`user.username` redaction + `enableLogs ⇒ beforeSendLog` wiring guard + existing scrubber suite)
- [x] `npm ci` against the committed lockfile — exit 0
- [x] Lockfile Sync gate command (`npm install --package-lock-only …` → `git diff --quiet`) — no drift
