### PR TITLE
feat(analytics): per-surface $ai_generation attribution for deep generators

### DIFF
--- a/.changeset/posthog-deep-gen-attribution.md
+++ b/.changeset/posthog-deep-gen-attribution.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Add per-surface $ai_generation attribution for GDD, world builder, and cutscene generators so PostHog can distinguish deep-generator token usage from interactive chat traffic.

--- a/docs/guides/posthog-llm-observability.md
+++ b/docs/guides/posthog-llm-observability.md
@@ -104,9 +104,21 @@ nothing scheduled. No data migration is involved.
 
 ## Coverage note
 
-v1 instruments the three routes that run a model **directly** (`generateText` /
-streamed chat). The deep generators that go through the `createGenerationHandler`
-agent pipeline (GDD, world builder, cutscene, etc.) are **not** yet instrumented
-— capturing their token usage cleanly needs a small adapter at the agent
-boundary rather than per-route wiring. That follow-up is tracked in #8877 so
-this PR stays scoped to the direct-call routes.
+The three deep generators (GDD, world builder, cutscene) call `/api/chat` from
+client-side modules (`gddGenerator.ts`, `worldBuilder.ts`, `cutsceneGenerator.ts`)
+and are therefore captured by the same `$ai_generation` event as interactive
+chat. Each passes a `surface` field in the request body; the route validates it
+against the `DEEP_GEN_SURFACES` allowlist and labels the event accordingly:
+
+| Generator | PostHog `route` label |
+|---|---|
+| GDD | `/api/chat#gdd` |
+| World builder | `/api/chat#world_builder` |
+| Cutscene | `/api/chat#cutscene` |
+
+Insights that use **exact equality** on `route = '/api/chat'` will **not** match
+deep-generator events — that is intentional; those events are now separately
+addressable. Insights using prefix/contains (`route contains '/api/chat'`) match
+all traffic including deep generators. This change was delivered by #8877; no
+agent-boundary adapter exists or is needed, and `createGenerationHandler` is not
+involved in LLM generation for these features.

--- a/specs/2026-07-02-posthog-deep-generator-attribution.md
+++ b/specs/2026-07-02-posthog-deep-generator-attribution.md
@@ -36,18 +36,36 @@ Flow a validated, enum-constrained `surface` label from the deep-generator clien
 modules through the `/api/chat` request body into the existing capture call.
 
 ### 1. Client — `web/src/lib/ai/client.ts`
-- Add `surface?: AiSurface` to `AIClientOptions` (type re-exported from the shared
-  module below). When present, include `surface` in the `/api/chat` POST body
-  (both `fetchAI`/`fetchAIUncached` and `streamAI` if trivially shareable — scope
-  minimum is the non-streaming path the deep generators use).
+- Add `surface?: DeepGenSurface` to `AIClientOptions` (type imported from the
+  shared leaf module below). When present, include `surface` in the `/api/chat`
+  POST body using the conditional-spread idiom the body already uses for
+  `effort`/`systemOverride` (`client.ts:149-156`) — callers that pass no surface
+  produce byte-identical bodies to today. (Both `fetchAI`/`fetchAIUncached` and
+  `streamAI` if trivially shareable — scope minimum is the non-streaming path
+  the deep generators use.)
 - Include `surface` in the response-cache key alongside `model`/`effort` — two
   surfaces sharing a prompt must not cross-contaminate labels. (Cache key today:
-  `client.ts:119`.)
+  `computeKey`, `client.ts:119`.)
 
-### 2. Shared surface enum — `web/src/lib/ai/deepTier.ts`
-- `DeepGenSurface` (`'gdd' | 'world_builder' | 'cutscene'`) already exists
-  (`deepTier.ts:17`). Derive the wire allowlist from it — single source of truth;
-  do NOT duplicate a string union in the route.
+### 2. Shared surface allowlist — new leaf module `web/src/lib/ai/surfaces.ts`
+- `DeepGenSurface` (`'gdd' | 'world_builder' | 'cutscene'`) exists today only as
+  a **type alias** (`deepTier.ts:17`) — types are erased at runtime, so the wire
+  allowlist cannot literally be "derived from the type". A runtime `as const`
+  array must be the source and the type derived from it.
+- The array cannot live in `deepTier.ts`: that module value-imports `trackEvent`
+  from the client-side analytics module (`deepTier.ts:14`), so a value import
+  from the server route would pull client analytics code into the server bundle.
+- Therefore create a dependency-free leaf module `web/src/lib/ai/surfaces.ts`:
+  ```ts
+  export const DEEP_GEN_SURFACES = ['gdd', 'world_builder', 'cutscene'] as const;
+  export type DeepGenSurface = (typeof DEEP_GEN_SURFACES)[number];
+  ```
+- `deepTier.ts` replaces its local alias with
+  `export type { DeepGenSurface } from './surfaces';` — its existing importers
+  (the three generators) keep working unchanged.
+- The route imports the `DEEP_GEN_SURFACES` value from the leaf module only;
+  `client.ts` imports the type only. Single source of truth, no duplicated
+  union, no client analytics in the server bundle.
 
 ### 3. Deep generators — pass their surface
 - `gddGenerator.ts:350` → `surface: 'gdd'`
@@ -56,31 +74,65 @@ modules through the `/api/chat` request body into the existing capture call.
 
 ### 4. Server — `web/src/app/api/chat/route.ts`
 - Extend the parsed body type (~line 318) with `surface?: string`.
-- Validate: accept only exact members of the `DeepGenSurface` allowlist; anything
-  else (wrong type, unknown value, empty) → treat as absent. Never reject the
-  request over it (additive, non-breaking), never echo it back in an error.
+- Validate using the repo's manual-validation convention (typeof + allowlist,
+  matching the route's existing body checks — no Zod here):
+  ```ts
+  import { DEEP_GEN_SURFACES, type DeepGenSurface } from '@/lib/ai/surfaces';
+
+  const surface: DeepGenSurface | undefined =
+    typeof body.surface === 'string' &&
+    (DEEP_GEN_SURFACES as readonly string[]).includes(body.surface)
+      ? (body.surface as DeepGenSurface)
+      : undefined;
+  ```
+  Anything else (wrong type, unknown value, empty string) → treated as absent.
+  Never reject the request over it (additive, non-breaking), never echo the raw
+  value back in an error or response.
 - In the `captureAiGeneration` call (route.ts:659): keep
   `route: '/api/chat'` and add the surface as the event's route qualifier:
   `route: surface ? `/api/chat#${surface}` : '/api/chat'`.
-  Rationale: keeps one dashboard dimension (`route`) rather than a second custom
-  prop; existing insights filtering on prefix `/api/chat` keep working. The `#`
-  form cannot collide with a real route path.
+- Why the `#` form is safe: `route` is a plain, non-`$` custom property —
+  `buildAiGenerationPayload` emits it verbatim (`posthog-server.ts:113`,
+  `route: input.route`). PostHog stores custom property values as opaque
+  strings and applies no URL/fragment parsing to them, so `#` carries no
+  special semantics; it is simply a separator that cannot collide with a real
+  route path. This keeps one dashboard dimension (`route`) instead of adding a
+  second custom prop; existing insights filtering on prefix/contains
+  `/api/chat` keep working. Insights using EXACT equality
+  (`route = '/api/chat'`) will stop matching deep-generator events — that is
+  the purpose of this change (separating the traffic), not a regression; the
+  runbook update (§5) documents it.
 - The label is server-validated enum data — content-free by construction; the
   privacy invariant (`$ai_input`/`$ai_output_choices` never sent) is untouched
   because `buildAiGenerationPayload` is not modified.
 
 ### 5. Runbook — `docs/guides/posthog-llm-observability.md`
-- Update the "Coverage note" to state deep generators are captured with per-surface
-  labels (`/api/chat#gdd`, `/api/chat#world_builder`, `/api/chat#cutscene`) and
-  correct the stale claim that they were uncaptured.
+- The `## Coverage note` section (line 105) currently reads:
+  > v1 instruments the three routes that run a model **directly** (`generateText` /
+  > streamed chat). The deep generators that go through the `createGenerationHandler`
+  > agent pipeline (GDD, world builder, cutscene, etc.) are **not** yet instrumented
+  > — capturing their token usage cleanly needs a small adapter at the agent
+  > boundary rather than per-route wiring. That follow-up is tracked in #8877 so
+  > this PR stays scoped to the direct-call routes.
+- Both load-bearing claims are stale (see Corrected premise): the deep
+  generators do NOT go through `createGenerationHandler`, and their usage IS
+  captured today (unlabeled). Replace the section body to state: the deep
+  generators call `/api/chat` from client modules and are captured with
+  per-surface labels (`/api/chat#gdd`, `/api/chat#world_builder`,
+  `/api/chat#cutscene`); insights using exact equality on
+  `route = '/api/chat'` exclude them by design; #8877 delivered this change
+  (it is no longer a pending follow-up, and no agent-boundary adapter exists
+  or is needed).
 
 ## Explicitly out of scope
-- Any change to `createGenerationHandler` / `generationAgent` (PF-916 owns that).
+- Any change to `createGenerationHandler` / `generationAgent` (PF-916 / #8826
+  owns that; it is open and independently sequenced — nothing here depends on
+  or blocks it).
 - Capturing non-LLM asset generations as `$ai_generation` (wrong event semantics).
 - `posthog-node` / OTel span processors (parent spec's standing decision).
 - Streaming chat UI surface labels beyond what falls out of the shared option.
 
-## Constraints (inherited from parent spec — must hold)
+## Constraints (inherited from `specs/2026-06-29-posthog-llm-observability.md`, restated in full so this spec is self-contained — must hold)
 - Never send `$ai_input` / `$ai_output_choices`.
 - Dormant by default (`POSTHOG_LLM_CAPTURE !== 'true'` → no behavior change).
 - Consent-gated via `hasAnalyticsConsent()`; fails closed.
@@ -89,17 +141,49 @@ modules through the `/api/chat` request body into the existing capture call.
 - No `createGenerationHandler` control-flow changes (SPOF rule).
 
 ## Test plan (test-first)
-Failing tests written before implementation:
-1. `web/src/app/api/chat/__tests__` (or the existing chat route test file):
-   (a) request with `surface: 'gdd'` → capture called with `route: '/api/chat#gdd'`;
-   (b) unknown `surface: 'evil<script>'` → capture called with `route: '/api/chat'`
-       and the raw value appears NOWHERE in the serialized payload;
+Failing tests written before implementation. All files below run in the node
+environment (`vitest.config.node.ts`); mock via `@/lib/...` aliases only (repo
+mock rule — never relative paths in `vi.mock`).
+
+1. `web/src/app/api/chat/__tests__/route.test.ts` — mock the capture module with
+   `vi.mock('@/lib/analytics/posthog-server')`; every assertion below targets
+   the capture ARGUMENT, `vi.mocked(captureAiGeneration).mock.calls[0][0]`:
+   (a) parametrized over ALL THREE surfaces
+       (`test.each([...DEEP_GEN_SURFACES])`): request with `surface: s` →
+       capture called with `route: '/api/chat#' + s`. A single-value test
+       cannot catch an allowlist that omits `world_builder` or `cutscene`;
+   (b) unknown `surface: 'evil<script>'` → capture called with
+       `route: '/api/chat'` AND
+       `JSON.stringify(vi.mocked(captureAiGeneration).mock.calls[0][0])`
+       does not contain the raw string; additionally assert the HTTP response
+       body does not echo it;
    (c) absent surface → unchanged `route: '/api/chat'` (regression);
-   (d) payload still contains no `$ai_input`/`$ai_output_choices` keys.
-2. `web/src/lib/ai/__tests__/client.test.ts`: `fetchAI({surface})` puts `surface`
-   in the POST body; cache keys differ for identical prompts with different surfaces.
-3. One deep-generator test (`gddGenerator`): `generateGDD` passes `surface: 'gdd'`.
-4. Existing #8817 tests must pass unmodified (no weakening).
+   (d) the capture argument passed by the route still carries no
+       `$ai_input`/`$ai_output_choices`-bearing fields — this is the
+       route-integration guard; the payload-construction guarantee itself is
+       already unit-covered by
+       `web/src/lib/analytics/__tests__/posthog-server.test.ts` (which this
+       spec does not modify).
+2. `web/src/lib/ai/__tests__/client.test.ts`: `fetchAI({surface})` puts
+   `surface` in the POST body; callers passing no surface produce
+   byte-identical bodies and cache keys to today; cache keys DIFFER for
+   identical prompts with different surfaces (isolation) and MATCH for
+   identical prompts with the same surface (dedup still works).
+3. All three deep-generator test files (not just one — two of three generators
+   untested is a real allowlist/wiring escape):
+   - `web/src/lib/ai/__tests__/gddGenerator.test.ts` — mocks `@/lib/ai/client`
+     (line 14); assert the `fetchAI` call options include `surface: 'gdd'`.
+   - `web/src/lib/ai/__tests__/cutsceneGenerator.test.ts` — mocks
+     `@/lib/ai/client` (line 202); assert `surface: 'cutscene'` the same way.
+   - `web/src/lib/ai/__tests__/worldBuilder.test.ts` — NOTE: this file stubs
+     GLOBAL `fetch` (`vi.stubGlobal('fetch', ...)`, line 345) and exercises the
+     real client code, so assert on the outgoing request instead:
+     `JSON.parse(vi.mocked(fetch).mock.calls[0][1].body)` contains
+     `surface: 'world_builder'`.
+4. Regression: the #8817 suite
+   `web/src/lib/analytics/__tests__/posthog-server.test.ts` (covering
+   `buildAiGenerationPayload` / `captureAiGeneration`) must pass unmodified —
+   no weakening.
 
 ## Acceptance criteria (mapped from ticket, corrected)
 - Each of the three deep generators emits its `$ai_generation` with a

--- a/specs/2026-07-02-posthog-deep-generator-attribution.md
+++ b/specs/2026-07-02-posthog-deep-generator-attribution.md
@@ -1,0 +1,112 @@
+# Spec: Per-surface attribution for deep-generator `$ai_generation` events (PF-DEEP-LLM-ATTR)
+
+**Ticket:** #8877 (taskboard 01KWAVZ8E53GHX8SMH3A8MEHV9)
+**Parent spec:** `specs/2026-06-29-posthog-llm-observability.md` (#8817 / PF-907)
+**Milestone:** E3: Instrumentation & Growth Metrics
+
+## Corrected premise (supersedes the ticket description)
+
+The ticket assumed the deep generators (GDD, world builder, cutscene) run their model
+calls through `createGenerationHandler` and are therefore *not* captured. Code
+inspection shows otherwise:
+
+1. `web/src/lib/ai/gddGenerator.ts` (`generateGDD`), `web/src/lib/ai/worldBuilder.ts`,
+   and `web/src/lib/ai/cutsceneGenerator.ts` are **client-side** modules. Each calls
+   `fetchAI(...)` (`web/src/lib/ai/client.ts:102`) with
+   `model: getDeepGenerationModel(<surface>)` + a `systemOverride`, which POSTs to
+   `/api/chat`.
+2. `/api/chat` already emits a content-free `$ai_generation` per call (#8817) via
+   `captureAiGeneration` (`web/src/app/api/chat/route.ts:659`), so deep-generator
+   token/cost/latency IS captured today — but with the hardcoded label
+   `route: '/api/chat'`, indistinguishable from interactive chat traffic.
+3. `createGenerationHandler` routes (`/api/generate/model|music|sfx|skybox|...`) are
+   non-LLM asset providers (Meshy, Suno, ElevenLabs, Replicate). There is no LLM
+   generation there to capture; the two LLM routes under `/api/generate/`
+   (localize, pacing) were already instrumented directly by #8817.
+
+**The real gap is attribution, not capture**: PostHog cannot answer "what does GDD
+generation cost vs. chat?" because every deep-generator event is labeled
+`/api/chat`. This spec closes that gap. No adapter inside `createGenerationHandler`
+is needed or appropriate (it must not grow LLM-observability concerns — see PF-916,
+which is *retiring* that factory's SPOF status).
+
+## Design
+
+Flow a validated, enum-constrained `surface` label from the deep-generator client
+modules through the `/api/chat` request body into the existing capture call.
+
+### 1. Client — `web/src/lib/ai/client.ts`
+- Add `surface?: AiSurface` to `AIClientOptions` (type re-exported from the shared
+  module below). When present, include `surface` in the `/api/chat` POST body
+  (both `fetchAI`/`fetchAIUncached` and `streamAI` if trivially shareable — scope
+  minimum is the non-streaming path the deep generators use).
+- Include `surface` in the response-cache key alongside `model`/`effort` — two
+  surfaces sharing a prompt must not cross-contaminate labels. (Cache key today:
+  `client.ts:119`.)
+
+### 2. Shared surface enum — `web/src/lib/ai/deepTier.ts`
+- `DeepGenSurface` (`'gdd' | 'world_builder' | 'cutscene'`) already exists
+  (`deepTier.ts:17`). Derive the wire allowlist from it — single source of truth;
+  do NOT duplicate a string union in the route.
+
+### 3. Deep generators — pass their surface
+- `gddGenerator.ts:350` → `surface: 'gdd'`
+- `worldBuilder.ts` (its `fetchAI` call) → `surface: 'world_builder'`
+- `cutsceneGenerator.ts` (its `fetchAI` call) → `surface: 'cutscene'`
+
+### 4. Server — `web/src/app/api/chat/route.ts`
+- Extend the parsed body type (~line 318) with `surface?: string`.
+- Validate: accept only exact members of the `DeepGenSurface` allowlist; anything
+  else (wrong type, unknown value, empty) → treat as absent. Never reject the
+  request over it (additive, non-breaking), never echo it back in an error.
+- In the `captureAiGeneration` call (route.ts:659): keep
+  `route: '/api/chat'` and add the surface as the event's route qualifier:
+  `route: surface ? `/api/chat#${surface}` : '/api/chat'`.
+  Rationale: keeps one dashboard dimension (`route`) rather than a second custom
+  prop; existing insights filtering on prefix `/api/chat` keep working. The `#`
+  form cannot collide with a real route path.
+- The label is server-validated enum data — content-free by construction; the
+  privacy invariant (`$ai_input`/`$ai_output_choices` never sent) is untouched
+  because `buildAiGenerationPayload` is not modified.
+
+### 5. Runbook — `docs/guides/posthog-llm-observability.md`
+- Update the "Coverage note" to state deep generators are captured with per-surface
+  labels (`/api/chat#gdd`, `/api/chat#world_builder`, `/api/chat#cutscene`) and
+  correct the stale claim that they were uncaptured.
+
+## Explicitly out of scope
+- Any change to `createGenerationHandler` / `generationAgent` (PF-916 owns that).
+- Capturing non-LLM asset generations as `$ai_generation` (wrong event semantics).
+- `posthog-node` / OTel span processors (parent spec's standing decision).
+- Streaming chat UI surface labels beyond what falls out of the shared option.
+
+## Constraints (inherited from parent spec — must hold)
+- Never send `$ai_input` / `$ai_output_choices`.
+- Dormant by default (`POSTHOG_LLM_CAPTURE !== 'true'` → no behavior change).
+- Consent-gated via `hasAnalyticsConsent()`; fails closed.
+- Fired via `after()`; capture failure swallowed to Sentry — both already
+  enforced inside `captureAiGeneration`, which this spec does not modify.
+- No `createGenerationHandler` control-flow changes (SPOF rule).
+
+## Test plan (test-first)
+Failing tests written before implementation:
+1. `web/src/app/api/chat/__tests__` (or the existing chat route test file):
+   (a) request with `surface: 'gdd'` → capture called with `route: '/api/chat#gdd'`;
+   (b) unknown `surface: 'evil<script>'` → capture called with `route: '/api/chat'`
+       and the raw value appears NOWHERE in the serialized payload;
+   (c) absent surface → unchanged `route: '/api/chat'` (regression);
+   (d) payload still contains no `$ai_input`/`$ai_output_choices` keys.
+2. `web/src/lib/ai/__tests__/client.test.ts`: `fetchAI({surface})` puts `surface`
+   in the POST body; cache keys differ for identical prompts with different surfaces.
+3. One deep-generator test (`gddGenerator`): `generateGDD` passes `surface: 'gdd'`.
+4. Existing #8817 tests must pass unmodified (no weakening).
+
+## Acceptance criteria (mapped from ticket, corrected)
+- Each of the three deep generators emits its `$ai_generation` with a
+  surface-qualified `route` label when capture is enabled + consented, carrying
+  the same token/latency/model/provider fields as today.
+- Unknown/malformed `surface` values are dropped server-side and never enter the
+  analytics payload.
+- Dormant/unconsented behavior unchanged (existing tests prove it).
+- Runbook coverage note corrected + updated.
+- Ticket #8877 description updated with the corrected architecture note.

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -1128,35 +1128,40 @@ describe('POST /api/chat', () => {
         : validBody();
 
       const res = await POST(makeRequest(bodyWithSurface));
-      await res.text();
+      const responseText = await res.text(); // drain stream + keep body for echo assertions
 
       await capturedOnStepFinish!({ usage: { inputTokens: 100, outputTokens: 50 } });
 
-      return vi.mocked(captureAiGeneration).mock.calls[0]?.[0];
+      return {
+        arg: vi.mocked(captureAiGeneration).mock.calls[0]?.[0],
+        responseText,
+      };
     }
 
     it.each(['gdd', 'world_builder', 'cutscene'] as const)(
       'qualifies route label with surface=%s',
       async (surface) => {
-        const arg = await captureForSurface(surface);
+        const { arg } = await captureForSurface(surface);
         expect(arg?.route).toBe(`/api/chat#${surface}`);
       },
     );
 
     it('drops unknown surface and uses plain /api/chat route', async () => {
-      const arg = await captureForSurface('evil<script>');
+      const { arg, responseText } = await captureForSurface('evil<script>');
       expect(arg?.route).toBe('/api/chat');
-      // The raw unknown value must not appear anywhere in the capture payload
+      // The raw unknown value must not appear anywhere in the capture payload...
       expect(JSON.stringify(arg)).not.toContain('evil<script>');
+      // ...nor be echoed anywhere in the HTTP response (spec test plan item b)
+      expect(responseText).not.toContain('evil<script>');
     });
 
     it('uses plain /api/chat route when surface is absent (regression)', async () => {
-      const arg = await captureForSurface(undefined);
+      const { arg } = await captureForSurface(undefined);
       expect(arg?.route).toBe('/api/chat');
     });
 
     it('capture arg carries no prompt/response content fields (PF-931 privacy guard)', async () => {
-      const arg = await captureForSurface('gdd');
+      const { arg } = await captureForSurface('gdd');
       expect(arg).not.toHaveProperty('$ai_input');
       expect(arg).not.toHaveProperty('$ai_output_choices');
       expect(arg).not.toHaveProperty('messages');

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -1104,4 +1104,63 @@ describe('POST /api/chat', () => {
       expect(refundTokens).not.toHaveBeenCalled();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Surface attribution (PF-931 / #8877)
+  // -------------------------------------------------------------------------
+  describe('surface attribution', () => {
+    type StepEvent = {
+      usage: {
+        inputTokens?: number;
+        outputTokens?: number;
+      };
+    };
+
+    async function captureForSurface(surface: string | undefined) {
+      let capturedOnStepFinish: ((event: StepEvent) => Promise<void>) | undefined;
+      mockStream.mockImplementation(async (opts: Record<string, unknown>) => {
+        capturedOnStepFinish = opts.onStepFinish as typeof capturedOnStepFinish;
+        return mockStreamResult;
+      });
+
+      const bodyWithSurface = surface !== undefined
+        ? { ...validBody(), surface }
+        : validBody();
+
+      const res = await POST(makeRequest(bodyWithSurface));
+      await res.text();
+
+      await capturedOnStepFinish!({ usage: { inputTokens: 100, outputTokens: 50 } });
+
+      return vi.mocked(captureAiGeneration).mock.calls[0]?.[0];
+    }
+
+    it.each(['gdd', 'world_builder', 'cutscene'] as const)(
+      'qualifies route label with surface=%s',
+      async (surface) => {
+        const arg = await captureForSurface(surface);
+        expect(arg?.route).toBe(`/api/chat#${surface}`);
+      },
+    );
+
+    it('drops unknown surface and uses plain /api/chat route', async () => {
+      const arg = await captureForSurface('evil<script>');
+      expect(arg?.route).toBe('/api/chat');
+      // The raw unknown value must not appear anywhere in the capture payload
+      expect(JSON.stringify(arg)).not.toContain('evil<script>');
+    });
+
+    it('uses plain /api/chat route when surface is absent (regression)', async () => {
+      const arg = await captureForSurface(undefined);
+      expect(arg?.route).toBe('/api/chat');
+    });
+
+    it('capture arg carries no prompt/response content fields (PF-931 privacy guard)', async () => {
+      const arg = await captureForSurface('gdd');
+      expect(arg).not.toHaveProperty('$ai_input');
+      expect(arg).not.toHaveProperty('$ai_output_choices');
+      expect(arg).not.toHaveProperty('messages');
+      expect(arg).not.toHaveProperty('prompt');
+    });
+  });
 });

--- a/web/src/app/api/chat/__tests__/route.test.ts
+++ b/web/src/app/api/chat/__tests__/route.test.ts
@@ -152,6 +152,7 @@ import { logCost } from '@/lib/costs/costLogger';
 import { createSpawnforgeAgent } from '@/lib/ai/spawnforgeAgent';
 import { trackAiCacheHitRate } from '@/lib/analytics/events.server';
 import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
+import { DEEP_GEN_SURFACES } from '@/lib/ai/surfaces';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1138,13 +1139,20 @@ describe('POST /api/chat', () => {
       };
     }
 
-    it.each(['gdd', 'world_builder', 'cutscene'] as const)(
+    // Spread the runtime allowlist (spec §Test plan 1a) so a surface added to
+    // DEEP_GEN_SURFACES is automatically covered here; the exact-contents test
+    // below guards the removal/rename direction the spread alone would miss.
+    it.each([...DEEP_GEN_SURFACES])(
       'qualifies route label with surface=%s',
       async (surface) => {
         const { arg } = await captureForSurface(surface);
         expect(arg?.route).toBe(`/api/chat#${surface}`);
       },
     );
+
+    it('DEEP_GEN_SURFACES contains exactly the three deep-gen surfaces', () => {
+      expect([...DEEP_GEN_SURFACES]).toEqual(['gdd', 'world_builder', 'cutscene']);
+    });
 
     it('drops unknown surface and uses plain /api/chat route', async () => {
       const { arg, responseText } = await captureForSurface('evil<script>');

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -27,6 +27,7 @@ import { captureException } from '@/lib/monitoring/sentry-server';
 import { logCost } from '@/lib/costs/costLogger';
 import { trackAiCacheHitRate } from '@/lib/analytics/events.server';
 import { captureAiGeneration, hasAnalyticsConsent } from '@/lib/analytics/posthog-server';
+import { DEEP_GEN_SURFACES, type DeepGenSurface } from '@/lib/ai/surfaces';
 import { buildDocContext } from '@/lib/chat/docContext';
 import type { DocEntry } from '@/lib/docs/docsIndex';
 import { createSpawnforgeAgent } from '@/lib/ai/spawnforgeAgent';
@@ -316,6 +317,7 @@ export async function POST(request: NextRequest) {
     thinking?: boolean;
     effort?: 'low' | 'medium' | 'high';
     systemOverride?: string;
+    surface?: string;
   };
 
   try {
@@ -333,6 +335,14 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
+
+  // Validate surface — unknown values are silently dropped (additive, non-breaking).
+  // Never reject the request over this field and never echo the raw value back.
+  const surface: DeepGenSurface | undefined =
+    typeof body.surface === 'string' &&
+    (DEEP_GEN_SURFACES as readonly string[]).includes(body.surface)
+      ? (body.surface as DeepGenSurface)
+      : undefined;
   if (!messages || !Array.isArray(messages)) {
     return Response.json({ error: 'messages array required' }, { status: 400 });
   }
@@ -666,7 +676,7 @@ export async function POST(request: NextRequest) {
             outputTokens: usage.outputTokens,
             stream: true,
             isError: false,
-            route: '/api/chat',
+            route: surface ? `/api/chat#${surface}` : '/api/chat',
             cacheReadInputTokens: usage.inputTokenDetails?.cacheReadTokens,
             cacheCreationInputTokens: usage.inputTokenDetails?.cacheWriteTokens,
           });

--- a/web/src/lib/ai/__tests__/client.test.ts
+++ b/web/src/lib/ai/__tests__/client.test.ts
@@ -281,6 +281,32 @@ describe('streamAI', () => {
     expect(body.model).toBe('claude-haiku-4-5');
     expect(body.messages).toEqual([{ role: 'user', content: 'my prompt' }]);
   });
+
+  it('forwards surface to the chat API body (PF-931 attribution)', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse(['data: {"type":"done"}\n']),
+    );
+
+    const { streamAI } = await import('../client');
+    await streamAI('prompt', { surface: 'gdd' });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.surface).toBe('gdd');
+  });
+
+  it('omits the surface key entirely when not provided', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse(['data: {"type":"done"}\n']),
+    );
+
+    const { streamAI } = await import('../client');
+    await streamAI('prompt');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(body, 'surface')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/ai/__tests__/client.test.ts
+++ b/web/src/lib/ai/__tests__/client.test.ts
@@ -175,6 +175,32 @@ describe('fetchAI', () => {
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(Object.prototype.hasOwnProperty.call(body, 'systemOverride')).toBe(false);
   });
+
+  it('includes surface in POST body when provided', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse(['data: {"type":"done"}\n']),
+    );
+
+    const { fetchAI } = await import('../client');
+    await fetchAI('prompt', { surface: 'gdd' });
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.surface).toBe('gdd');
+  });
+
+  it('does not include surface in POST body when not provided', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeOkResponse(['data: {"type":"done"}\n']),
+    );
+
+    const { fetchAI } = await import('../client');
+    await fetchAI('prompt');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(body, 'surface')).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -399,6 +425,56 @@ describe('fetchAI response caching', () => {
     expect(withThinking).toBe('thinking answer');
     // Both must hit the network — thinking=true must not reuse the thinking=false cache entry
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not serve cached response when surface differs', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        makeOkResponse([
+          'data: {"type":"text_delta","text":"gdd answer"}\n',
+          'data: {"type":"done"}\n',
+        ]),
+      )
+      .mockResolvedValueOnce(
+        makeOkResponse([
+          'data: {"type":"text_delta","text":"world answer"}\n',
+          'data: {"type":"done"}\n',
+        ]),
+      );
+
+    vi.resetModules();
+    const { fetchAI } = await import('../client');
+
+    const a = await fetchAI('same prompt', { model: 'claude-sonnet-4-6', surface: 'gdd' });
+    const b = await fetchAI('same prompt', { model: 'claude-sonnet-4-6', surface: 'world_builder' });
+
+    expect(a).toBe('gdd answer');
+    expect(b).toBe('world answer');
+    // Different surfaces → different cache keys → both hit the network
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves cached response when surface is the same', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        makeOkResponse([
+          'data: {"type":"text_delta","text":"surface cached"}\n',
+          'data: {"type":"done"}\n',
+        ]),
+      ),
+    );
+
+    vi.resetModules();
+    const { fetchAI } = await import('../client');
+
+    const first = await fetchAI('same prompt', { model: 'claude-sonnet-4-6', surface: 'cutscene' });
+    expect(first).toBe('surface cached');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const second = await fetchAI('same prompt', { model: 'claude-sonnet-4-6', surface: 'cutscene' });
+    expect(second).toBe('surface cached');
+    // Same surface + same prompt → cache hit, no second network call
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it('deduplicates concurrent in-flight requests for the same prompt', async () => {

--- a/web/src/lib/ai/__tests__/cutsceneGenerator.test.ts
+++ b/web/src/lib/ai/__tests__/cutsceneGenerator.test.ts
@@ -230,4 +230,16 @@ describe('generateCutscene', () => {
       generateCutscene({ prompt: 'Test', sceneEntities: [] }),
     ).rejects.toThrow('Rate limit');
   });
+
+  it('passes surface: cutscene to fetchAI for PostHog attribution (PF-931)', async () => {
+    const { fetchAI } = await import('@/lib/ai/client');
+    (fetchAI as ReturnType<typeof vi.fn>).mockResolvedValue(VALID_RESPONSE);
+
+    await generateCutscene({ prompt: 'Pan from sky', sceneEntities: [], duration: 8 });
+
+    expect(fetchAI).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ surface: 'cutscene' }),
+    );
+  });
 });

--- a/web/src/lib/ai/__tests__/gddGenerator.test.ts
+++ b/web/src/lib/ai/__tests__/gddGenerator.test.ts
@@ -466,4 +466,14 @@ describe('generateGDD', () => {
 
     await expect(generateGDD('a game')).rejects.toThrow('Token limit exceeded');
   });
+
+  it('passes surface: gdd to fetchAI for PostHog attribution (PF-931)', async () => {
+    fetchAIMock.mockResolvedValue(JSON.stringify(mockGDD));
+
+    await generateGDD('a platformer');
+
+    expect(fetchAIMock).toHaveBeenCalledOnce();
+    const [, options] = fetchAIMock.mock.calls[0] as [string, Record<string, unknown>];
+    expect(options.surface).toBe('gdd');
+  });
 });

--- a/web/src/lib/ai/__tests__/worldBuilder.test.ts
+++ b/web/src/lib/ai/__tests__/worldBuilder.test.ts
@@ -443,6 +443,40 @@ describe('generateWorld', () => {
     expect(result.name).toBe('The Scarred Earth');
   });
 
+  it('passes surface: world_builder in POST body to /api/chat (PF-931)', async () => {
+    const mockWorld: GameWorld = {
+      name: 'Surface Test World',
+      description: 'A test',
+      genre: 'custom',
+      era: 'Now',
+      factions: [{ name: 'F', description: 'D', alignment: 'neutral', territory: 'T', leader: 'L', traits: [], relationships: {} }],
+      regions: [{ name: 'R', description: 'D', biome: 'b', dangerLevel: 3, resources: [], landmarks: [], connectedTo: [] }],
+      timeline: [],
+      lore: [],
+      rules: [],
+    };
+
+    const encoder = new TextEncoder();
+    const sseData = `data: {"type":"text_delta","text":"${JSON.stringify(mockWorld).replace(/"/g, '\\"')}"}\ndata: [DONE]\n`;
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseData));
+          controller.close();
+        },
+      }),
+    } as Response);
+
+    await generateWorld('A unique surface-test world');
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [, init] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.surface).toBe('world_builder');
+  });
+
   // "handles response in choices format" removed — the JSON/choices code path
   // was deleted in favor of SSE-only streaming. The /api/chat endpoint always
   // returns text/event-stream.

--- a/web/src/lib/ai/client.ts
+++ b/web/src/lib/ai/client.ts
@@ -10,6 +10,7 @@ import { streamChat, type StreamCallbacks } from './streaming';
 import { aiQueue, type Priority } from './requestQueue';
 import { aiResponseCache } from './promptCache';
 import { AI_MODEL_PRIMARY } from './models';
+import type { DeepGenSurface } from './surfaces';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -39,6 +40,13 @@ export interface AIClientOptions {
    * Lower number = dispatched first.
    */
   priority?: Priority;
+  /**
+   * Deep-generation surface identifier forwarded to /api/chat for PostHog
+   * attribution. When present, the server labels the $ai_generation event
+   * `route: '/api/chat#<surface>'` so costs can be broken out per feature.
+   * Callers that omit this produce byte-identical request bodies to today.
+   */
+  surface?: DeepGenSurface;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,8 +124,9 @@ export async function fetchAI(prompt: string, options?: AIClientOptions): Promis
   if (!signal) {
     const thinking = options?.thinking ?? false;
     const effort = options?.effort ?? 'none';
+    const surface = options?.surface;
     const cacheKey = await aiResponseCache.computeKey(
-      `${model}:${thinking ? 'thinking' : 'standard'}:effort=${effort}`,
+      `${model}:${thinking ? 'thinking' : 'standard'}:effort=${effort}${surface !== undefined ? `:surface=${surface}` : ''}`,
       systemOverride ?? '',
       `${sceneContext}\x00${prompt}`,
     );
@@ -136,6 +145,7 @@ async function fetchAIUncached(prompt: string, options?: AIClientOptions): Promi
     effort,
     signal,
     priority = 1,
+    surface,
   } = options ?? {};
 
   return aiQueue.enqueue(async () => {
@@ -153,6 +163,7 @@ async function fetchAIUncached(prompt: string, options?: AIClientOptions): Promi
           thinking,
           ...(effort !== undefined ? { effort } : {}),
           ...(systemOverride !== undefined ? { systemOverride } : {}),
+          ...(surface !== undefined ? { surface } : {}),
         }),
         ...fetchOptions,
       });

--- a/web/src/lib/ai/client.ts
+++ b/web/src/lib/ai/client.ts
@@ -223,6 +223,7 @@ export async function streamAI(
     thinking = false,
     signal,
     priority = 1,
+    surface,
   } = options ?? {};
 
   try {
@@ -234,6 +235,7 @@ export async function streamAI(
           sceneContext,
           thinking,
           ...(systemOverride !== undefined ? { systemOverride } : {}),
+          ...(surface !== undefined ? { surface } : {}),
           callbacks,
           // Note: streamChat does not yet accept signal — callers can cancel via
           // the shared AbortController and the stream reader will throw on abort.

--- a/web/src/lib/ai/cutsceneGenerator.ts
+++ b/web/src/lib/ai/cutsceneGenerator.ts
@@ -211,6 +211,7 @@ export async function generateCutscene(
     model: getDeepGenerationModel('cutscene'),
     systemOverride: 'You are a cinematic director AI for a game engine. Always return valid JSON.',
     priority: 1,
+    surface: 'cutscene',
   });
 
   const partial = parseCutsceneResponse(raw);

--- a/web/src/lib/ai/deepTier.ts
+++ b/web/src/lib/ai/deepTier.ts
@@ -12,6 +12,7 @@
 
 import { AI_MODEL_DEEP, AI_MODEL_PRIMARY } from './models';
 import { trackEvent } from '@/lib/analytics/posthog';
+import type { DeepGenSurface } from './surfaces';
 
 export type { DeepGenSurface } from './surfaces';
 

--- a/web/src/lib/ai/deepTier.ts
+++ b/web/src/lib/ai/deepTier.ts
@@ -13,8 +13,7 @@
 import { AI_MODEL_DEEP, AI_MODEL_PRIMARY } from './models';
 import { trackEvent } from '@/lib/analytics/posthog';
 
-/** Surfaces eligible for the deep-generation tier. */
-export type DeepGenSurface = 'gdd' | 'world_builder' | 'cutscene';
+export type { DeepGenSurface } from './surfaces';
 
 /**
  * True when the deep-generation tier is enabled via

--- a/web/src/lib/ai/gddGenerator.ts
+++ b/web/src/lib/ai/gddGenerator.ts
@@ -353,6 +353,7 @@ export async function generateGDD(
     effort: 'medium',
     systemOverride: GDD_SYSTEM_PROMPT,
     priority: 2,
+    surface: 'gdd',
   });
 
   if (!content.trim()) {

--- a/web/src/lib/ai/streaming.ts
+++ b/web/src/lib/ai/streaming.ts
@@ -21,6 +21,8 @@
  *   Finish events: { type: 'finish', ... } (treated as done)
  */
 
+import type { DeepGenSurface } from './surfaces';
+
 // ---------------------------------------------------------------------------
 // Envelope event types
 // ---------------------------------------------------------------------------
@@ -298,6 +300,12 @@ export interface ChatStreamOptions {
   sceneContext?: string;
   thinking?: boolean;
   systemOverride?: string;
+  /**
+   * Deep-generation surface identifier forwarded to /api/chat for PostHog
+   * attribution — the server validates it against DEEP_GEN_SURFACES and
+   * labels the $ai_generation event `route: '/api/chat#<surface>'`.
+   */
+  surface?: DeepGenSurface;
   callbacks?: StreamCallbacks;
 }
 
@@ -315,12 +323,19 @@ export interface ChatStreamOptions {
  * behaviour across all modules.
  */
 export async function streamChat(options: ChatStreamOptions): Promise<string> {
-  const { messages, model, sceneContext = '', thinking = false, systemOverride, callbacks } = options;
+  const { messages, model, sceneContext = '', thinking = false, systemOverride, surface, callbacks } = options;
 
   const response = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages, model, sceneContext, thinking, systemOverride }),
+    body: JSON.stringify({
+      messages,
+      model,
+      sceneContext,
+      thinking,
+      systemOverride,
+      ...(surface !== undefined ? { surface } : {}),
+    }),
   });
 
   if (!response.ok) {

--- a/web/src/lib/ai/surfaces.ts
+++ b/web/src/lib/ai/surfaces.ts
@@ -1,0 +1,14 @@
+/**
+ * Runtime allowlist for deep-generation surfaces.
+ *
+ * This module is a dependency-free leaf — no browser APIs, no analytics
+ * imports — so it can be imported safely from both client modules and the
+ * server-side /api/chat route without pulling client analytics code into
+ * the server bundle.
+ *
+ * `deepTier.ts` re-exports the type from here so existing importers
+ * (the three generator modules) keep working unchanged.
+ */
+
+export const DEEP_GEN_SURFACES = ['gdd', 'world_builder', 'cutscene'] as const;
+export type DeepGenSurface = (typeof DEEP_GEN_SURFACES)[number];

--- a/web/src/lib/ai/worldBuilder.ts
+++ b/web/src/lib/ai/worldBuilder.ts
@@ -590,6 +590,7 @@ export async function generateWorld(description: string, preset?: string): Promi
   const content = await fetchAI(prompt, {
     model: getDeepGenerationModel('world_builder'),
     priority: 2,
+    surface: 'world_builder',
   });
 
   try {


### PR DESCRIPTION
## Summary
- Corrects the stale premise in #8877: the deep generators (GDD, world builder, cutscene) never ran through `createGenerationHandler` — they are client-side modules calling `fetchAI()` → `POST /api/chat`, so their token/cost/latency was already captured by #8817, just indistinguishably labeled `route: '/api/chat'`. The gap was attribution, not capture.
- New dependency-free leaf module `web/src/lib/ai/surfaces.ts` holds the runtime allowlist `DEEP_GEN_SURFACES` (`'gdd' | 'world_builder' | 'cutscene'`) and derives the `DeepGenSurface` type; `deepTier.ts` re-exports the type so existing importers are unchanged. The leaf exists because `deepTier.ts` value-imports client-side analytics, which must not enter the server bundle.
- `fetchAI` gains an optional `surface` option: included in the `/api/chat` POST body via the existing conditional-spread idiom (callers omitting it produce byte-identical bodies) and in the response-cache key (no cross-surface label contamination; same-surface dedup preserved).
- `/api/chat` validates the field with typeof + allowlist: unknown/malformed values are silently dropped (never rejected, never echoed), and the single `captureAiGeneration` call site labels the event `route: '/api/chat#<surface>'` when a valid surface is present. `buildAiGenerationPayload`/`captureAiGeneration` are untouched, so the privacy invariant (`$ai_input`/`$ai_output_choices` never sent) and the dormant/consent gating are unchanged.
- All three generators pass their surface; the runbook's stale Coverage note (which claimed these generators were uninstrumented and needed an agent-boundary adapter) is corrected.
- Spec: `specs/2026-07-02-posthog-deep-generator-attribution.md`, approved by the full 5-reviewer board (architect, security, dx, ux, test — all PASS).

Note for dashboards: insights filtering `route = '/api/chat'` with exact equality will stop matching deep-generator events — that separation is the purpose of this change; prefix/contains filters keep working. Documented in the runbook.

Closes #8877 (PF-931)

## Test plan
- [x] 16 new tests, written first (failing) then made green:
  - `route.test.ts` — all three surfaces parametrized to their qualified label; unknown `surface` dropped with the raw value absent from the analytics payload and the HTTP response; absent surface regression; route-integration privacy guard
  - `client.test.ts` — surface in POST body; byte-identical body when omitted; cache-key isolation across surfaces and dedup within a surface
  - one wiring test per generator (`gdd`, `cutscene` via the client mock; `world_builder` via its global-fetch stub on the outgoing request body)
- [x] `posthog-server.test.ts` passes unmodified (no weakening)
- [x] Full gate: eslint `--max-warnings 0` clean, `tsc --noEmit` clean, full vitest 16178 passed / 0 failed