### PR TITLE
chore(engine): Bevy 0.19 readiness audit + unify bevy_derive 0.18 in gizmo fork

### DIFF
--- a/.claude/skills/changelog-review/SKILL.md
+++ b/.claude/skills/changelog-review/SKILL.md
@@ -60,7 +60,7 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 |---------|-----------------|-----------------|
 | Bevy | https://github.com/bevyengine/bevy/releases | 0.18.1 |
 | wasm-bindgen | https://github.com/nickel-mine/nickelmine-pkg/releases | =0.2.108 (pinned) |
-| bevy_rapier | https://github.com/dimforge/bevy_rapier/releases | 0.33 |
+| bevy_rapier | https://github.com/dimforge/bevy_rapier/releases | 0.34 |
 
 ## Procedure
 

--- a/.claude/skills/changelog-review/SKILL.md
+++ b/.claude/skills/changelog-review/SKILL.md
@@ -59,7 +59,7 @@ You are reviewing changelogs and release notes for SpawnForge's dependency stack
 | Library | Changelog Source | Current Version |
 |---------|-----------------|-----------------|
 | Bevy | https://github.com/bevyengine/bevy/releases | 0.18.1 |
-| wasm-bindgen | https://github.com/nickel-mine/nickelmine-pkg/releases | =0.2.108 (pinned) |
+| wasm-bindgen | https://github.com/rustwasm/wasm-bindgen/releases | =0.2.108 (pinned) |
 | bevy_rapier | https://github.com/dimforge/bevy_rapier/releases | 0.34 |
 
 ## Procedure

--- a/.transform-gizmo-fork/Cargo.toml
+++ b/.transform-gizmo-fork/Cargo.toml
@@ -47,7 +47,7 @@ bevy_ecs = { version = "0.18", default-features = false }
 bevy_log = { version = "0.18", default-features = false }
 bevy_window = { version = "0.18", default-features = false }
 bevy_transform = { version = "0.18", default-features = false }
-bevy_derive = { version = "0.19", default-features = false }
+bevy_derive = { version = "0.18", default-features = false }
 bevy_image = { version = "0.18", default-features = false }
 bevy_picking = { version = "0.18", default-features = false }
 

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "ef69b6d2dec07cbf407c63f6987e1746e4b735a9beea51f4bfc25ad49e344f75"
 dependencies = [
  "accesskit",
  "bevy_app",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_reflect",
 ]
@@ -329,7 +329,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_math",
  "bevy_mesh",
@@ -358,7 +358,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac120bfd5a74e05f96013817d28318dc716afaa68864af069c7ffc3ccaf9d153"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "quote",
  "syn",
 ]
@@ -373,7 +373,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
@@ -391,7 +391,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
@@ -456,7 +456,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288e1edf17069afe2e02a0c0e7e5936b3d22a67c7d2dc9201a27e4451875f909"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn",
@@ -471,7 +471,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -514,7 +514,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
@@ -540,18 +540,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
- "bevy_macro_utils 0.18.0",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "bevy_derive"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293df2b2f7ed65ef2ce02b2e7359faac1a9a92a8cc96c182c9de77eb06049ae0"
-dependencies = [
- "bevy_macro_utils 0.19.0",
+ "bevy_macro_utils",
  "quote",
  "syn",
 ]
@@ -636,7 +625,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb14c18ca71e11c69fbae873c2db129064efac6d52e48d0127d37bfba1acfa8"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn",
@@ -648,7 +637,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f89146a8fcbfe47310fc929ee762dd3b08d4de3e3371c601529cfa8eeb861de"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "encase_derive_impl",
 ]
 
@@ -678,7 +667,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60bb92e0ef80ff7c59429133244765515db3d313fae77ee67ffe94dab5b2725d"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "quote",
  "syn",
 ]
@@ -844,7 +833,7 @@ dependencies = [
  "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_dev_tools",
  "bevy_diagnostic",
  "bevy_ecs",
@@ -926,19 +915,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "bevy_macro_utils"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746a19912c6dc1bbe79188778573e8a253d5832c696b2fcb95578c17b29ff7ba"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -969,7 +946,7 @@ checksum = "288f590c8173d4cca3cae5f2ba579accd5ed1a35dd3fab338f427eb39d55f05e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -1012,7 +989,7 @@ dependencies = [
  "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_image",
@@ -1047,7 +1024,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
@@ -1093,7 +1070,7 @@ dependencies = [
  "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -1179,7 +1156,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "067af30072b1611fda1a577f1cb678b8ea2c9226133068be808dd49aac30cef0"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "indexmap",
  "proc-macro2",
  "quote",
@@ -1198,7 +1175,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_diagnostic",
  "bevy_ecs",
  "bevy_encase_derive",
@@ -1243,7 +1220,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e16b8cac95b87021399ed19f6ab79c0b1e03101a448e3a0240934f78f66a56"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "proc-macro2",
  "quote",
  "syn",
@@ -1258,7 +1235,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_camera",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_platform",
  "bevy_reflect",
@@ -1298,7 +1275,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -1323,7 +1300,7 @@ dependencies = [
  "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -1366,7 +1343,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d733081e57e49b3c43bdf3766d1de74c7df32e0f4db20c20437c85b1d18908de"
 dependencies = [
- "bevy_macro_utils 0.18.0",
+ "bevy_macro_utils",
  "quote",
  "syn",
 ]
@@ -1398,7 +1375,7 @@ dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_log",
@@ -1460,7 +1437,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_color",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_input",
@@ -1491,7 +1468,7 @@ dependencies = [
  "bevy_camera",
  "bevy_color",
  "bevy_core_pipeline",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_math",
@@ -1551,7 +1528,7 @@ dependencies = [
  "bevy_a11y",
  "bevy_android",
  "bevy_app",
- "bevy_derive 0.18.1",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_input",
  "bevy_input_focus",
@@ -4169,7 +4146,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4981,36 +4958,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5128,7 +5084,7 @@ dependencies = [
  "bevy_asset",
  "bevy_camera",
  "bevy_core_pipeline",
- "bevy_derive 0.19.0",
+ "bevy_derive",
  "bevy_ecs",
  "bevy_image",
  "bevy_input",
@@ -5998,9 +5954,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/specs/2026-07-02-bevy-0.19-readiness-audit.md
+++ b/specs/2026-07-02-bevy-0.19-readiness-audit.md
@@ -37,7 +37,7 @@
 
 The local fork at `.transform-gizmo-fork/` has its workspace `Cargo.toml` pinning `bevy 0.18` (and individual bevy_* crates at 0.18). Bevy 0.19 is a semver-incompatible major bump for bevy; the fork's workspace deps must all be updated from `version = "0.18"` to `version = "0.19"` and source patched for any upstream API changes. See Section 2 for the specific API changes affecting the fork.
 
-One anomaly noted: the fork already has `bevy_derive = { version = "0.19", ... }` on line 50 of the workspace `Cargo.toml` (likely a pre-patch artifact). This needs correcting — all bevy_* workspace deps should be consistent.
+One anomaly noted: the fork had `bevy_derive = { version = "0.19", ... }` on line 50 of the workspace `Cargo.toml` (a pre-patch artifact), which resolved a second `bevy_derive 0.19.0` into `engine/Cargo.lock` alongside the engine's `0.18.1`. **Corrected in this PR**: the fork now pins `bevy_derive = "0.18"` like every other bevy_* workspace dep, and the engine lockfile resolves a single `bevy_derive 0.18.1`.
 
 ---
 
@@ -105,8 +105,7 @@ The following 0.19 breaking changes were searched (`grep -rn`) across `engine/sr
 
 ### Phase 2 — transform-gizmo Fork Re-patch
 
-- [ ] In `.transform-gizmo-fork/Cargo.toml`, update all `bevy_*` workspace deps from `version = "0.18"` to `version = "0.19"` (9 dep entries)
-- [ ] Fix the `bevy_derive = { version = "0.19", ... }` anomaly — it should be consistent
+- [ ] In `.transform-gizmo-fork/Cargo.toml`, update all `bevy_*` workspace deps from `version = "0.18"` to `version = "0.19"` (10 dep entries — the `bevy_derive` anomaly was already normalized to 0.18 in this PR)
 - [ ] Re-run `cargo check --target wasm32-unknown-unknown --features webgl2` inside the fork's `examples/bevy/` to surface any upstream API breakage in `src/render.rs`, `src/picking.rs`, `src/mouse_interact.rs`
 - [ ] Apply fixes for any `On<T>` / `bevy_picking` / `bevy_render` API changes flagged by the compiler
 

--- a/specs/2026-07-02-bevy-0.19-readiness-audit.md
+++ b/specs/2026-07-02-bevy-0.19-readiness-audit.md
@@ -129,7 +129,7 @@ The following 0.19 breaking changes were searched (`grep -rn`) across `engine/sr
 - [ ] For any fire-and-forget task (result ignored with `let _ = ...` or `task` dropped without storing), add `.detach()` call
 - [ ] Verify no async asset loads are silently cancelled
 
-### Phase 5 — Verification (all 4 must pass)
+### Phase 5 — Verification (all 6 must pass)
 
 - [ ] `cargo check --target wasm32-unknown-unknown --features webgl2`  
   (currently passing on 0.18.1 baseline)
@@ -137,9 +137,9 @@ The following 0.19 breaking changes were searched (`grep -rn`) across `engine/sr
   (currently passing on 0.18.1 baseline)
 - [ ] `cargo test` (native, core only)  
   (currently: 219 passed, 0 failed)
-- [ ] `tonemapping_luts` feature present in Cargo.toml features — materials must NOT render pink/magenta. Do NOT remove this feature during the migration.
-- [ ] Check WASM binary size against 35 MB CI threshold (wgpu 27→29 bump may affect size)
-- [ ] Scene save/load round-trip smoke test — verify animation clips survive serialize/deserialize with new `AnimationTargetId` algorithm
+- [ ] `grep tonemapping_luts engine/Cargo.toml` — feature must still be present after the migration; without it, materials render pink/magenta. Do NOT remove this feature.
+- [ ] WASM binary size within the CI gate: the "Check WASM binary sizes" step in `quality-gates.yml` (build-wasm job) enforces `WEBGL2_THRESHOLD`/`WEBGPU_THRESHOLD` = 47185920 bytes (**45 MB**, post `wasm-opt -Oz`) with a 10% tolerance — effective limit 49.5 MB per binary. The wgpu 27→29 bump may affect size; compare the CI step output against the 0.18.1 baseline sizes before merging.
+- [ ] Animation clips survive scene serialize/deserialize under the new `AnimationTargetId` algorithm. **No existing test covers this**: `web/e2e/tests/save-load-roundtrip.spec.ts` (10 tests) exercises scene round-trips but has zero animation-clip cases, and `engine/src/core/scene_file.rs` has no native tests. The migration MUST add a test — either a case in `save-load-roundtrip.spec.ts` (create clip → save → load → assert clip present and playable) or a native round-trip test in `scene_file.rs` — before this phase can be checked off.
 
 ---
 

--- a/specs/2026-07-02-bevy-0.19-readiness-audit.md
+++ b/specs/2026-07-02-bevy-0.19-readiness-audit.md
@@ -1,0 +1,182 @@
+# Bevy 0.18.1 → 0.19.0 Readiness Audit
+
+**Ticket:** PF-934 / GitHub #8884  
+**Date:** 2026-07-02  
+**Status:** HARD-BLOCKED — upstream `bevy_rapier` has no 0.19-compatible release as of this date.
+
+**Sources (all fetched 2026-07-02):**
+- Bevy 0.19 migration guide: https://bevy.org/learn/migration-guides/0-18-to-0-19/
+- Bevy 0.19 release announcement: https://bevy.org/news/bevy-0-19/ (published 2026-06-19)
+- crates.io API queried with `User-Agent: spawnforge-dep-check`
+
+---
+
+## 1. Dependency Matrix
+
+| Dependency | Installed | Latest | bevy 0.19 compat? | Status |
+|---|---|---|---|---|
+| bevy | 0.18.1 | **0.19.0** (2026-06-19) | — | UPGRADE TARGET |
+| bevy_rapier3d/2d | 0.34.0 | 0.34.0 | requires `bevy ^0.18.1` | **HARD BLOCKED** |
+| bevy_hanabi | 0.18.0 | **0.19.0** | requires `bevy ^0.19` | READY (feature-gated `webgpu`) |
+| bevy_panorbit_camera | 0.34.0 | **0.35.0** | requires `bevy ^0.19` | READY |
+| transform-gizmo-bevy | 0.9.0 (local fork) | 0.9.0 | workspace pins `bevy 0.18` | needs re-patching |
+| wasm-bindgen | =0.2.108 (pinned) | 0.2.x | `^0.2.108` required by wgpu 29 | **PIN COMPATIBLE** |
+| wgpu (transitive) | 27.0.1 (via bevy 0.18) | 30.0.0 | bevy 0.19 uses `^29.0.3` | TRANSITIVE UPGRADE |
+| csgrs | 0.20.1 | 0.20.1 | no bevy dep | UNAFFECTED |
+| noise | 0.9.x | 0.9.x | no bevy dep | UNAFFECTED |
+
+### bevy_rapier — Blocking Detail
+
+`bevy_rapier3d` 0.34.0 (verified on crates.io 2026-07-02) declares `bevy ^0.18.1`. No release in the 0.35.x range or a bevy-0.19 branch was found on crates.io as of the audit date. **The entire coordinated engine migration is gated on Dimforge shipping bevy_rapier 0.35 (or equivalent) with `bevy ^0.19`.**
+
+### wasm-bindgen Pin
+
+`wgpu 29.0.3` (the version required by bevy_render 0.19) declares `wasm-bindgen ^0.2.108`. Our existing pin `=0.2.108` satisfies `^0.2.108`. **The pin does not need to change for a bevy 0.19 migration.** The pin should only move with explicit user approval per the engine architecture rules.
+
+### transform-gizmo-fork
+
+The local fork at `.transform-gizmo-fork/` has its workspace `Cargo.toml` pinning `bevy 0.18` (and individual bevy_* crates at 0.18). Bevy 0.19 is a semver-incompatible major bump for bevy; the fork's workspace deps must all be updated from `version = "0.18"` to `version = "0.19"` and source patched for any upstream API changes. See Section 2 for the specific API changes affecting the fork.
+
+One anomaly noted: the fork already has `bevy_derive = { version = "0.19", ... }` on line 50 of the workspace `Cargo.toml` (likely a pre-patch artifact). This needs correcting — all bevy_* workspace deps should be consistent.
+
+---
+
+## 2. API-Change Impact Scan
+
+The Bevy 0.19 migration guide was fetched in full (2026-07-02). Every breaking change listed was grepped against `engine/src/`. The following table records actionable hits (APIs we USE) and explicitly dismisses non-hits:
+
+### Actionable — Changes Required in Our Source
+
+| Change | Migration Guide | Our Usage | File:Line |
+|---|---|---|---|
+| `bevy::scene::SceneRoot` → `bevy::world_serialization::WorldAssetRoot` | Scene system renamed `bevy_scene` → `bevy_world_serialization`; `SceneRoot` → `WorldAssetRoot` | `use bevy::scene::SceneRoot;` + `SceneRoot(scene_handle)` spawn | `engine/src/bridge/scene_io.rs:593,616` |
+| `Skybox::image` now `Option<Handle<Image>>` | `Skybox::image` field changed from `Handle<Image>` to `Option<Handle<Image>>` | Three sites construct `Skybox { image: handle }` — must become `image: Some(handle)` | `engine/src/bridge/material.rs:129,130,144,145,305,306` |
+| `bevy_scene` feature → `bevy_world_serialization` | Scene crate renamed | `"bevy_scene"` in features list in `engine/Cargo.toml:line 47` | `engine/Cargo.toml` |
+
+### Actionable — transform-gizmo-fork Re-patching
+
+The fork uses `bevy 0.18` workspace pins across all `bevy_*` sub-crates. For 0.19, all `version = "0.18"` entries in `.transform-gizmo-fork/Cargo.toml` must be bumped to `"0.19"`, and the fork source patched for any bevy_picking, bevy_render, or bevy_pbr API changes that affect `src/render.rs`, `src/picking.rs`, and `src/mouse_interact.rs`.
+
+### Non-Actionable — Checked but Not Used in Our Source
+
+The following 0.19 breaking changes were searched (`grep -rn`) across `engine/src/` and returned zero hits. They require no action during migration:
+
+| Change | Search Term | Result |
+|---|---|---|
+| `WgpuSettingsPriority::Compatibility` → `WgpuSettingsPriority::WebGPU` | `WgpuSettingsPriority` | Not found |
+| `ShaderStorageBuffer` → `ShaderBuffer` | `ShaderStorageBuffer` | Not found |
+| `MorphPlugin` removed | `MorphPlugin` | Not found |
+| `AnimationTargetId` algorithm changed | `AnimationTargetId` | Not found |
+| `ExecutorKind` removed | `ExecutorKind` | Not found |
+| `non_send_resource` → `non_send` method renames | `non_send_resource` | Not found |
+| `ResourceData<SEND: true>` / `Resources<SEND: true>` removed | `ResourceData\|Resources<SEND` | Not found |
+| `SceneRoot(handle)` for GLTF via `SceneSpawner` | `SceneSpawner` | Not found (our GLTF load uses `SceneRoot` component directly — covered above) |
+| `PipelineCacheError` → `ShaderCacheError` | `PipelineCacheError` | Not found |
+| `bevy_gltf` now optional | uses `bevy_gltf` feature explicitly | Our Cargo.toml explicitly enables `"bevy_gltf"` — no change needed |
+
+### Notable 0.19 Changes Affecting Engine Architecture (No Code Change Now)
+
+- **Resources as Components:** `#[derive(Resource)]` now implements `Component`. Broad queries (`Query<()>`, `Query<Entity>`) may conflict with resource access; `Without<IsResource>` filter needed. Our ECS systems use typed queries — risk is low but should be verified during migration.
+- **wgpu 27 → 29 (transitive):** A two-major-version bump in the GPU layer. WebGPU and WebGL2 rendering behavior should be unchanged at the API boundary we use, but WASM binary size may shift. CI WASM size gate (35 MB threshold) must be re-checked post-migration.
+- **`AnimationTargetId` algorithm change:** Breaks existing saved animation targets. Our engine serializes animation clips as part of scene snapshots — verify scene round-trip doesn't silently lose animation assignments after migration.
+- **WASM `Task<T>` drop now cancels:** Call `.detach()` for fire-and-forget. We use `Task` in the bridge for async asset loads; existing `let _ = task` patterns may now cancel instead of running to completion. Audit all `Task` usages in `bridge/` when migrating.
+
+---
+
+## 3. Go/No-Go Migration Checklist
+
+**Current verdict: NO-GO.** The hard blocker is bevy_rapier. All steps below are the ordered sequence for when rapier unblocks.
+
+### Phase 0 — Unblock Condition (external dependency)
+
+- [ ] `bevy_rapier3d` ≥ 0.35.0 published on crates.io with `bevy ^0.19` dependency
+- [ ] Monitor: https://github.com/dimforge/bevy_rapier/releases
+- [ ] When released: verify `bevy_rapier2d` 0.35.0 also ships simultaneously (historically they ship together)
+
+### Phase 1 — Cargo.toml Manifest Bumps
+
+- [ ] Bump `bevy` from `"0.18.1"` to `"0.19.0"` in `engine/Cargo.toml`
+- [ ] Bump `bevy_rapier3d` from `"0.34"` to `"0.35"` in `engine/Cargo.toml`
+- [ ] Bump `bevy_rapier2d` from `"0.34"` to `"0.35"` in `engine/Cargo.toml`
+- [ ] Bump `bevy_panorbit_camera` from `"0.34"` to `"0.35"` in `engine/Cargo.toml`
+- [ ] Bump `bevy_hanabi` from `"0.18"` to `"0.19"` in `engine/Cargo.toml`
+- [ ] Rename `"bevy_scene"` feature to `"bevy_world_serialization"` in `engine/Cargo.toml` features list
+- [ ] **wasm-bindgen: do NOT change.** `=0.2.108` satisfies wgpu 29's `^0.2.108` requirement.
+
+### Phase 2 — transform-gizmo Fork Re-patch
+
+- [ ] In `.transform-gizmo-fork/Cargo.toml`, update all `bevy_*` workspace deps from `version = "0.18"` to `version = "0.19"` (9 dep entries)
+- [ ] Fix the `bevy_derive = { version = "0.19", ... }` anomaly — it should be consistent
+- [ ] Re-run `cargo check --target wasm32-unknown-unknown --features webgl2` inside the fork's `examples/bevy/` to surface any upstream API breakage in `src/render.rs`, `src/picking.rs`, `src/mouse_interact.rs`
+- [ ] Apply fixes for any `On<T>` / `bevy_picking` / `bevy_render` API changes flagged by the compiler
+
+### Phase 3 — Engine Source Fixes (3 required changes)
+
+1. **`engine/src/bridge/scene_io.rs:593,616`**
+   - `use bevy::scene::SceneRoot;` → `use bevy::world_serialization::WorldAssetRoot;`
+   - `SceneRoot(scene_handle)` → `WorldAssetRoot(scene_handle)`
+
+2. **`engine/src/bridge/material.rs:129,144,305`**
+   - `Skybox { image: handle }` → `Skybox { image: Some(handle) }` (3 sites)
+   - `Skybox { image: handle.clone() }` → `Skybox { image: Some(handle.clone()) }` (1 site at line 145)
+
+3. **`engine/Cargo.toml`**
+   - Remove `"bevy_scene"` from features list
+   - Add `"bevy_world_serialization"` to features list
+
+### Phase 4 — Task<T> WASM Audit
+
+- [ ] Grep `engine/src/bridge/` for all `Task` usages
+- [ ] For any fire-and-forget task (result ignored with `let _ = ...` or `task` dropped without storing), add `.detach()` call
+- [ ] Verify no async asset loads are silently cancelled
+
+### Phase 5 — Verification (all 4 must pass)
+
+- [ ] `cargo check --target wasm32-unknown-unknown --features webgl2`  
+  (currently passing on 0.18.1 baseline)
+- [ ] `cargo check --target wasm32-unknown-unknown --features webgpu`  
+  (currently passing on 0.18.1 baseline)
+- [ ] `cargo test` (native, core only)  
+  (currently: 219 passed, 0 failed)
+- [ ] `tonemapping_luts` feature present in Cargo.toml features — materials must NOT render pink/magenta. Do NOT remove this feature during the migration.
+- [ ] Check WASM binary size against 35 MB CI threshold (wgpu 27→29 bump may affect size)
+- [ ] Scene save/load round-trip smoke test — verify animation clips survive serialize/deserialize with new `AnimationTargetId` algorithm
+
+---
+
+## 4. Effort Estimate
+
+| Work Item | Estimate |
+|---|---|
+| Cargo.toml manifest bumps + lockfile regeneration | 30 min |
+| transform-gizmo fork re-patch | 2–4 hours (unknown API breakage surface) |
+| Engine source fixes (3 known changes) | 1 hour |
+| `Task<T>` WASM audit in bridge/ | 1 hour |
+| WASM build verification (both backends) | 30 min per backend; first build after major dep bump is typically 15–20 min |
+| Animation round-trip smoke test | 1 hour |
+| **Total (excludes rapier unblock wait)** | **~1.5 days** |
+
+Effort excludes the time waiting for `bevy_rapier` to release. The migration should be treated as a single coordinated PR once rapier unblocks — do not partially migrate (e.g. bumping bevy without rapier) as the engine will not compile.
+
+---
+
+## 5. Baseline Verification (2026-07-02)
+
+The following verification was run on the current `deps/engine-refresh-bevy019-audit` branch before this spec was written:
+
+```
+cargo check --target wasm32-unknown-unknown --features webgl2
+→ Finished `dev` profile; 2 dead_code warnings only (PASS)
+
+cargo check --target wasm32-unknown-unknown --features webgpu
+→ Finished `dev` profile; 2 dead_code warnings only (PASS)
+
+cargo test (native)
+→ test result: ok. 219 passed; 0 failed; 0 ignored (PASS)
+```
+
+wasm-bindgen lock pin: `=0.2.108` — verified unchanged.
+
+### Lockfile State Note
+
+The lockfile (`engine/Cargo.lock`) was already at csgrs 0.20.1 at the start of this branch. A blanket `cargo update` fails with `error: failed to select a version for the requirement core2 = "^0.4"` — this is a cargo resolver quirk: when re-resolving `csgrs ^0.20` from scratch, the resolver encounters csgrs 0.20.0 as a candidate, but csgrs 0.20.0 has a yanked transitive dep (`core2 0.4.0`). The lock file is correct at 0.20.1; targeted `cargo update -p serde -p serde_json -p tracing` confirmed these are already at latest compatible versions (0 packages updated). No further lockfile changes are needed or possible without the blanket-update blocker being resolved upstream (e.g., crates.io yanking csgrs 0.20.0 itself).


### PR DESCRIPTION
## Summary

- **Bevy 0.19 readiness audit** committed as `specs/2026-07-02-bevy-0.19-readiness-audit.md`: full dependency matrix, API-change impact scan (3 actionable changes found), go/no-go migration checklist, effort estimate
- **bevy_derive unification (review fix, pre-existing on main):** `.transform-gizmo-fork/Cargo.toml` pinned `bevy_derive = "0.19"` while every sibling bevy_* workspace dep is `0.18`, resolving BOTH `bevy_derive 0.18.1` and `0.19.0` into `engine/Cargo.lock`. Normalized to `0.18`; lockfile deduped via `cargo update -p bevy_derive@0.19.0 --precise 0.18.1` (also drops orphaned `bevy_macro_utils 0.19.0` + stray toml crates)
- **Dep refresh outcome: zero version bumps needed.** Lockfile already at csgrs 0.20.1; targeted update for serde/serde_json/tracing confirms latest compatible (0 packages to update). A blanket `cargo update` fails on a cargo resolver quirk (csgrs 0.20.0 has a yanked transitive dep `core2 0.4.0`); the lock itself is correct
- `wasm-bindgen =0.2.108` pin verified unchanged; compatible with wgpu 29.x (`^0.2.108` requirement confirmed via crates.io)
- Boy Scout in `.claude/skills/changelog-review/SKILL.md`: bevy_rapier 0.33 → 0.34 (stale since #8569) and wasm-bindgen changelog URL corrected to `rustwasm/wasm-bindgen` (was a non-canonical repo; security review finding)
- Follow-up blocked migration ticket filed as #8887

Closes #8884 (PF-934)
Follow-up blocked migration: #8887

## Verification Results

```
cargo check --target wasm32-unknown-unknown --features webgl2
→ Finished dev profile; 2 dead_code warnings, pre-existing (PASS)

cargo check --target wasm32-unknown-unknown --features webgpu
→ Finished dev profile; 2 dead_code warnings, pre-existing (PASS)

cargo test (native)
→ test result: ok. 219 passed; 0 failed; 0 ignored (PASS)

wasm-bindgen in Cargo.lock: =0.2.108 (UNCHANGED)
csgrs in Cargo.lock: 0.20.1 (CORRECT)
bevy_derive in Cargo.lock: single entry 0.18.1 (was 0.18.1 + 0.19.0)
```

## Bevy 0.19 Audit Headline

**GO/NO-GO: NO-GO** — blocked on `bevy_rapier3d` 0.35 (no release as of 2026-07-02). When unblocked: 3 engine source changes, transform-gizmo fork re-patch, wasm-bindgen pin stays at =0.2.108. See `specs/2026-07-02-bevy-0.19-readiness-audit.md` for full detail.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown --features webgl2` — PASS
- [x] `cargo check --target wasm32-unknown-unknown --features webgpu` — PASS
- [x] `cargo test` (native core) — PASS (219 tests)
- [x] `grep wasm-bindgen engine/Cargo.lock` — confirms =0.2.108 unchanged
- [x] `grep -A1 'name = "bevy_derive"' engine/Cargo.lock` — single 0.18.1 entry