### PR TITLE
PF-907: server-side PostHog LLM observability ($ai_generation) — dormant, consent-gated, content-free

### DIFF
--- a/.changeset/posthog-llm-observability.md
+++ b/.changeset/posthog-llm-observability.md
@@ -1,0 +1,7 @@
+---
+"web": patch
+---
+
+feat(analytics): server-side LLM observability via PostHog `$ai_generation` (PF-907, #8817)
+
+Adds an env-guarded, dormant-by-default, consent-gated server capture of PostHog `$ai_generation` events on the three routes that run a model server-side (`/api/chat`, `/api/generate/localize`, `/api/generate/pacing`), powering PostHog's per-generation cost/token/latency/model/error dashboards. Capture is a dependency-free `fetch` (no `posthog-node`, no OTel span processor) fired via `after()`, and is **private by construction** — it never sends the content fields `$ai_input` / `$ai_output_choices`, only non-content metrics. Fully dormant unless `POSTHOG_LLM_CAPTURE === "true"` AND a project key is set; independently suppressed unless the user consented to analytics (PF-30, via a new server-readable `forge-cookie-consent` cookie). No behavior change when dormant.

--- a/docs/guides/posthog-llm-observability.md
+++ b/docs/guides/posthog-llm-observability.md
@@ -1,0 +1,109 @@
+# Activating server-side LLM observability (PostHog `$ai_generation`, PF-907)
+
+PostHog's [LLM observability](https://posthog.com/docs/ai-engineering/observability)
+product renders per-generation **cost, token, latency, model, and error**
+dashboards from a single event type: `$ai_generation`. Client-side analytics
+(`posthog-js`) already captures product events; this feature adds the **server**
+side — one `$ai_generation` event per LLM call on the routes that actually run a
+model server-side.
+
+It is wired into three self-contained capture sites (no change to the shared
+`createGenerationHandler` factory — each route captures inside its own callback):
+
+- `POST /api/chat` — one event per `onStepFinish` (streamed; carries Anthropic
+  prompt-cache read/creation tokens).
+- `POST /api/generate/localize` — one event per per-chunk `generateText`, all
+  sharing a single trace id for the whole localize op.
+- `POST /api/generate/pacing` — one event per `generateText`.
+
+## Private by construction
+
+The capture payload is built by `buildAiGenerationPayload()` in
+`web/src/lib/analytics/posthog-server.ts`, which **never** includes the only two
+`$ai_*` properties that hold prompt/response content — `$ai_input` and
+`$ai_output_choices`. Only non-content metrics are sent: trace id, model,
+provider, input/output tokens, latency (seconds), stream/error flags,
+prompt-cache tokens, and a `route` label. The cost/token/latency/error
+dashboards all render without the content fields. A unit test asserts the
+serialized body contains neither content key.
+
+We deliberately do **not** use `posthog-node` or the OpenTelemetry
+`PostHogSpanProcessor`: Sentry owns the server OTel provider, and adding a
+runtime dependency triggers the single-root-lockfile / Node-24-relock pain this
+repo has hit repeatedly. Server LLM events are low-volume, so a dependency-free
+`fetch` to PostHog's public capture endpoint is sufficient. See
+`specs/2026-06-29-posthog-llm-observability.md` for the full rationale.
+
+## Dormant by default
+
+Capture is **fully dormant** until BOTH conditions hold — there is **no code
+change** to activate it, only environment config:
+
+1. `POSTHOG_LLM_CAPTURE` is exactly the string `"true"`, **and**
+2. `NEXT_PUBLIC_POSTHOG_KEY` is set (the PostHog project key).
+
+`isLlmCaptureEnabled()` gates every capture on both. Enabling client analytics
+alone (`NEXT_PUBLIC_POSTHOG_KEY` without the dedicated server flag) does **not**
+turn on server capture. While dormant, `captureAiGeneration()` is a no-op — no
+`fetch`, no `after()` scheduling — so the routes behave exactly as before.
+
+## Consent-gated (PF-30)
+
+Independent of the dormancy lever, capture is suppressed unless the user has
+consented to analytics. `CookieConsent.tsx` writes a server-readable cookie
+`forge-cookie-consent=true|false` (in addition to its existing localStorage
+flag) on accept/decline. Each route resolves consent with
+`hasAnalyticsConsent()` (reads that cookie via `next/headers`) and passes
+`consented` into `captureAiGeneration()`, which no-ops when it is not exactly
+`true`. `hasAnalyticsConsent()` **fails closed** — outside a request scope, or if
+the cookie store throws, it returns `false`.
+
+## Activation steps (owner-only)
+
+1. **Have a PostHog project.** `NEXT_PUBLIC_POSTHOG_KEY` is the project key from
+   [PostHog → Project settings](https://us.posthog.com). If client analytics is
+   already live, this is already set — confirm it is present in the `spawnforge`
+   Vercel project.
+2. **Set the server flag** in Vercel (Production **and** Preview) for the
+   `spawnforge` project — scope `tnolan`:
+   ```bash
+   vercel env add POSTHOG_LLM_CAPTURE production --scope tnolan   # value: true
+   vercel env add POSTHOG_LLM_CAPTURE preview --scope tnolan      # value: true
+   ```
+3. **Confirm the capture host.** The module posts to PostHog US cloud
+   (`https://us.i.posthog.com/i/v0/e/`). If the project lives in EU cloud, change
+   `CAPTURE_URL` in `posthog-server.ts` to the `eu.i.posthog.com` host (this is a
+   code change, not an env var, because it is a constant).
+4. **Redeploy.** `NEXT_PUBLIC_POSTHOG_KEY` is build-time; a redeploy is required
+   for a changed value to take effect. `POSTHOG_LLM_CAPTURE` is read at request
+   time but a redeploy is the clean way to roll the change.
+
+## Verifying it is live
+
+- With consent accepted, send a chat message (or run a localize/pacing
+  generation), then open **PostHog → LLM observability**. A new `$ai_generation`
+  event should appear within a minute, carrying token/latency/model/cost but no
+  prompt or response text.
+- Filter insights by the custom `route` property
+  (`/api/chat`, `/api/generate/localize`, `/api/generate/pacing`) to attribute
+  spend per surface.
+- Decline cookies (or never accept) and confirm **no** `$ai_generation` events
+  arrive — consent gating is working.
+- Capture failures are silent to the user and reported to Sentry under `route:
+  posthog_ai_capture` (`phase: schedule` if `after()` had no request scope,
+  `phase: fetch` if the POST failed).
+
+## Rolling back
+
+Remove (or set to anything other than `"true"`) `POSTHOG_LLM_CAPTURE` in Vercel
+and redeploy. Capture returns to fully dormant immediately — no `fetch`,
+nothing scheduled. No data migration is involved.
+
+## Coverage note
+
+v1 instruments the three routes that run a model **directly** (`generateText` /
+streamed chat). The deep generators that go through the `createGenerationHandler`
+agent pipeline (GDD, world builder, cutscene, etc.) are **not** yet instrumented
+— capturing their token usage cleanly needs a small adapter at the agent
+boundary rather than per-route wiring. That follow-up is tracked separately so
+this PR stays scoped to the direct-call routes.

--- a/docs/guides/posthog-llm-observability.md
+++ b/docs/guides/posthog-llm-observability.md
@@ -82,8 +82,11 @@ the cookie store throws, it returns `false`.
 
 - With consent accepted, send a chat message (or run a localize/pacing
   generation), then open **PostHog → LLM observability**. A new `$ai_generation`
-  event should appear within a minute, carrying token/latency/model/cost but no
-  prompt or response text.
+  event should appear within a minute, carrying token/model/cost but no prompt or
+  response text. The `localize` and `pacing` events also carry `$ai_latency`
+  (wall-clock around the `generateText` call); the `/api/chat` events do **not**
+  — latency is not meaningful per `onStepFinish` step of a streamed turn, so it
+  is intentionally omitted there.
 - Filter insights by the custom `route` property
   (`/api/chat`, `/api/generate/localize`, `/api/generate/pacing`) to attribute
   spend per surface.

--- a/docs/guides/posthog-llm-observability.md
+++ b/docs/guides/posthog-llm-observability.md
@@ -105,5 +105,5 @@ v1 instruments the three routes that run a model **directly** (`generateText` /
 streamed chat). The deep generators that go through the `createGenerationHandler`
 agent pipeline (GDD, world builder, cutscene, etc.) are **not** yet instrumented
 — capturing their token usage cleanly needs a small adapter at the agent
-boundary rather than per-route wiring. That follow-up is tracked separately so
+boundary rather than per-route wiring. That follow-up is tracked in #8877 so
 this PR stays scoped to the direct-call routes.

--- a/specs/2026-06-29-posthog-llm-observability.md
+++ b/specs/2026-06-29-posthog-llm-observability.md
@@ -1,0 +1,228 @@
+# PostHog LLM Observability (`$ai_generation`)
+
+- **Ticket:** PF-907 / #8817
+- **Milestone:** E3: Instrumentation & Growth Metrics
+- **Status:** Spec — dormant-by-default, reviewer-gated
+- **Author:** Engineering
+- **Date:** 2026-06-29
+
+## Problem
+
+We have zero per-generation observability on our LLM calls. Token spend, latency,
+model mix, and error rate for the AI chat tool-loop and the text-generation routes
+are invisible outside of (a) the billing `costLog` table (chat-only, no latency,
+no model breakdown) and (b) Sentry AI spans (which we keep **content-free** and do
+not aggregate into product dashboards). PostHog ships a first-class **LLM analytics**
+product keyed on a single event — `$ai_generation` — that renders cost / token /
+latency / model / error dashboards and a per-trace view. We already ship
+`posthog-js` on the client; the server emits nothing.
+
+## Goal
+
+Emit a privacy-safe `$ai_generation` event for each server-side LLM generation on
+our AI-SDK **text** call paths, so PostHog LLM analytics can chart cost, tokens,
+latency, model, and error rate per route — **without ever sending prompt or
+response content**, **gated on cookie consent (PF-30)**, and **fully dormant until
+an owner sets one env var** (no code change to activate).
+
+Non-goals (this PR): media generation routes (Meshy/Suno/Replicate are HTTP jobs,
+not LLM generations — they have no token usage and do not belong on `$ai_generation`);
+the deep-generation routes that flow through `aiSdkAdapter`/`createSpawnforgeAgent`
+(GDD/world/cutscene) — see **Deferred** below; client-side `$ai_*` capture; session
+replay / flags / experiments.
+
+## Architecture decision — manual `fetch` capture, NOT the OTel span processor
+
+The ticket was written from PostHog's docs and named the
+`PostHogSpanProcessor` (`@posthog/ai` + an OpenTelemetry `NodeSDK` in
+`instrumentation.ts`). During spec investigation that approach was found to conflict
+with our current stack, so this spec **deviates deliberately** and documents why.
+Reviewers should scrutinize this section.
+
+### Why not the OTel `PostHogSpanProcessor`
+
+1. **Sentry already owns the server OTel provider.** `@sentry/nextjs` installs its
+   own `NodeTracerProvider` with a `SentrySampler` / `SentryPropagator` /
+   `SentrySpanProcessor`. Adding PostHog's processor means either
+   `skipOpenTelemetrySetup: true` + manually rebuilding the provider with BOTH
+   vendors' samplers/propagators, or letting two SDKs fight over the global
+   provider. Either path destabilizes the existing, working Sentry AI spans. The
+   manual path has **zero** interaction with the OTel provider.
+2. **No processor-level privacy knob.** The only content toggle on the span path is
+   the AI-SDK `experimental_telemetry.recordInputs/recordOutputs`, which **also**
+   feeds Sentry spans — flipping it to satisfy PostHog would change Sentry's data
+   collection too. The manual path is **private by construction**: we build the
+   event body ourselves and simply never include the content fields.
+3. **Smaller dependency surface.** The OTel path pulls `@posthog/ai` +
+   `@opentelemetry/sdk-node` + `@opentelemetry/resources`. The manual path needs
+   **no new dependency at all** — `$ai_generation` is captured with a single `fetch`
+   to PostHog's public capture endpoint. This matters disproportionately here: this
+   repo has a **single-root `package-lock.json`** and a history of new/changed deps
+   breaking `npm ci` on main (the `Lockfile Sync` gate, the Node-24 relock dance).
+   Zero new deps = zero relock = zero gate exposure.
+4. **Data is already in hand.** At every finalize hook we already have
+   `usage.inputTokens` / `usage.outputTokens` and the resolved model id. The span
+   path would re-derive the same numbers from a span we'd have to wire up anyway.
+
+### The manual path
+
+PostHog's capture API is a public, project-token POST endpoint
+(`https://us.i.posthog.com/i/v0/e/`, body `{ api_key, event, distinct_id,
+properties, timestamp }`). LLM analytics is documented to populate from a manually
+captured `$ai_generation` event — it is a first-class, supported path, not a hack.
+Server-side LLM events are low-volume (one per chat step / generate call), so we do
+not need `posthog-node`'s batching/retry/shutdown machinery; a fire-after-response
+`fetch` is sufficient and simpler to keep dormant.
+
+**OTel path is documented as a future upgrade**, not discarded: if we later want
+full distributed AI tracing that ties PostHog and Sentry to the same trace id, the
+processor approach is revisited as its own spec once the Sentry-provider-ownership
+question is designed for. `sentry.server.config.ts` already pins
+`streamGenAiSpans: false` with a comment deferring the opt-in to "the dedicated
+LLM-observability work" — i.e. this ticket. We are NOT flipping that flag here; the
+manual path is orthogonal to Sentry's spans.
+
+## Privacy & consent (PF-30 — hard requirement)
+
+- **No content, ever.** We never send `$ai_input` or `$ai_output_choices` (the only
+  `$ai_*` props that carry prompt/response text). We send only: `$ai_trace_id`,
+  `$ai_model`, `$ai_provider`, `$ai_input_tokens`, `$ai_output_tokens`,
+  `$ai_latency` (seconds), `$ai_stream`, `$ai_is_error`, plus non-content custom
+  props (`route`, optional `$ai_cache_read_input_tokens` /
+  `$ai_cache_creation_input_tokens` from the chat path where we already read them).
+  The cost/token/latency/model/error dashboards all render from these; only the
+  per-trace conversation drill-down (which shows message text) is intentionally
+  blank — an accepted privacy tradeoff.
+- **`distinctId`** is the Clerk user id (already the identifier we bill on). No PII
+  beyond the id we already store.
+- **Consent gate.** PF-30 requires PostHog tracking to be gated behind cookie
+  consent. Today consent lives **only in `localStorage`** (`CookieConsent.tsx`
+  writes `forge-cookie-consent` to `localStorage`, never to a cookie), so the
+  **server cannot see it**. This spec closes that gap:
+  - `CookieConsent.tsx` ALSO writes a server-readable cookie
+    `forge-cookie-consent=true|false` (non-`HttpOnly` so the client keeps managing
+    it, `SameSite=Lax`, `path=/`, ~1-year max-age) on accept/decline.
+  - A server util `hasAnalyticsConsent()` reads that cookie via `next/headers`
+    `cookies()` and returns `true` only when its value is exactly `'true'`.
+  - `captureAiGeneration` is a no-op unless `consented === true`. **No consent
+    cookie → no event.** (Strictest PF-30 reading: absence is not consent.)
+
+## Dormancy (mirrors QStash / PF-906)
+
+Capture is **off** until BOTH are true at runtime:
+
+- `process.env.POSTHOG_LLM_CAPTURE === 'true'` (a NEW dedicated flag), **and**
+- a project key is present (`NEXT_PUBLIC_POSTHOG_KEY`).
+
+A dedicated flag (rather than reusing the client `NEXT_PUBLIC_POSTHOG_KEY` alone)
+means **enabling client analytics does NOT silently turn on server LLM capture** —
+the two are independently switched. There is **no code change** to activate: set the
+env var in Vercel (Production/Preview, scope `tnolan`) and redeploy. Unset it →
+fully dormant again. This matches the PF-906 QStash dormancy contract exactly.
+
+## Touch points (v1)
+
+`logCost` is **chat-route-only**, so it is not a universal chokepoint; capture wires
+at each finalize site through one shared helper. All three sites already pass
+`experimental_telemetry: { isEnabled: true }` (Sentry) — the manual capture is
+orthogonal and needs no telemetry-metadata change.
+
+| # | File | Hook | Notes |
+|---|------|------|-------|
+| 1 | `web/src/app/api/chat/route.ts` | `agent.stream({ onStepFinish })` | One `$ai_generation` per tool-loop step. `usage` + `userId` already in scope; resolve `consented` once at the top of the handler (pre-stream) and pass it in. |
+| 2 | `web/src/app/api/generate/localize/route.ts` | inside `execute`, after each `generateText` | `ctx.userId` is passed by the factory (route just doesn't destructure it today); `generateText` returns `usage`. |
+| 3 | `web/src/app/api/generate/pacing/route.ts` | inside `execute`, after `generateText` | same shape as localize. |
+
+The `createGenerationHandler` factory is the documented SPOF ("all generate routes
+use this factory; a bug breaks every route"). We **do not modify it** — capture
+lives inside each route's own `execute`, reading the `ctx.userId` the factory
+already provides. Zero blast radius on the other ~10 generate routes.
+
+## New / changed files
+
+- **`web/src/lib/analytics/posthog-server.ts`** (new) — server capture module:
+  - `isLlmCaptureEnabled(): boolean` — `POSTHOG_LLM_CAPTURE === 'true'` && key present.
+  - `hasAnalyticsConsent(): Promise<boolean>` — reads `forge-cookie-consent` cookie via
+    `next/headers`; returns `false` (fail-closed) if there is no request scope.
+  - `buildAiGenerationPayload(input): Record<string, unknown> | null` — **pure**,
+    unit-testable; returns the capture body with ONLY non-content `$ai_*` props, or
+    `null` when dormant. The privacy guarantee is asserted here (no content keys).
+  - `captureAiGeneration(input): void` — no-op unless enabled + `input.consented`;
+    builds payload; fires the POST via `after()` (post-response, survives serverless
+    freeze) wrapped in try/catch → `captureException` on error. **Never throws.**
+- **`web/src/components/CookieConsent.tsx`** (edit) — on accept/decline ALSO write
+  the server-readable `forge-cookie-consent` cookie (in addition to the existing
+  `localStorage` write + `initPostHog()` + storage event). No behavior change to the
+  client path.
+- **3 route edits** (chat, localize, pacing) — one `captureAiGeneration(...)` call
+  each at the finalize hook; resolve `consented`/`distinctId` per the table above.
+- **`docs/guides/posthog-llm-observability.md`** (new) — owner runbook:
+  activation (`POSTHOG_LLM_CAPTURE`), verification (dashboard + a probe), privacy
+  guarantee, consent dependency, rollback. Mirrors `docs/guides/qstash-setup.md`.
+- **`.changeset/<name>.md`** — patch/minor for `web`.
+
+## Test plan (Test-First)
+
+New `web/src/lib/analytics/__tests__/posthog-server.test.ts`:
+
+- **Dormancy:** `buildAiGenerationPayload` returns `null` and `captureAiGeneration`
+  fires no `fetch` when `POSTHOG_LLM_CAPTURE` ≠ `'true'`, when the key is absent, and
+  when `consented === false`. (Each independently.)
+- **Privacy (the core assertion):** when enabled+consented, the payload contains
+  `$ai_input_tokens`/`$ai_output_tokens`/`$ai_model`/`$ai_provider`/`$ai_trace_id`/
+  `$ai_latency` and **NOT** `$ai_input` nor `$ai_output_choices` — assert the keys
+  are absent, and assert no payload value equals a sentinel prompt/response string
+  passed in.
+- **Shape:** event name is exactly `$ai_generation`; `distinct_id` is the passed
+  user id; `api_key` is the project token; endpoint is `…/i/v0/e/`.
+- **Fail-safe:** a rejected `fetch` does not throw out of `captureAiGeneration`
+  (assert it resolves and `captureException` was called).
+- **Consent util:** `hasAnalyticsConsent` true only for cookie value exactly
+  `'true'`; false for `'false'`, missing, and when `cookies()` throws (no scope).
+
+Route-level: extend the existing chat-route and localize/pacing tests with a case
+asserting `captureAiGeneration` is invoked once per step / per call when enabled, and
+zero times when dormant. (Mock `posthog-server`; do not hit the network.)
+
+Local gate (Node 24): `eslint --max-warnings 0`, `tsc --noEmit`, and targeted
+`vitest run` for the new + touched test files. No full suite (M2).
+
+## Acceptance criteria
+
+1. With `POSTHOG_LLM_CAPTURE` unset, **no** `$ai_generation` `fetch` is issued from
+   any of the three paths, and response shapes are byte-for-byte unchanged.
+2. With the flag set, a key present, and consent cookie `= 'true'`, each chat step
+   and each localize/pacing call issues exactly one `$ai_generation` POST to
+   `…/i/v0/e/` carrying tokens/model/provider/latency/trace-id and **no content**.
+3. With consent cookie absent or `'false'`, no event is issued even when the flag is
+   set.
+4. A `fetch` failure never surfaces to the user and never fails the request; it is
+   reported to Sentry.
+5. New tests cover dormancy, privacy (no-content), consent gating, and fail-safe;
+   `eslint`/`tsc`/targeted `vitest` all green on Node 24.
+6. Owner runbook documents activation, verification, privacy, consent, and rollback.
+
+## Deferred (tracked, not gaps)
+
+- **Deep-generation routes** (GDD / world / cutscene via `aiSdkAdapter` /
+  `createSpawnforgeAgent`): same helper applies, but wiring requires threading
+  `userId` + `consented` through the shared adapter signature (touches multiple
+  callers). Kept out of this PR to bound blast radius; file as a follow-up issue and
+  reference it here. fix-it-or-track-it.
+- **OTel `PostHogSpanProcessor`** distributed-trace upgrade: revisit once the
+  Sentry-provider-ownership design is done (see Architecture decision).
+
+## Review board
+
+Touches a new server analytics module + production routes + a consent change + a
+runbook → **7 reviewers**: the 5 specialized (architect, security, dx, ux, test) +
+`infra-devops` (env-gated production capture, dormancy) + `docs-guardian` (runbook).
+PASS or FAIL only; loop until all clean. Orchestrator owns the board.
+
+## PR
+
+Stacked on the #8816 branch (`feat/qstash-generation-callbacks-8816`) per the agreed
+Wave-2 sequencing. `Closes #8817 (PF-907)`, `--milestone "E3: Instrumentation &
+Growth Metrics"`, changeset included. As a stacked PR it gets **no `ci.yml` run**
+until #8816 merges and the base rebases to main — verified instead by the local
+Node-24 gate + a post-merge CI re-check. **Do not merge** — user reviews and merges.

--- a/specs/2026-06-29-posthog-llm-observability.md
+++ b/specs/2026-06-29-posthog-llm-observability.md
@@ -87,9 +87,11 @@ manual path is orthogonal to Sentry's spans.
 - **No content, ever.** We never send `$ai_input` or `$ai_output_choices` (the only
   `$ai_*` props that carry prompt/response text). We send only: `$ai_trace_id`,
   `$ai_model`, `$ai_provider`, `$ai_input_tokens`, `$ai_output_tokens`,
-  `$ai_latency` (seconds), `$ai_stream`, `$ai_is_error`, plus non-content custom
-  props (`route`, optional `$ai_cache_read_input_tokens` /
-  `$ai_cache_creation_input_tokens` from the chat path where we already read them).
+  `$ai_latency` (seconds — `localize`/`pacing` only; omitted on the chat path,
+  where per-`onStepFinish`-step latency is not meaningful), `$ai_stream`,
+  `$ai_is_error`, plus non-content custom props (`route`, optional
+  `$ai_cache_read_input_tokens` / `$ai_cache_creation_input_tokens` from the chat
+  path where we already read them).
   The cost/token/latency/model/error dashboards all render from these; only the
   per-trace conversation drill-down (which shows message text) is intentionally
   blank — an accepted privacy tradeoff.

--- a/specs/2026-06-29-posthog-llm-observability.md
+++ b/specs/2026-06-29-posthog-llm-observability.md
@@ -207,8 +207,8 @@ Local gate (Node 24): `eslint --max-warnings 0`, `tsc --noEmit`, and targeted
 - **Deep-generation routes** (GDD / world / cutscene via `aiSdkAdapter` /
   `createSpawnforgeAgent`): same helper applies, but wiring requires threading
   `userId` + `consented` through the shared adapter signature (touches multiple
-  callers). Kept out of this PR to bound blast radius; file as a follow-up issue and
-  reference it here. fix-it-or-track-it.
+  callers). Kept out of this PR to bound blast radius; tracked in #8877
+  (fix-it-or-track-it).
 - **OTel `PostHogSpanProcessor`** distributed-trace upgrade: revisit once the
   Sentry-provider-ownership design is done (see Architecture decision).
 

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -151,7 +151,7 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 import { logCost } from '@/lib/costs/costLogger';
 import { createSpawnforgeAgent } from '@/lib/ai/spawnforgeAgent';
 import { trackAiCacheHitRate } from '@/lib/analytics/events.server';
-import { captureAiGeneration } from '@/lib/analytics/posthog-server';
+import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -622,6 +622,10 @@ describe('POST /api/chat', () => {
       expect(arg).toMatchObject({
         distinctId: 'user-1',
         consented: true,
+        // traceId is the usageId from resolveApiKey — groups the whole turn under one trace.
+        traceId: 'usage-1',
+        // model must be the resolved model, never blank (a blank model breaks PostHog dashboards).
+        model: 'claude-sonnet-4.6',
         provider: 'anthropic',
         inputTokens: 1200,
         outputTokens: 300,
@@ -635,6 +639,26 @@ describe('POST /api/chat', () => {
       expect(arg).not.toHaveProperty('$ai_input');
       expect(arg).not.toHaveProperty('messages');
       expect(arg).not.toHaveProperty('prompt');
+    });
+
+    it('forwards consented=false to capture when the user has not consented (PF-30)', async () => {
+      // Symmetric with the localize/pacing route tests: the consent value resolved
+      // pre-stream must flow through to captureAiGeneration so the helper can no-op.
+      vi.mocked(hasAnalyticsConsent).mockResolvedValueOnce(false);
+      type StepEvent = { usage: { inputTokens?: number; outputTokens?: number } };
+      let capturedOnStepFinish: ((event: StepEvent) => Promise<void>) | undefined;
+      mockStream.mockImplementation(async (opts: Record<string, unknown>) => {
+        capturedOnStepFinish = opts.onStepFinish as typeof capturedOnStepFinish;
+        return mockStreamResult;
+      });
+
+      const res = await POST(makeRequest(validBody()));
+      await res.text();
+
+      await capturedOnStepFinish!({ usage: { inputTokens: 1200, outputTokens: 300 } });
+
+      expect(captureAiGeneration).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(captureAiGeneration).mock.calls[0][0].consented).toBe(false);
     });
 
     it('does NOT capture $ai_generation when the step reports no usage', async () => {

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -92,6 +92,14 @@ vi.mock('@/lib/analytics/events.server', () => ({
   trackAiCacheHitRate: vi.fn().mockResolvedValue(undefined),
 }));
 
+// PostHog LLM observability ($ai_generation). Mocked so the route test can
+// assert the capture is invoked from onStepFinish without touching the network
+// or the dormancy/consent internals (those are unit-tested in posthog-server.test.ts).
+vi.mock('@/lib/analytics/posthog-server', () => ({
+  captureAiGeneration: vi.fn(),
+  hasAnalyticsConsent: vi.fn().mockResolvedValue(true),
+}));
+
 // Mock resolveChatRoute so tests don't depend on any backend being configured
 vi.mock('@/lib/providers/resolveChat', () => ({
   // resolveChat is no longer used by route.ts (migrated to AI SDK streamText)
@@ -143,6 +151,7 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 import { logCost } from '@/lib/costs/costLogger';
 import { createSpawnforgeAgent } from '@/lib/ai/spawnforgeAgent';
 import { trackAiCacheHitRate } from '@/lib/analytics/events.server';
+import { captureAiGeneration } from '@/lib/analytics/posthog-server';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -581,6 +590,67 @@ describe('POST /api/chat', () => {
           usageId: 'usage-1',
         }),
       );
+    });
+
+    it('captures a content-free $ai_generation event from onStepFinish (PF-907)', async () => {
+      type StepEvent = {
+        usage: {
+          inputTokens?: number;
+          outputTokens?: number;
+          inputTokenDetails?: { cacheReadTokens?: number; cacheWriteTokens?: number };
+        };
+      };
+      let capturedOnStepFinish: ((event: StepEvent) => Promise<void>) | undefined;
+      mockStream.mockImplementation(async (opts: Record<string, unknown>) => {
+        capturedOnStepFinish = opts.onStepFinish as typeof capturedOnStepFinish;
+        return mockStreamResult;
+      });
+
+      const res = await POST(makeRequest(validBody()));
+      await res.text();
+
+      await capturedOnStepFinish!({
+        usage: {
+          inputTokens: 1200,
+          outputTokens: 300,
+          inputTokenDetails: { cacheReadTokens: 800, cacheWriteTokens: 100 },
+        },
+      });
+
+      expect(captureAiGeneration).toHaveBeenCalledTimes(1);
+      const arg = vi.mocked(captureAiGeneration).mock.calls[0][0];
+      expect(arg).toMatchObject({
+        distinctId: 'user-1',
+        consented: true,
+        provider: 'anthropic',
+        inputTokens: 1200,
+        outputTokens: 300,
+        cacheReadInputTokens: 800,
+        cacheCreationInputTokens: 100,
+        stream: true,
+        isError: false,
+        route: '/api/chat',
+      });
+      // The capture input must never carry prompt/response content.
+      expect(arg).not.toHaveProperty('$ai_input');
+      expect(arg).not.toHaveProperty('messages');
+      expect(arg).not.toHaveProperty('prompt');
+    });
+
+    it('does NOT capture $ai_generation when the step reports no usage', async () => {
+      type StepEvent = { usage?: unknown };
+      let capturedOnStepFinish: ((event: StepEvent) => Promise<void>) | undefined;
+      mockStream.mockImplementation(async (opts: Record<string, unknown>) => {
+        capturedOnStepFinish = opts.onStepFinish as typeof capturedOnStepFinish;
+        return mockStreamResult;
+      });
+
+      const res = await POST(makeRequest(validBody()));
+      await res.text();
+
+      await capturedOnStepFinish!({ usage: undefined });
+
+      expect(captureAiGeneration).not.toHaveBeenCalled();
     });
 
     it('forwards cacheReadTokens and cacheWriteTokens from inputTokenDetails to logCost', async () => {

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -26,6 +26,7 @@ import { assertTier } from '@/lib/auth/api-auth';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { logCost } from '@/lib/costs/costLogger';
 import { trackAiCacheHitRate } from '@/lib/analytics/events.server';
+import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
 import { buildDocContext } from '@/lib/chat/docContext';
 import type { DocEntry } from '@/lib/docs/docsIndex';
 import { createSpawnforgeAgent } from '@/lib/ai/spawnforgeAgent';
@@ -588,6 +589,13 @@ export async function POST(request: NextRequest) {
   // 8. Convert messages
   const modelMessages = buildModelMessages(messages);
 
+  // Resolve analytics consent + one trace id for this turn, before streaming.
+  // Every step's `$ai_generation` event below shares this trace. Consent is
+  // resolved once (request scope) rather than per step; capture itself is
+  // dormant unless POSTHOG_LLM_CAPTURE is set, so this is a no-op by default.
+  const analyticsConsented = await hasAnalyticsConsent();
+  const aiTraceId = usageId ?? crypto.randomUUID();
+
   // 9. Stream via Agent and return UI message stream response
   try {
     const result = await agent.stream({
@@ -640,6 +648,27 @@ export async function POST(request: NextRequest) {
             cacheWriteTokens,
           }).catch((err: unknown) => {
             captureException(err, { route: '/api/chat', phase: 'track_cache_hit_rate' });
+          });
+        }
+
+        // PostHog LLM observability ($ai_generation) — content-free, consent-gated,
+        // dormant by default. Intentionally a BROADER guard than the billing block
+        // above (no `usageId` requirement) so gateway + BYOK steps are observed too;
+        // the helper resolves token/latency/model breakdowns without prompt content.
+        if (auth.ctx.user.id && usage) {
+          captureAiGeneration({
+            distinctId: auth.ctx.user.id,
+            consented: analyticsConsented,
+            traceId: aiTraceId,
+            model: resolvedModelId || model || '',
+            provider: usingDirect ? 'anthropic' : 'gateway',
+            inputTokens: usage.inputTokens,
+            outputTokens: usage.outputTokens,
+            stream: true,
+            isError: false,
+            route: '/api/chat',
+            cacheReadInputTokens: usage.inputTokenDetails?.cacheReadTokens,
+            cacheCreationInputTokens: usage.inputTokenDetails?.cacheWriteTokens,
           });
         }
       },

--- a/web/src/app/api/generate/localize/__tests__/route.test.ts
+++ b/web/src/app/api/generate/localize/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/**
+ * PostHog `$ai_generation` capture coverage for POST /api/generate/localize (PF-907).
+ *
+ * The full generation pipeline is exercised by createGenerationHandler.test.ts.
+ * Here we mock the factory to capture the route's own `execute` callback and drive
+ * it directly, asserting the route's contribution: one content-free, consent-gated
+ * capture per generation, all sharing a single trace id.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// The holder is created via vi.hoisted so it is initialized before the hoisted
+// vi.mock factory and the static `import '../route'` run (the route calls
+// createGenerationHandler at module-load time — a plain `let` would be in the TDZ).
+type ExecuteCtx = { userId: string; tier: string; usageId: string | undefined; tokenCost: number };
+type ExecuteFn = (params: unknown, apiKey: string, ctx: ExecuteCtx) => Promise<unknown>;
+const holder = vi.hoisted(() => ({ execute: undefined as ExecuteFn | undefined }));
+vi.mock('@/lib/api/createGenerationHandler', () => ({
+  createGenerationHandler: (config: { execute: ExecuteFn }) => {
+    holder.execute = config.execute;
+    return vi.fn();
+  },
+}));
+
+const generateText = vi.fn();
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => generateText(...args),
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn(() => (model: string) => ({ __model: model })),
+}));
+
+// Deterministic localization helpers — one chunk per locale, fixed parse output.
+vi.mock('@/lib/i18n/gameLocalization', () => ({
+  buildTranslationPrompt: () => 'translate-prompt',
+  parseTranslationResponse: () => ({ translations: { greeting: 'hola' } }),
+  chunkArray: (arr: unknown[]) => [arr],
+  LOCALE_MAP: new Map([['es', 'Spanish'], ['fr', 'French']]),
+}));
+
+const captureAiGeneration = vi.fn();
+const hasAnalyticsConsent = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/analytics/posthog-server', () => ({
+  captureAiGeneration: (...args: unknown[]) => captureAiGeneration(...args),
+  hasAnalyticsConsent: () => hasAnalyticsConsent(),
+}));
+
+import '../route';
+
+const PARAMS = {
+  strings: [{ id: 'greeting', text: 'Hello', context: 'menu' }],
+  sourceLocale: 'en',
+  targetLocales: ['es', 'fr'],
+};
+
+const CTX: ExecuteCtx = { userId: 'user-1', tier: 'pro', usageId: 'usage-1', tokenCost: 10 };
+
+describe('POST /api/generate/localize — $ai_generation capture (PF-907)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasAnalyticsConsent.mockResolvedValue(true);
+    generateText.mockResolvedValue({ text: '{"greeting":"hola"}', usage: { inputTokens: 200, outputTokens: 80 } });
+  });
+
+  it('captures one content-free event per generation, all under a single trace id', async () => {
+    expect(holder.execute).toBeDefined();
+    await holder.execute!(PARAMS, 'anthropic-key', CTX);
+
+    // 2 target locales × 1 chunk each = 2 generations.
+    expect(captureAiGeneration).toHaveBeenCalledTimes(2);
+    for (const call of captureAiGeneration.mock.calls) {
+      const arg = call[0];
+      expect(arg).toMatchObject({
+        distinctId: 'user-1',
+        consented: true,
+        traceId: 'usage-1',
+        provider: 'anthropic',
+        inputTokens: 200,
+        outputTokens: 80,
+        stream: false,
+        isError: false,
+        route: '/api/generate/localize',
+      });
+      expect(arg).not.toHaveProperty('prompt');
+      expect(arg).not.toHaveProperty('$ai_input');
+    }
+    // Same trace id across the whole localize op.
+    const traceIds = new Set(captureAiGeneration.mock.calls.map((c) => c[0].traceId));
+    expect(traceIds.size).toBe(1);
+  });
+
+  it('passes consented=false through when the user has not consented', async () => {
+    hasAnalyticsConsent.mockResolvedValue(false);
+    await holder.execute!(PARAMS, 'anthropic-key', CTX);
+    expect(captureAiGeneration.mock.calls.every((c) => c[0].consented === false)).toBe(true);
+  });
+});

--- a/web/src/app/api/generate/localize/__tests__/route.test.ts
+++ b/web/src/app/api/generate/localize/__tests__/route.test.ts
@@ -48,6 +48,8 @@ vi.mock('@/lib/analytics/posthog-server', () => ({
 }));
 
 import '../route';
+// Real constant the route forwards as the model — asserting it catches a blank model.
+import { AI_MODEL_FAST } from '@/lib/ai/models';
 
 const PARAMS = {
   strings: [{ id: 'greeting', text: 'Hello', context: 'menu' }],
@@ -76,6 +78,7 @@ describe('POST /api/generate/localize — $ai_generation capture (PF-907)', () =
         distinctId: 'user-1',
         consented: true,
         traceId: 'usage-1',
+        model: AI_MODEL_FAST,
         provider: 'anthropic',
         inputTokens: 200,
         outputTokens: 80,

--- a/web/src/app/api/generate/localize/route.ts
+++ b/web/src/app/api/generate/localize/route.ts
@@ -14,6 +14,7 @@ import {
 import { generateText } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { AI_MODEL_FAST } from '@/lib/ai/models';
+import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
 import { TOKEN_COSTS } from '@/lib/tokens/pricing';
 
 const CHUNK_SIZE = 200;
@@ -118,9 +119,14 @@ export const POST = createGenerationHandler<
     sourceLocale: params.sourceLocale,
     targetLocales: params.targetLocales,
   }),
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, { userId, usageId }) => {
     const anthropicProvider = createAnthropic({ apiKey });
     const result: Record<string, LocaleBundle> = {};
+
+    // Resolve consent + a single trace id once for the whole localize op — every
+    // per-chunk generation below is one generation in the same trace.
+    const consented = await hasAnalyticsConsent();
+    const aiTraceId = usageId ?? crypto.randomUUID();
 
     for (const targetLocale of params.targetLocales) {
       const allTranslations: Record<string, string> = {};
@@ -128,12 +134,27 @@ export const POST = createGenerationHandler<
 
       for (const chunk of chunks) {
         const prompt = buildTranslationPrompt(chunk, params.sourceLocale, targetLocale);
-        const { text: raw } = await generateText({
+        const startedAt = Date.now();
+        const { text: raw, usage } = await generateText({
           model: anthropicProvider(AI_MODEL_FAST),
           system: 'You are a professional video game localizer. Return only valid JSON.',
           prompt,
           maxOutputTokens: 4096,
           experimental_telemetry: { isEnabled: true },
+        });
+
+        captureAiGeneration({
+          distinctId: userId,
+          consented,
+          traceId: aiTraceId,
+          model: AI_MODEL_FAST,
+          provider: 'anthropic',
+          inputTokens: usage?.inputTokens,
+          outputTokens: usage?.outputTokens,
+          latencySeconds: (Date.now() - startedAt) / 1000,
+          stream: false,
+          isError: false,
+          route: '/api/generate/localize',
         });
 
         const { translations } = parseTranslationResponse(raw, chunk);

--- a/web/src/app/api/generate/pacing/__tests__/route.test.ts
+++ b/web/src/app/api/generate/pacing/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * PostHog `$ai_generation` capture coverage for POST /api/generate/pacing (PF-907).
+ *
+ * The full generation pipeline (auth, rate limit, billing, content safety) is
+ * exercised by createGenerationHandler.test.ts. Here we mock the factory to
+ * capture the route's own `execute` callback and drive it directly, so we assert
+ * exactly what the route contributes: a content-free, consent-gated capture.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// Capture the execute callback the route registers with the factory. The holder
+// is created via vi.hoisted so it is initialized before the hoisted vi.mock
+// factory and the static `import '../route'` run (which call createGenerationHandler
+// at module-load time — a plain `let` would be in the TDZ at that point).
+type ExecuteCtx = { userId: string; tier: string; usageId: string | undefined; tokenCost: number };
+type ExecuteFn = (params: unknown, apiKey: string, ctx: ExecuteCtx) => Promise<unknown>;
+const holder = vi.hoisted(() => ({ execute: undefined as ExecuteFn | undefined }));
+vi.mock('@/lib/api/createGenerationHandler', () => ({
+  createGenerationHandler: (config: { execute: ExecuteFn }) => {
+    holder.execute = config.execute;
+    return vi.fn();
+  },
+}));
+
+const generateText = vi.fn();
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => generateText(...args),
+  Output: { object: vi.fn(() => ({ __output: true })) },
+}));
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn(() => (model: string) => ({ __model: model })),
+}));
+
+const captureAiGeneration = vi.fn();
+const hasAnalyticsConsent = vi.fn().mockResolvedValue(true);
+vi.mock('@/lib/analytics/posthog-server', () => ({
+  captureAiGeneration: (...args: unknown[]) => captureAiGeneration(...args),
+  hasAnalyticsConsent: () => hasAnalyticsConsent(),
+}));
+
+// Importing the route runs createGenerationHandler(config) → captures execute.
+import '../route';
+
+const REPORT = {
+  score: 70,
+  curve: { segments: [{ sceneIndex: 0, sceneName: 'Intro', intensity: 0.5, emotion: 'calm' }], averageIntensity: 0.5, variance: 0.01 },
+  suggestions: [],
+};
+
+const CTX: ExecuteCtx = { userId: 'user-1', tier: 'pro', usageId: 'usage-1', tokenCost: 10 };
+
+describe('POST /api/generate/pacing — $ai_generation capture (PF-907)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasAnalyticsConsent.mockResolvedValue(true);
+    generateText.mockResolvedValue({ output: [], usage: { inputTokens: 500, outputTokens: 120 } });
+  });
+
+  it('captures one content-free $ai_generation event with token + latency metrics', async () => {
+    expect(holder.execute).toBeDefined();
+    await holder.execute!({ report: REPORT }, 'anthropic-key', CTX);
+
+    expect(captureAiGeneration).toHaveBeenCalledTimes(1);
+    const arg = captureAiGeneration.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      distinctId: 'user-1',
+      consented: true,
+      traceId: 'usage-1',
+      provider: 'anthropic',
+      inputTokens: 500,
+      outputTokens: 120,
+      stream: false,
+      isError: false,
+      route: '/api/generate/pacing',
+    });
+    expect(typeof arg.latencySeconds).toBe('number');
+    // Never carries prompt / response content.
+    expect(arg).not.toHaveProperty('prompt');
+    expect(arg).not.toHaveProperty('$ai_input');
+  });
+
+  it('passes consented=false through when the user has not consented', async () => {
+    hasAnalyticsConsent.mockResolvedValue(false);
+    await holder.execute!({ report: REPORT }, 'anthropic-key', CTX);
+    expect(captureAiGeneration.mock.calls[0][0].consented).toBe(false);
+  });
+});

--- a/web/src/app/api/generate/pacing/__tests__/route.test.ts
+++ b/web/src/app/api/generate/pacing/__tests__/route.test.ts
@@ -43,6 +43,8 @@ vi.mock('@/lib/analytics/posthog-server', () => ({
 
 // Importing the route runs createGenerationHandler(config) → captures execute.
 import '../route';
+// Real constant the route forwards as the model — asserting it catches a blank model.
+import { AI_MODEL_FAST } from '@/lib/ai/models';
 
 const REPORT = {
   score: 70,
@@ -69,6 +71,7 @@ describe('POST /api/generate/pacing — $ai_generation capture (PF-907)', () => 
       distinctId: 'user-1',
       consented: true,
       traceId: 'usage-1',
+      model: AI_MODEL_FAST,
       provider: 'anthropic',
       inputTokens: 500,
       outputTokens: 120,

--- a/web/src/app/api/generate/pacing/route.ts
+++ b/web/src/app/api/generate/pacing/route.ts
@@ -7,6 +7,7 @@ import { DB_PROVIDER } from '@/lib/config/providers';
 import { generateText, Output } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { AI_MODEL_FAST } from '@/lib/ai/models';
+import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
 import { z } from 'zod';
 
 interface PacingSegment {
@@ -83,8 +84,9 @@ export const POST = createGenerationHandler<
 
     return { ok: true, params: { report: r } };
   },
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, { userId, usageId }) => {
     const { report } = params;
+    const consented = await hasAnalyticsConsent();
 
     const segmentSummary = report.curve.segments
       .map((s) => `Scene ${s.sceneIndex} "${s.sceneName}": intensity=${s.intensity.toFixed(2)}, emotion=${s.emotion}`)
@@ -109,6 +111,7 @@ ${existingSuggestions || 'None yet.'}
 Generate 2–4 additional AI suggestions to improve the emotional pacing.`;
 
     const anthropicClient = createAnthropic({ apiKey });
+    const startedAt = Date.now();
     const aiResult = await generateText({
       model: anthropicClient(AI_MODEL_FAST),
       system: SYSTEM_PROMPT,
@@ -117,6 +120,20 @@ Generate 2–4 additional AI suggestions to improve the emotional pacing.`;
       temperature: 0.4,
       output: Output.object({ schema: PacingSuggestionSchema }),
       experimental_telemetry: { isEnabled: true },
+    });
+
+    captureAiGeneration({
+      distinctId: userId,
+      consented,
+      traceId: usageId ?? crypto.randomUUID(),
+      model: AI_MODEL_FAST,
+      provider: 'anthropic',
+      inputTokens: aiResult.usage?.inputTokens,
+      outputTokens: aiResult.usage?.outputTokens,
+      latencySeconds: (Date.now() - startedAt) / 1000,
+      stream: false,
+      isError: false,
+      route: '/api/generate/pacing',
     });
 
     const aiSuggestions: PacingSuggestion[] = (aiResult.output ?? []).map((s) => ({

--- a/web/src/components/CookieConsent.tsx
+++ b/web/src/components/CookieConsent.tsx
@@ -5,6 +5,18 @@ import { initPostHog } from '@/lib/analytics/posthog';
 
 const STORAGE_KEY = 'forge-cookie-consent';
 
+/**
+ * Mirror the consent choice into a server-readable cookie so server-side
+ * analytics (e.g. LLM observability, PF-907) can honor it — `localStorage` is
+ * client-only and invisible to route handlers. Non-`HttpOnly` so the client
+ * keeps managing it; site-wide; ~1 year; `Lax` to allow top-level navigations;
+ * `Secure` only over https (so it still works on the local http dev origin).
+ */
+function setConsentCookie(consented: boolean) {
+  const secure = typeof location !== 'undefined' && location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${STORAGE_KEY}=${consented ? 'true' : 'false'}; path=/; max-age=31536000; SameSite=Lax${secure}`;
+}
+
 function subscribeToStorage(callback: () => void) {
   window.addEventListener('storage', callback);
   return () => window.removeEventListener('storage', callback);
@@ -31,6 +43,7 @@ export function CookieConsent() {
 
   const handleAccept = useCallback(() => {
     localStorage.setItem(STORAGE_KEY, 'true');
+    setConsentCookie(true);
     initPostHog();
     // Force re-render via storage event won't fire in same tab — trigger
     // by dispatching a synthetic event so useSyncExternalStore picks it up.
@@ -39,6 +52,7 @@ export function CookieConsent() {
 
   const handleDecline = useCallback(() => {
     localStorage.setItem(STORAGE_KEY, 'false');
+    setConsentCookie(false);
     window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY }));
   }, []);
 

--- a/web/src/components/__tests__/CookieConsent.test.tsx
+++ b/web/src/components/__tests__/CookieConsent.test.tsx
@@ -10,11 +10,14 @@ const STORAGE_KEY = 'forge-cookie-consent';
 describe('CookieConsent', () => {
   beforeEach(() => {
     localStorage.removeItem(STORAGE_KEY);
+    // Clear the server-readable consent cookie between cases.
+    document.cookie = `${STORAGE_KEY}=; path=/; max-age=0`;
   });
 
   afterEach(() => {
     cleanup();
     localStorage.removeItem(STORAGE_KEY);
+    document.cookie = `${STORAGE_KEY}=; path=/; max-age=0`;
   });
 
   it('shows banner when no consent is stored', () => {
@@ -43,11 +46,24 @@ describe('CookieConsent', () => {
     expect(container.querySelector('[role="region"]')).toBeNull();
   });
 
+  it('writes the server-readable consent cookie =true on Accept (PF-907)', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText('Accept'));
+    // The server reads this cookie via next/headers to consent-gate $ai_generation.
+    expect(document.cookie).toContain(`${STORAGE_KEY}=true`);
+  });
+
   it('stores decline and hides banner on Decline click', () => {
     const { container } = render(<CookieConsent />);
     fireEvent.click(screen.getByText('Decline'));
     expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
     expect(container.querySelector('[role="region"]')).toBeNull();
+  });
+
+  it('writes the server-readable consent cookie =false on Decline (PF-907)', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText('Decline'));
+    expect(document.cookie).toContain(`${STORAGE_KEY}=false`);
   });
 
   it('has correct ARIA attributes', () => {

--- a/web/src/lib/analytics/__tests__/posthog-server.test.ts
+++ b/web/src/lib/analytics/__tests__/posthog-server.test.ts
@@ -220,6 +220,9 @@ describe('captureAiGeneration', () => {
     const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toBe('https://us.i.posthog.com/i/v0/e/');
     expect(init.method).toBe('POST');
+    // A timeout signal bounds each POST so a SLOW PostHog can't pin serverless
+    // compute open until maxDuration (localize can schedule ~100 of these).
+    expect(init.signal).toBeInstanceOf(AbortSignal);
     const body = JSON.parse(init.body as string);
     expect(body.event).toBe('$ai_generation');
     expect(body.distinct_id).toBe('user-123');

--- a/web/src/lib/analytics/__tests__/posthog-server.test.ts
+++ b/web/src/lib/analytics/__tests__/posthog-server.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for the dormant-by-default, content-free server LLM capture
+ * (`$ai_generation`) helper — PF-907 / #8817.
+ *
+ * The three guarantees this suite locks in:
+ *   1. DORMANT unless `POSTHOG_LLM_CAPTURE === 'true'` AND a project key is set.
+ *   2. CONSENT-gated (PF-30) — no event without explicit consent.
+ *   3. PRIVATE — the payload NEVER carries `$ai_input` / `$ai_output_choices`
+ *      (the only `$ai_*` props that hold prompt/response content).
+ */
+
+vi.mock('server-only', () => ({}));
+
+const captureException = vi.fn();
+vi.mock('@/lib/monitoring/sentry-server', () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+// `after()` is captured so the test can drive the post-response callback itself.
+// `afterThrows` simulates calling capture outside a request scope.
+const afterCallbacks: Array<() => void | Promise<void>> = [];
+let afterThrows = false;
+vi.mock('next/server', () => ({
+  after: (cb: () => void | Promise<void>) => {
+    if (afterThrows) throw new Error('after() called outside a request scope');
+    afterCallbacks.push(cb);
+  },
+}));
+
+// `cookies()` double — value and throw behavior controlled per test.
+let cookieValue: string | undefined;
+let cookiesThrows = false;
+vi.mock('next/headers', () => ({
+  cookies: async () => {
+    if (cookiesThrows) throw new Error('cookies() called outside a request scope');
+    return {
+      get: (name: string) =>
+        name === 'forge-cookie-consent' && cookieValue !== undefined
+          ? { value: cookieValue }
+          : undefined,
+    };
+  },
+}));
+
+import {
+  buildAiGenerationPayload,
+  captureAiGeneration,
+  hasAnalyticsConsent,
+  isLlmCaptureEnabled,
+  type AiGenerationInput,
+} from '../posthog-server';
+
+const VALID: AiGenerationInput = {
+  distinctId: 'user-123',
+  consented: true,
+  traceId: 'trace-abc',
+  model: 'claude-haiku-4-5',
+  provider: 'anthropic',
+  inputTokens: 100,
+  outputTokens: 50,
+  latencySeconds: 1.25,
+  stream: false,
+  isError: false,
+  route: '/api/generate/localize',
+};
+
+const ORIGINAL_ENV = { ...process.env };
+
+function enable() {
+  process.env.POSTHOG_LLM_CAPTURE = 'true';
+  process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  afterCallbacks.length = 0;
+  afterThrows = false;
+  cookieValue = undefined;
+  cookiesThrows = false;
+  delete process.env.POSTHOG_LLM_CAPTURE;
+  delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response(null, { status: 200 }))));
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.unstubAllGlobals();
+});
+
+describe('isLlmCaptureEnabled', () => {
+  it('is false when the flag is unset', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+    expect(isLlmCaptureEnabled()).toBe(false);
+  });
+
+  it('is false when the flag is set but the key is absent', () => {
+    process.env.POSTHOG_LLM_CAPTURE = 'true';
+    expect(isLlmCaptureEnabled()).toBe(false);
+  });
+
+  it('is false when the flag is any value other than the exact string "true"', () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test_key';
+    process.env.POSTHOG_LLM_CAPTURE = '1';
+    expect(isLlmCaptureEnabled()).toBe(false);
+  });
+
+  it('is true only when both the flag is "true" and a key is present', () => {
+    enable();
+    expect(isLlmCaptureEnabled()).toBe(true);
+  });
+});
+
+describe('buildAiGenerationPayload — dormancy & consent', () => {
+  it('returns null when capture is disabled (flag unset)', () => {
+    expect(buildAiGenerationPayload(VALID)).toBeNull();
+  });
+
+  it('returns null when the key is absent even with the flag set', () => {
+    process.env.POSTHOG_LLM_CAPTURE = 'true';
+    expect(buildAiGenerationPayload(VALID)).toBeNull();
+  });
+
+  it('returns null when the user has not consented', () => {
+    enable();
+    expect(buildAiGenerationPayload({ ...VALID, consented: false })).toBeNull();
+  });
+});
+
+describe('buildAiGenerationPayload — shape (enabled + consented)', () => {
+  beforeEach(enable);
+
+  it('builds a $ai_generation event with the correct envelope', () => {
+    const payload = buildAiGenerationPayload(VALID)!;
+    expect(payload).not.toBeNull();
+    expect(payload.event).toBe('$ai_generation');
+    expect(payload.distinct_id).toBe('user-123');
+    expect(payload.api_key).toBe('phc_test_key');
+  });
+
+  it('carries the non-content metric props', () => {
+    const props = buildAiGenerationPayload(VALID)!.properties as Record<string, unknown>;
+    expect(props.$ai_trace_id).toBe('trace-abc');
+    expect(props.$ai_model).toBe('claude-haiku-4-5');
+    expect(props.$ai_provider).toBe('anthropic');
+    expect(props.$ai_input_tokens).toBe(100);
+    expect(props.$ai_output_tokens).toBe(50);
+    expect(props.$ai_latency).toBe(1.25);
+    expect(props.$ai_is_error).toBe(false);
+    expect(props.route).toBe('/api/generate/localize');
+  });
+
+  it('NEVER includes content fields ($ai_input / $ai_output_choices)', () => {
+    const props = buildAiGenerationPayload(VALID)!.properties as Record<string, unknown>;
+    expect('$ai_input' in props).toBe(false);
+    expect('$ai_output_choices' in props).toBe(false);
+    // Defense in depth: the serialized JSON must not carry either content KEY.
+    // Match the quoted-key form so `$ai_input_tokens` (a legit metric whose name
+    // starts with `$ai_input`) does not false-positive.
+    const serialized = JSON.stringify(buildAiGenerationPayload(VALID));
+    expect(serialized).not.toContain('"$ai_input"');
+    expect(serialized).not.toContain('"$ai_output_choices"');
+  });
+
+  it('omits optional numeric props that are not finite', () => {
+    const props = buildAiGenerationPayload({
+      ...VALID,
+      inputTokens: undefined,
+      outputTokens: undefined,
+      latencySeconds: undefined,
+    })!.properties as Record<string, unknown>;
+    expect('$ai_input_tokens' in props).toBe(false);
+    expect('$ai_output_tokens' in props).toBe(false);
+    expect('$ai_latency' in props).toBe(false);
+  });
+
+  it('includes cache token props only when provided', () => {
+    const withCache = buildAiGenerationPayload({
+      ...VALID,
+      cacheReadInputTokens: 80,
+      cacheCreationInputTokens: 20,
+    })!.properties as Record<string, unknown>;
+    expect(withCache.$ai_cache_read_input_tokens).toBe(80);
+    expect(withCache.$ai_cache_creation_input_tokens).toBe(20);
+
+    const withoutCache = buildAiGenerationPayload(VALID)!.properties as Record<string, unknown>;
+    expect('$ai_cache_read_input_tokens' in withoutCache).toBe(false);
+    expect('$ai_cache_creation_input_tokens' in withoutCache).toBe(false);
+  });
+});
+
+describe('captureAiGeneration', () => {
+  it('fires no fetch and registers no callback when dormant', () => {
+    captureAiGeneration(VALID); // flag unset
+    expect(afterCallbacks).toHaveLength(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fires no fetch when the user has not consented', () => {
+    enable();
+    captureAiGeneration({ ...VALID, consented: false });
+    expect(afterCallbacks).toHaveLength(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('registers exactly one post-response callback when enabled + consented', () => {
+    enable();
+    captureAiGeneration(VALID);
+    expect(afterCallbacks).toHaveLength(1);
+    // The fetch only happens when the post-response callback runs.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs the event to the PostHog capture endpoint when the callback runs', async () => {
+    enable();
+    captureAiGeneration(VALID);
+    await afterCallbacks[0]();
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://us.i.posthog.com/i/v0/e/');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body.event).toBe('$ai_generation');
+    expect(body.distinct_id).toBe('user-123');
+  });
+
+  it('never throws when the fetch rejects — reports to Sentry instead', async () => {
+    enable();
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network down'))));
+    captureAiGeneration(VALID);
+    await expect(afterCallbacks[0]()).resolves.toBeUndefined();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws when after() is unavailable (no request scope)', () => {
+    enable();
+    afterThrows = true;
+    expect(() => captureAiGeneration(VALID)).not.toThrow();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('hasAnalyticsConsent', () => {
+  it('is true only when the consent cookie is exactly "true"', async () => {
+    cookieValue = 'true';
+    await expect(hasAnalyticsConsent()).resolves.toBe(true);
+  });
+
+  it('is false when the cookie value is "false"', async () => {
+    cookieValue = 'false';
+    await expect(hasAnalyticsConsent()).resolves.toBe(false);
+  });
+
+  it('is false when the consent cookie is absent', async () => {
+    cookieValue = undefined;
+    await expect(hasAnalyticsConsent()).resolves.toBe(false);
+  });
+
+  it('is false (fail-closed) when cookies() throws (no request scope)', async () => {
+    cookiesThrows = true;
+    await expect(hasAnalyticsConsent()).resolves.toBe(false);
+  });
+});

--- a/web/src/lib/analytics/posthog-server.ts
+++ b/web/src/lib/analytics/posthog-server.ts
@@ -28,6 +28,14 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 /** PostHog public capture endpoint (US cloud). Project-token authenticated. */
 const CAPTURE_URL = 'https://us.i.posthog.com/i/v0/e/';
 
+/**
+ * Hard ceiling on each capture POST. A single localize request can schedule up
+ * to ~100 `after()` callbacks (per-chunk × per-locale); without a timeout a
+ * SLOW (not down) PostHog would hold each callback's serverless compute open
+ * until the route's maxDuration. The cap bounds that to 5s per event.
+ */
+const CAPTURE_TIMEOUT_MS = 5000;
+
 /** Server-readable mirror of the client consent choice (set by CookieConsent). */
 const CONSENT_COOKIE = 'forge-cookie-consent';
 
@@ -142,6 +150,7 @@ export function captureAiGeneration(input: AiGenerationInput): void {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(CAPTURE_TIMEOUT_MS),
         });
       } catch (err) {
         captureException(err, { route: 'posthog_ai_capture', phase: 'fetch' });

--- a/web/src/lib/analytics/posthog-server.ts
+++ b/web/src/lib/analytics/posthog-server.ts
@@ -1,0 +1,154 @@
+import 'server-only';
+import { after } from 'next/server';
+import { cookies } from 'next/headers';
+import { captureException } from '@/lib/monitoring/sentry-server';
+
+/**
+ * Server-side PostHog LLM observability — content-free `$ai_generation` capture
+ * (PF-907 / #8817).
+ *
+ * We deliberately do NOT use `posthog-node` or the OpenTelemetry
+ * `PostHogSpanProcessor`. Sentry owns the server OTel provider, and adding a
+ * runtime dependency triggers the single-root-lockfile / Node-24-relock pain
+ * this repo has hit repeatedly. Server LLM events are low-volume (one per chat
+ * step / generate call), so a dependency-free `fetch` to PostHog's public
+ * capture endpoint is sufficient, simpler to keep dormant, and private by
+ * construction — see specs/2026-06-29-posthog-llm-observability.md.
+ *
+ * THREE invariants this module enforces:
+ *   1. DORMANT unless `POSTHOG_LLM_CAPTURE === 'true'` AND a project key is set.
+ *      Enabling client analytics alone does NOT activate server capture.
+ *   2. CONSENT-gated (PF-30) — `captureAiGeneration` is a no-op unless the caller
+ *      passes `consented: true` (resolve via `hasAnalyticsConsent()`).
+ *   3. PRIVATE — the payload NEVER carries `$ai_input` / `$ai_output_choices`
+ *      (the only `$ai_*` props that hold prompt/response content). The cost,
+ *      token, latency, model, and error dashboards all render without them.
+ */
+
+/** PostHog public capture endpoint (US cloud). Project-token authenticated. */
+const CAPTURE_URL = 'https://us.i.posthog.com/i/v0/e/';
+
+/** Server-readable mirror of the client consent choice (set by CookieConsent). */
+const CONSENT_COOKIE = 'forge-cookie-consent';
+
+export interface AiGenerationInput {
+  /** Clerk user id — PostHog `distinct_id`. */
+  distinctId: string;
+  /** Whether the user has consented to analytics (PF-30). Resolve via hasAnalyticsConsent(). */
+  consented: boolean;
+  /** Groups related generations into one trace (e.g. a per-request id or usageId). */
+  traceId: string;
+  /** Canonical / resolved model id (e.g. 'claude-haiku-4-5'). */
+  model: string;
+  /** LLM provider (e.g. 'anthropic'). */
+  provider: string;
+  /** Prompt token count, if known. */
+  inputTokens?: number;
+  /** Completion token count, if known. */
+  outputTokens?: number;
+  /** Wall-clock latency in SECONDS (PostHog `$ai_latency` unit), if measured. */
+  latencySeconds?: number;
+  /** Whether the generation was streamed. */
+  stream?: boolean;
+  /** Whether the generation errored. */
+  isError?: boolean;
+  /** Logical route/path for grouping in insights (custom prop, non-content). */
+  route: string;
+  /** Anthropic prompt-cache read tokens, if known (chat path). */
+  cacheReadInputTokens?: number;
+  /** Anthropic prompt-cache creation tokens, if known (chat path). */
+  cacheCreationInputTokens?: number;
+}
+
+/**
+ * True only when the dedicated server flag is exactly `"true"` AND a PostHog
+ * project key is present. No code change activates capture — it is env-only.
+ */
+export function isLlmCaptureEnabled(): boolean {
+  return (
+    process.env.POSTHOG_LLM_CAPTURE === 'true' &&
+    !!process.env.NEXT_PUBLIC_POSTHOG_KEY
+  );
+}
+
+/**
+ * Read the server-readable consent cookie. Returns `true` only when the value is
+ * exactly `'true'`. Fails closed (returns `false`) outside a request scope.
+ */
+export async function hasAnalyticsConsent(): Promise<boolean> {
+  try {
+    const store = await cookies();
+    return store.get(CONSENT_COOKIE)?.value === 'true';
+  } catch {
+    // No request scope (e.g. background task) → treat as not consented.
+    return false;
+  }
+}
+
+/**
+ * Build the `$ai_generation` capture body, or `null` when dormant / unconsented.
+ * Pure and side-effect-free so the privacy + dormancy guarantees are unit-testable.
+ *
+ * PRIVACY: deliberately omits `$ai_input` and `$ai_output_choices` — the content
+ * fields. Only non-content metrics are emitted.
+ */
+export function buildAiGenerationPayload(
+  input: AiGenerationInput,
+): Record<string, unknown> | null {
+  if (!isLlmCaptureEnabled() || !input.consented) return null;
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!apiKey) return null;
+
+  const properties: Record<string, unknown> = {
+    $ai_trace_id: input.traceId,
+    $ai_model: input.model,
+    $ai_provider: input.provider,
+    route: input.route,
+  };
+  if (Number.isFinite(input.inputTokens)) properties.$ai_input_tokens = input.inputTokens;
+  if (Number.isFinite(input.outputTokens)) properties.$ai_output_tokens = input.outputTokens;
+  if (Number.isFinite(input.latencySeconds)) properties.$ai_latency = input.latencySeconds;
+  if (typeof input.stream === 'boolean') properties.$ai_stream = input.stream;
+  if (typeof input.isError === 'boolean') properties.$ai_is_error = input.isError;
+  if (Number.isFinite(input.cacheReadInputTokens)) {
+    properties.$ai_cache_read_input_tokens = input.cacheReadInputTokens;
+  }
+  if (Number.isFinite(input.cacheCreationInputTokens)) {
+    properties.$ai_cache_creation_input_tokens = input.cacheCreationInputTokens;
+  }
+
+  return {
+    api_key: apiKey,
+    event: '$ai_generation',
+    distinct_id: input.distinctId,
+    properties,
+  };
+}
+
+/**
+ * Capture a single `$ai_generation` event. No-op when dormant or unconsented.
+ * The POST is fired after the response via `after()` so it never adds request
+ * latency and survives serverless freeze. NEVER throws — any failure (including
+ * being called outside a request scope) is reported to Sentry and swallowed.
+ */
+export function captureAiGeneration(input: AiGenerationInput): void {
+  const payload = buildAiGenerationPayload(input);
+  if (!payload) return;
+
+  try {
+    after(async () => {
+      try {
+        await fetch(CAPTURE_URL, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      } catch (err) {
+        captureException(err, { route: 'posthog_ai_capture', phase: 'fetch' });
+      }
+    });
+  } catch (err) {
+    // `after()` throws if there is no active request scope — never fail the caller.
+    captureException(err, { route: 'posthog_ai_capture', phase: 'schedule' });
+  }
+}


### PR DESCRIPTION
## Summary

Adds **dormant-by-default, consent-gated, content-free** server-side LLM observability — one PostHog `$ai_generation` event per server-side model call — powering PostHog's per-generation **cost / token / latency / model / error** dashboards.

Wired into the three routes that run a model **directly**, each inside its own callback so the shared `createGenerationHandler` single-point-of-failure is **untouched**:

- `POST /api/chat` — one event per `onStepFinish` (streamed; carries Anthropic prompt-cache read/creation tokens)
- `POST /api/generate/localize` — one event per per-chunk `generateText`, all sharing one trace id for the localize op
- `POST /api/generate/pacing` — one event per `generateText`

### Design
- **Dependency-free** `fetch` to PostHog's capture endpoint via `after()` — no `posthog-node`, no OTel `PostHogSpanProcessor` (Sentry owns the server OTel provider; a new runtime dep would trigger the repo's single-root-lockfile / Node-24-relock pain). Server LLM events are low-volume, so no batching is needed.
- **Private by construction:** `buildAiGenerationPayload()` can never emit the only two content props (`$ai_input` / `$ai_output_choices`). A unit test asserts the serialized body contains neither key.
- **Dormant by default:** no capture unless `POSTHOG_LLM_CAPTURE === "true"` **and** `NEXT_PUBLIC_POSTHOG_KEY` is set. No code change activates it; while dormant `captureAiGeneration()` is a no-op (no `fetch`, no `after()`).
- **Consent-gated (PF-30):** `CookieConsent.tsx` now also writes a server-readable `forge-cookie-consent` cookie; `hasAnalyticsConsent()` reads it via `next/headers` and **fails closed** (no request scope / cookie store throws -> `false`).
- Capture failure is swallowed to Sentry (`route: posthog_ai_capture`) and never thrown into the request path.

### Coverage note
v1 instruments the direct-call routes only. The deep generators (GDD / world / cutscene) that run through the `createGenerationHandler` agent pipeline are tracked for a follow-up adapter in #8877.

Closes #8817 (PF-907)

> **Stacked on #8816** (`feat/qstash-generation-callbacks-8816`). This PR targets that branch, so `ci.yml` does not run until #8816 merges and the base rebases to `main`. Validated locally on the Node-24 gate (eslint `--max-warnings 0`, `tsc --noEmit`, targeted vitest) — see test plan.

## Test plan
- [x] `eslint --max-warnings 0` clean on all touched files (Node 24)
- [x] `tsc --noEmit` — 0 errors (Node 24)
- [x] `vitest` green on Node 24: **81 tests pass** across the 5 touched test files (posthog-server helper, chat route, pacing route, localize route, CookieConsent), including the 22-case helper suite (dormancy x4, consent x3, payload shape x5, capture lifecycle x6, consent-cookie reader x4)
- [x] Privacy: serialized payload asserted to exclude `$ai_input` / `$ai_output_choices`
- [x] Dormant path (no env flag / no key -> no capture) and unconsented path covered
- [x] Post-merge of #8816: re-run full `ci.yml` against the rebased-to-`main` base