### PR TITLE
feat(settings): Security tab with Clerk UserProfile (MFA, passkeys)

### DIFF
--- a/.changeset/clerk-security-tab.md
+++ b/.changeset/clerk-security-tab.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Add a Security tab to the account settings page that mounts Clerk's prebuilt `<UserProfile routing="hash" />`, giving users self-serve access to MFA (authenticator app + backup codes), passkeys, and connected-account/device management (#8820). The tab inherits the app-level dark `appearance` and uses `routing="hash"` so Clerk's internal navigation stays scoped to the URL hash and cannot hijack the page's own `?tab=` query routing. Dormant-safe by default: the underlying factors only become enrollable once the owner toggles them in the Clerk Dashboard (no code change, $0 on the current plan), and with no Clerk keys the provider is not mounted so nothing renders. Bot protection is documented for the future real `<SignUp>` (the public route is currently a waitlist form). No dependency or `@clerk/nextjs` version change.

--- a/specs/PF-910-clerk-mfa-security-tab.md
+++ b/specs/PF-910-clerk-mfa-security-tab.md
@@ -1,0 +1,86 @@
+# PF-910 (#8820) — Clerk MFA (TOTP) + Passkeys + Bot-Protection Discoverability
+
+## Summary
+
+The MFA/passkey enrollment UI is fundamentally Clerk Dashboard configuration (zero
+code) PLUS one genuine code improvement: make Clerk's prebuilt **Security** UI
+**discoverable** from SpawnForge's own `/settings` page.
+
+Clerk's `<UserProfile>` component auto-renders a Security section — Two-step
+verification (TOTP authenticator app + backup codes) and Passkeys — once the
+corresponding Clerk Dashboard toggles are enabled. Today that UI is only reachable
+through the small `<UserButton>` avatar menu in the dashboard/editor chrome. This
+feature surfaces it directly as a tab on the settings page.
+
+## Approach
+
+Add a **Security** tab to `web/src/components/settings/SettingsPage.tsx` that renders
+Clerk's `<UserProfile routing="hash" />`, reusing the file's existing `?tab=` URL-sync
+and accessible tab-nav patterns, and inheriting the dark theme from the app-level
+`<ClerkProvider appearance={{ theme: dark }}>`.
+
+- `routing="hash"` keeps Clerk's internal Profile/Security navigation inside the URL
+  hash, so it does not fight SpawnForge's own `?tab=` query-param routing or trigger a
+  Next.js route mismatch (the page is not a Clerk catch-all route).
+- The tab is added to the existing `TABS` array, so it automatically inherits the
+  same `<button>` rendering, `aria-current="page"` active marker, desktop sidebar +
+  mobile horizontal layouts, and the `handleTabChange` URL-sync — no bespoke nav code.
+
+This is the only required code change.
+
+### Out of scope (deliberately NOT changed)
+
+- `web/src/app/layout.tsx` — NO change. `<ClerkProvider appearance={{ theme: dark }}>`
+  (~line 135) is inherited by `<UserProfile>`. **Never reintroduce `baseTheme`** — Clerk
+  7.5 removed it (would break tsc / visual regression).
+- `web/src/proxy.ts` — NO change. Forcing MFA at the proxy/middleware layer is a product
+  decision, out of scope.
+- `web/src/app/sign-up/[[...sign-up]]/SignUpClient.tsx` — NO change. **Nuance:**
+  `/sign-up` is a SpawnForge **waitlist** form, NOT Clerk's `<SignUp/>` component, so
+  Clerk Dashboard bot-protection on sign-up is inert today. Enabling bot protection in
+  the dashboard is future-proofing only (it activates if/when the real Clerk `<SignUp/>`
+  is adopted).
+- No `@clerk/nextjs` version bump. It is override-pinned to `^7.5.7`
+  (`@clerk/shared ^4.14.0`) in the ROOT `package.json`; bumping is blocked by #8856.
+  7.5.7 already supports MFA/passkeys.
+
+### Optional / nice-to-have (skip if it risks budget)
+
+- `web/src/components/settings/SettingsPanel.tsx` — the in-editor settings dialog has its
+  own `TAB_ORDER`; a matching Security tab is parity-only. The `SettingsPage` tab is the
+  acceptance criterion.
+
+## Integration points (exact files)
+
+1. `web/src/components/settings/SettingsPage.tsx` — PRIMARY. Add `'security'` to the `Tab`
+   union + `TABS` array (icon: `Shield`), render `<UserProfile routing="hash" />` in
+   `renderContent()`. Must be a `'use client'` file (it already is).
+2. `web/src/components/settings/__tests__/SettingsPage.test.tsx` — add unit coverage for
+   the Security tab: mock `@clerk/nextjs` `<UserProfile>` (mirroring how
+   `DashboardLayout`/`EditorLayout` tests mock `<UserButton>`); assert the tab renders,
+   switches `activeTab`, syncs `?tab=security`, and exposes `aria-current` matching the
+   existing tabs.
+
+## External prerequisites (NOT a code task — activation runbook)
+
+These are toggled once in the Clerk Dashboard (org owner). All $0 on the current Clerk
+Pro plan. Live keys are needed to E2E the actual enrollment flow (CI runs in Clerk
+passthrough mode and cannot exercise enrollment).
+
+1. **User & Authentication → Multi-factor**: enable **Authenticator application (TOTP)**
+   and **Backup codes**.
+2. **User & Authentication → Passkeys**: enable Passkeys.
+3. **Attack protection → Bot protection**: enable (future-proofing; inert until the real
+   Clerk `<SignUp/>` replaces the waitlist form).
+
+Once toggled, the Security tab's `<UserProfile>` automatically renders the Two-step
+verification and Passkeys management UI — no further code change.
+
+## Test plan
+
+- **Unit (vitest/RTL):** the Security-tab cases above. `@clerk/nextjs` is mocked because
+  CI/E2E run in Clerk passthrough mode (no keys → `<ClerkProvider>` not mounted).
+- **Regression:** `proxy.ts` and `SignUpClient.tsx` are untouched, so
+  `web/src/__tests__/proxy.test.ts` and `SignUpClient.test.tsx` stay green.
+- **Gate (Node 24):** `npx eslint --max-warnings 0 .` + `npx tsc --noEmit` + targeted
+  `npx vitest run` on the touched settings test(s).

--- a/web/src/components/settings/SettingsPage.tsx
+++ b/web/src/components/settings/SettingsPage.tsx
@@ -2,24 +2,43 @@
 
 import { useState, useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { User, Coins, Key, CreditCard, AlertTriangle, ArrowLeft } from 'lucide-react';
+import { User, Coins, Key, CreditCard, Shield, AlertTriangle, ArrowLeft } from 'lucide-react';
+import { UserProfile } from '@clerk/nextjs';
 import { ProfileTab } from './ProfileTab';
 import { TokenDashboard } from './TokenDashboard';
 import { ApiKeyManager } from './ApiKeyManager';
 import { BillingTab } from './BillingTab';
 import { AccountTab } from './AccountTab';
 
-type Tab = 'profile' | 'tokens' | 'keys' | 'billing' | 'account';
+type Tab = 'profile' | 'tokens' | 'keys' | 'billing' | 'security' | 'account';
 
 const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
   { id: 'profile', label: 'Profile', icon: <User size={16} /> },
   { id: 'tokens', label: 'Tokens', icon: <Coins size={16} /> },
   { id: 'keys', label: 'API Keys', icon: <Key size={16} /> },
   { id: 'billing', label: 'Billing', icon: <CreditCard size={16} /> },
+  { id: 'security', label: 'Security', icon: <Shield size={16} /> },
   { id: 'account', label: 'Account', icon: <AlertTriangle size={16} /> },
 ];
 
 const VALID_TABS = new Set<string>(TABS.map((t) => t.id));
+
+/**
+ * Surfaces Clerk's prebuilt account-management UI — its Security section covers
+ * Two-step verification (TOTP authenticator + backup codes) and Passkeys once the
+ * matching Clerk Dashboard toggles are enabled. `routing="hash"` keeps Clerk's
+ * internal navigation in the URL hash so it does not collide with this page's own
+ * `?tab=` query-param routing. The dark theme is inherited from the app-level
+ * <ClerkProvider appearance={{ theme: dark }}> (do NOT reintroduce baseTheme —
+ * removed in Clerk 7.5).
+ */
+function SecurityTab() {
+  return (
+    <div className="p-4 sm:p-6">
+      <UserProfile routing="hash" />
+    </div>
+  );
+}
 
 export function SettingsPage() {
   const router = useRouter();
@@ -49,6 +68,7 @@ export function SettingsPage() {
       case 'tokens': return <TokenDashboard />;
       case 'keys': return <ApiKeyManager />;
       case 'billing': return <BillingTab />;
+      case 'security': return <SecurityTab />;
       case 'account': return <AccountTab />;
     }
   };

--- a/web/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -49,6 +49,13 @@ vi.mock('../AccountTab', () => ({
   AccountTab: () => <div data-testid="account-tab">Account Content</div>,
 }));
 
+// Clerk's prebuilt <UserProfile> (Security tab) is mocked because CI/E2E run in
+// Clerk passthrough mode (no keys → <ClerkProvider> is not mounted). Mirrors how
+// DashboardLayout/EditorLayout tests stub <UserButton>.
+vi.mock('@clerk/nextjs', () => ({
+  UserProfile: () => <div data-testid="clerk-user-profile">Clerk Security</div>,
+}));
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,12 +72,13 @@ describe('SettingsPage', () => {
     expect(screen.getByText('Settings')).toBeDefined();
   });
 
-  it('renders all five navigation tabs', () => {
+  it('renders all six navigation tabs', () => {
     render(<SettingsPage />);
     expect(screen.getAllByText('Profile').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Tokens').length).toBeGreaterThan(0);
     expect(screen.getAllByText('API Keys').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Billing').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Security').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Account').length).toBeGreaterThan(0);
   });
 
@@ -109,6 +117,12 @@ describe('SettingsPage', () => {
     expect(screen.getAllByTestId('account-tab').length).toBeGreaterThan(0);
   });
 
+  it('shows Clerk <UserProfile> when URL param is "security"', () => {
+    mockSearchParamsGet.mockReturnValue('security');
+    render(<SettingsPage />);
+    expect(screen.getAllByTestId('clerk-user-profile').length).toBeGreaterThan(0);
+  });
+
   it('falls back to profile tab for invalid URL param', () => {
     mockSearchParamsGet.mockReturnValue('invalid_tab_value');
     render(<SettingsPage />);
@@ -145,6 +159,13 @@ describe('SettingsPage', () => {
     expect(screen.getAllByTestId('account-tab').length).toBeGreaterThan(0);
   });
 
+  it('switches to Security tab on click', () => {
+    render(<SettingsPage />);
+    const securityButtons = screen.getAllByText('Security');
+    fireEvent.click(securityButtons[0]);
+    expect(screen.getAllByTestId('clerk-user-profile').length).toBeGreaterThan(0);
+  });
+
   // ── URL updates ────────────────────────────────────────────────────────
 
   it('calls router.replace with tab param when switching tabs', () => {
@@ -167,6 +188,36 @@ describe('SettingsPage', () => {
       expect.not.stringContaining('tab='),
       expect.any(Object)
     );
+  });
+
+  it('syncs ?tab=security to the URL when switching to Security tab', () => {
+    render(<SettingsPage />);
+    const securityButtons = screen.getAllByText('Security');
+    fireEvent.click(securityButtons[0]);
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      expect.stringContaining('security'),
+      expect.any(Object)
+    );
+  });
+
+  // ── Accessibility (aria-current parity with existing tabs) ───────────────
+
+  it('marks the active Security tab with aria-current="page", matching other tabs', () => {
+    mockSearchParamsGet.mockReturnValue('security');
+    render(<SettingsPage />);
+    // Desktop + mobile layouts each render a Security button; the active tab(s)
+    // must expose aria-current="page" exactly like every other tab does.
+    const securityButtons = screen.getAllByText('Security');
+    const currentSecurity = securityButtons.filter(
+      (btn) => btn.closest('button')?.getAttribute('aria-current') === 'page'
+    );
+    expect(currentSecurity.length).toBeGreaterThan(0);
+    // A non-active tab (Billing) must NOT carry aria-current while Security is active.
+    const billingButtons = screen.getAllByText('Billing');
+    const currentBilling = billingButtons.filter(
+      (btn) => btn.closest('button')?.getAttribute('aria-current') === 'page'
+    );
+    expect(currentBilling.length).toBe(0);
   });
 
   // ── Back button ────────────────────────────────────────────────────────

--- a/web/src/components/settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsPage.test.tsx
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@/test/utils/componentTestUtils';
+import { UserProfile } from '@clerk/nextjs';
 import { SettingsPage } from '../SettingsPage';
 
 // ── Router & navigation mocks ──────────────────────────────────────────────
@@ -51,9 +52,16 @@ vi.mock('../AccountTab', () => ({
 
 // Clerk's prebuilt <UserProfile> (Security tab) is mocked because CI/E2E run in
 // Clerk passthrough mode (no keys → <ClerkProvider> is not mounted). Mirrors how
-// DashboardLayout/EditorLayout tests stub <UserButton>.
+// DashboardLayout/EditorLayout tests stub <UserButton>. The mock is a vi.fn that
+// reflects the `routing` prop onto data-routing so a test can assert the
+// routing="hash" guard (which keeps Clerk's internal nav from hijacking the
+// page's own ?tab= routing) actually reaches the component.
 vi.mock('@clerk/nextjs', () => ({
-  UserProfile: () => <div data-testid="clerk-user-profile">Clerk Security</div>,
+  UserProfile: vi.fn(({ routing }: { routing?: string }) => (
+    <div data-testid="clerk-user-profile" data-routing={routing}>
+      Clerk Security
+    </div>
+  )),
 }));
 
 describe('SettingsPage', () => {
@@ -120,7 +128,14 @@ describe('SettingsPage', () => {
   it('shows Clerk <UserProfile> when URL param is "security"', () => {
     mockSearchParamsGet.mockReturnValue('security');
     render(<SettingsPage />);
-    expect(screen.getAllByTestId('clerk-user-profile').length).toBeGreaterThan(0);
+    const profiles = screen.getAllByTestId('clerk-user-profile');
+    expect(profiles.length).toBeGreaterThan(0);
+    // routing="hash" is the critical guard: it scopes Clerk's internal navigation
+    // to the URL hash so it cannot hijack the page's own ?tab= query routing.
+    // Assert it actually reaches <UserProfile> (rendered attr + the real prop on
+    // the mock call) so a future edit that drops the prop fails here.
+    expect(profiles[0].getAttribute('data-routing')).toBe('hash');
+    expect(vi.mocked(UserProfile).mock.calls[0]?.[0]).toMatchObject({ routing: 'hash' });
   });
 
   it('falls back to profile tab for invalid URL param', () => {


### PR DESCRIPTION
## Summary

Adds a **Security** tab to the account settings page (`SettingsPage`) that mounts Clerk's prebuilt `<UserProfile routing="hash" />`. This surfaces Clerk's account-security UI — **MFA** (authenticator app + backup codes), **passkeys**, and connected-account / active-device management — without us building any of those flows ourselves.

The change is **dormant-safe by default** and cannot affect production even if merged before activation:
- The factors users can actually enroll are gated by **owner-only Clerk Dashboard toggles** (no code change, $0 on the current plan). Until the owner enables them, the tab renders Clerk's profile UI with nothing extra to configure.
- In CI / E2E (no Clerk keys) `<ClerkProvider>` is not mounted, so the tab renders nothing — no new failure surface.
- No new dependency and **no `@clerk/nextjs` version change** (stays on the pinned `^7.5.7`; the 7.5.9 bump remains deferred under #8856).

### What changed
- **`web/src/components/settings/SettingsPage.tsx`** — new `'security'` entry in the `Tab` union, the `TABS` array (with a `Shield` icon), and the `renderContent` switch. `VALID_TABS` is derived from `TABS.map()`, so the tab list is a single source of truth and the union / nav / validator cannot drift. New `SecurityTab` component renders `<UserProfile routing="hash" />`; JSDoc documents *why* `routing="hash"` (keeps Clerk's internal nav from hijacking the page's `?tab=` routing), that the dark theme is inherited from the app-level `<ClerkProvider appearance>`, and that `baseTheme` must not be reintroduced (removed in Clerk 7.5).
- **`web/src/components/settings/__tests__/SettingsPage.test.tsx`** — coverage for the new tab: renders six tabs incl. Security; `?tab=security` shows `<UserProfile>`; click switches to Security; URL syncs to `?tab=security`; aria-current parity with the other tabs. The `@clerk/nextjs` mock is a `vi.fn` that reflects the `routing` prop so the test asserts `routing="hash"` actually reaches `<UserProfile>` (rendered attribute + mock-call arg), guarding against a future edit silently dropping it.
- **`specs/PF-910-clerk-mfa-security-tab.md`** — spec + activation runbook.

Closes #8820 (PF-910)

## Activation runbook (owner-only, post-merge)
These are **dashboard-only** and **$0 on the current Clerk plan** — no code change:
1. Clerk Dashboard → **User & Authentication → Multi-factor** → enable **Authenticator app** and **Backup codes**.
2. Clerk Dashboard → **User & Authentication → Passkeys** → enable.
3. (Future, once `/sign-up` is a real Clerk `<SignUp>` rather than the waitlist form) → **Attack protection → Bot protection** → enable.
Live Clerk keys are required to see/enroll factors in a deployed environment (the tab is inert without them).

## Test plan
- [x] `npx vitest run src/components/settings/__tests__/SettingsPage.test.tsx` — 19/19 pass on Node 24 / vitest 4.1.9
- [x] `eslint --max-warnings 0` clean on both changed source files
- [x] `tsc --noEmit` clean (validates `routing="hash"` against the installed `@clerk/nextjs` `UserProfile` prop types — `RoutingOptions` permits `'path' | 'hash'`)
- [x] 5-reviewer board (Architect, Security, DX, UX, Test) + Docs reviewer — all PASS

## Reviewers
Architect ✅ · Security ✅ · DX ✅ · UX ✅ · Docs ✅ · Test ✅ (re-reviewed after asserting the `routing` prop)
