### PR TITLE
feat(api): complete generation-agent SPOF retirement — abort forwarding, usageId refunds, contract pins (PF-916)

### DIFF
--- a/.changeset/generation-agent-abort-forwarding.md
+++ b/.changeset/generation-agent-abort-forwarding.md
@@ -1,0 +1,10 @@
+---
+"web": patch
+---
+
+fix(generate): sprite-sheet and tileset-gen generation responses now include usageId so failed jobs refund from the client
+
+All 12 generate routes now forward the generation agent's abort signal into their
+provider HTTP calls, so a per-route wall-clock deadline cancels the in-flight
+request deterministically rather than only the factory's await. Provider-error
+details are no longer exposed in voice/batch user-visible error messages.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -126,7 +126,8 @@
           "jobId": { "type": "string" },
           "provider": { "type": "string" },
           "status": { "type": "string", "enum": ["pending", "processing", "completed", "failed"] },
-          "estimatedSeconds": { "type": "integer" }
+          "estimatedSeconds": { "type": "integer" },
+          "usageId": { "type": "string", "description": "Usage record ID needed to trigger a client-side refund if the async job fails after queuing. Omitted on BYOK (bring-your-own-key) requests where billing is not metered." }
         }
       },
       "GenerationStatus": {

--- a/docs/decisions/2026-06-23-generation-agent-spof.md
+++ b/docs/decisions/2026-06-23-generation-agent-spof.md
@@ -61,12 +61,17 @@ refund-on-failure. The runner never reshapes the result, so the response shape,
 3. **Production.** Flip `USE_GENERATION_AGENT=true` in Production once the canary
    is clean. No deploy needed to revert — unset the env var.
 
-## Follow-ups (out of this slice)
+## Follow-ups
 
-- Routes that want the wall-clock abort to cancel the in-flight provider request
-  (not just the function) should forward `ctx.abortSignal` (now contractually
-  available, optional) into their provider client / `fetch`. The provider
-  clients today carry their own shorter `AbortSignal.timeout(...)`; the agent
-  deadline is a longer backstop above those.
-- Pairs with the QStash durable-queue ticket for long jobs — durable agents can
-  survive function timeouts entirely once that lands.
+- **Abort forwarding — DELIVERED** (PF-916 / #8826, this PR): all 12 generate
+  routes now forward `ctx.abortSignal` into their provider-client call.
+  `composeAbortSignal` combines the agent deadline with each client's own
+  per-fetch timeout so the in-flight HTTP request is cancelled when either fires.
+  Client-level tests (Dispatches 4–5) + route-level signal-forwarding tests
+  (Dispatch 6, test 17) verify the signal reaches every provider.
+- **Durable completion path** (replacing `useGenerationPolling` + the 8
+  `*/status` routes) → tracked as **#8892 (PF-938)**. The 2026-06-27 grounding
+  comment re-scoped this to a dedicated spec.
+- **`voice/batch` remaining hardening** (#8597-class migration to the factory
+  pattern) → tracked as **#8893 (PF-939)**. Its provider-error-message leak is
+  **closed by this PR** (Design §13, test 20 — see #8826); #8893 holds the rest.

--- a/specs/2026-07-03-generation-agent-spof-completion.md
+++ b/specs/2026-07-03-generation-agent-spof-completion.md
@@ -1,0 +1,208 @@
+# PF-916 (#8826) — Retire the createGenerationHandler SPOF: close the remaining legs (abort forwarding, refund-contract gaps, rollout runbook)
+
+**Ticket:** #8826 (taskboard PF-916, `01KVTCY2FQP3SWV0SP4ZBE696Z`)
+**Milestone:** S1: Quality & Reliability
+**Prior art:** PR #8833 (`d23b4ba2`) shipped the core slice; ADR `docs/decisions/2026-06-23-generation-agent-spof.md` ("Adopted, flag-gated, default off") is the authoritative design record.
+**Delivery:** one PR off `main`, `Closes #8826`, built across 6 sequenced builder dispatches (≤7 logical items each; every dispatch is self-contained — it names the Design sections it implements and the exact files it touches; boundaries in the Test plan).
+
+---
+
+## Corrected premise (supersedes the ticket description)
+
+The issue body and the taskboard ticket both describe replacing a "hand-rolled tool loop" with an AI SDK `ToolLoopAgent`. That premise is stale, corrected twice on the issue itself (2026-06-25 spec comment, 2026-06-27 grounding comment) and by what shipped:
+
+1. **The factory is not a tool loop.** `web/src/lib/api/createGenerationHandler.ts` (475 lines) is a fixed billing/auth/safety pipeline — authenticate → aggregate rate limit → per-route rate limit → parse → validate → content safety → pricing → cache → key-before-deduct (#8597) → execute-once → QStash publish (PF-906, dormant by default) → refund-on-throw → opaque 500. Only 2 of its 12 routes (`localize`, `pacing`) make LLM calls; the other 10 are single-shot provider job submissions (Meshy, Suno, ElevenLabs, Replicate/OpenAI via SpriteClient/PixelArtClient).
+2. **The core of this ticket already shipped** in PR #8833 (merged 2026-06-23): `web/src/lib/api/generationAgent.ts` is an "honest single-step executor" behind the global flag `USE_GENERATION_AGENT` (exact string `'true'`, server env, default OFF; check at `generationAgent.ts:166`). It enforces a per-route wall-clock deadline via `deriveGenerationStepTimeoutMs` (`web/src/lib/config/timeouts.ts`; 55s base cap under the ~60s `maxDuration`; model/music 180s and localize 120s pass `maxDurationSeconds` explicitly) and throws typed `GenerationTimeoutError` so the factory's existing refund path runs while the function is still alive. Response contract (incl. `usageId`) is proven identical in both flag states by the flag-on describe block in `web/src/app/api/generate/__tests__/route-integration.test.ts` (29 tests, all 12 routes).
+3. **This work is NOT blocked on #8883 (AI SDK v6→v7).** The remaining legs touch no AI SDK surface except passing `abortSignal` into two `generateText` calls — an option supported identically in v6 and v7. The only v7-gated option ("DurableAgent"/`WorkflowAgent` on Vercel Workflows) is explicitly rejected below.
+4. **What verifiably remains** (each grounded in code inspection on `origin/main`):
+   - **(a) Abort forwarding (ADR follow-up #1).** No generate route forwards `ctx.abortSignal` into its provider call — a repo-wide grep of `web/src/app/api/generate/*/route.ts` returns zero hits. The agent path's abort today cancels only the factory's `await`, not the in-flight provider HTTP request. `ctx` gained optional `abortSignal` at `createGenerationHandler.ts:130`; the agent wrap passes `{ ...ctx, abortSignal: signal }` at ~`:278`.
+   - **(b) A live refund bug.** `sprite-sheet/route.ts` and `tileset-gen/route.ts` omit `usageId` from their success payloads (their `execute` returns only `{ jobId, provider, status, estimatedSeconds }` — sprite-sheet `:62–77`, tileset-gen `:49–63`). The client poller early-returns without it (`web/src/hooks/useGenerationPolling.ts:460` — `if (!job?.usageId) return;`), so client-triggered refunds silently no-op for those two async types. The regression scan misses them because `ASYNC_ROUTES` at `web/src/app/api/__tests__/sentry-regressions.test.ts:77` lists only `['model', 'music', 'skybox', 'sprite', 'texture', 'pixel-art']`.
+   - **(c) 14 untested factory contract behaviors** (inventory in the Test plan) including a relative-path `vi.mock('../responseCache')` landmine that would silently un-mock on any file move.
+   - **(d) The rollout itself** (ADR steps 2–3): `USE_GENERATION_AGENT=true` has never been flipped in any environment — owner-only runbook below, not set by this PR.
+   - **(e) The re-scoped durable-polling leg** (2026-06-27 grounding comment): replacing `useGenerationPolling` + the 8 `*/status` routes with a durable completion path. Extracted to **#8892 (PF-938)** — see Out of scope.
+
+## Goal
+
+One PR that completes #8826's factory-scoped work: every generate route forwards the agent-path abort into its provider HTTP call (so a timeout cancels the in-flight provider HTTP request/poll loop, not just the factory's `await` — for async job-submission providers the job already accepted server-side may still complete, which is pre-existing and inherent to async generation; tokens are refunded regardless); the two async routes missing `usageId` return it (restoring client-side refunds); every previously-unpinned factory contract behavior gets a test; one Boy-Scout fix for the `voice/batch` provider-error leak (Design §13); and the flag-flip runbook is documented. Flag-off behavior stays byte-for-byte identical.
+
+## Constraints (restated in full so this spec is self-contained — must hold)
+
+1. **`usageId` must never be removed** from generate route responses — the client needs it for async refunds (this spec only ADDS it where missing).
+2. **Factory blast radius**: any factory or route change requires `route-integration.test.ts` green in BOTH flag states.
+3. **`refundTokens()` idempotency** (CTE `INSERT … ON CONFLICT DO NOTHING` against `uq_token_usage_refund_idempotent`) is untouched.
+4. **Rate limits stay `await`ed**; the auth → aggregate → per-route ordering is not reordered.
+5. **Content safety**: `.safe` checked before `.filtered` substitution; primary + `secondaryPromptFields` loop unchanged.
+6. **QStash (PF-906) dormancy**: with any of `QSTASH_TOKEN`/`QSTASH_CURRENT_SIGNING_KEY`/`QSTASH_NEXT_SIGNING_KEY` unset, behavior is byte-identical; publish only after successful non-cached execute; publish failure is Sentry-logged, never user-visible; no duplicate job rows.
+7. **Status surface untouched**: the 8 `*/status/route.ts` files, `pollProviderStatus.ts`, and the `succeededButEmpty` → `failed` mapping are not modified.
+8. **#8817 telemetry untouched**: `captureAiGeneration` in `localize`/`pacing` stays as-is; no LLM-observability concern is added to the factory.
+9. **Flag semantics**: `USE_GENERATION_AGENT` enables only on the exact string `'true'`; revert = unset env var.
+10. **`??` not `||`** for defaults; token/timeout math guarded by `Number.isFinite`.
+11. **Route paths frozen**: no route is added, renamed, or deleted, so the `openapi-route-sync` gate passes without allowlist changes; the only OpenAPI edit is one additive optional property on the shared `GenerationJob` response schema (Design §9) — its documentation reach spans the seven routes that `$ref` it, all of which genuinely return the field after this PR.
+12. **No new npm dependencies** → no lockfile change; `AbortSignal.any` is a Node ≥20.3 built-in (repo runs Node 24 per `.node-version`, CI + Vercel match).
+13. **No new hardcoded constants**: existing per-fetch timeout literals in provider clients are preserved as-is, not re-derived.
+14. **Coverage ratchet (70/60/65/72)**: this PR only adds tests; no suite is weakened or deleted.
+15. **Test conventions**: `vi.mock` via `@/lib/...` aliases only (never relative); node-env vitest config for factory/route tests, jsdom for the poller hook; targeted vitest during dev, full gate before push.
+16. **Process**: Spec-First (this document), Test-First (failing tests before implementation), ≤7 items per builder dispatch, commit after every logical chunk, changeset required, PR carries `Closes #8826` + milestone `S1: Quality & Reliability`.
+
+## Scope enumeration
+
+| Route (POST) | Provider client | Abort forwarding | `usageId` change |
+|---|---|---|---|
+| `model`, `texture`, `skybox` | `meshyClient.ts` | yes | none (already returns it, e.g. `model/route.ts:124`) |
+| `music` | `sunoClient.ts` | yes | none |
+| `sfx`, `voice` | `elevenlabsClient.ts` | yes | none (sync routes) |
+| `sprite` | `spriteClient.ts` | yes | none |
+| **`sprite-sheet`**, **`tileset-gen`** | `spriteClient.ts` | yes | **ADD `usageId: ctx.usageId`** (live bug) |
+| `pixel-art` | `pixelArtClient.ts` | yes | none |
+| `localize`, `pacing` | `generateText` (AI SDK) | yes (`abortSignal` option) | none (sync routes) |
+
+Excluded routes/files: `voice/batch` factory migration/hardening (hand-rolled, not factory → **#8893** — EXCEPT its provider-error-message leak, fixed here as a Boy-Scout one-liner, Design §13), `refund/route.ts`, all 8 `*/status/route.ts`, `useGenerationPolling.ts` replacement (→ **#8892**), QStash webhook `generation-complete`.
+
+## Design
+
+### 1. `web/src/lib/generate/abortComposition.ts` (new)
+
+```ts
+/**
+ * Combine an optional external abort (the generation agent's per-route
+ * deadline) with a client's own per-fetch timeout. When no external signal
+ * is supplied (flag off, or the inline execute path), this returns exactly
+ * AbortSignal.timeout(timeoutMs) — byte-identical to today's behavior.
+ */
+export function composeAbortSignal(
+  external: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return external ? AbortSignal.any([external, timeout]) : timeout;
+}
+```
+
+Why safe: `AbortSignal.any` fires on the FIRST of its inputs, so per-fetch timeouts still bound each request exactly as today; the external deadline can only make cancellation earlier, never later. No behavior change when `external` is `undefined`.
+
+### 2. `web/src/lib/generate/meshyClient.ts`
+
+Each public method's params object gains optional `signal?: AbortSignal`. Every internal `signal: AbortSignal.timeout(N)` (lines 70, 97, 118, 149, 170) becomes `signal: composeAbortSignal(params.signal, N)`. Retry/backoff, response parsing, and error mapping are NOT modified.
+
+### 3. `web/src/lib/generate/sunoClient.ts`
+
+Same pattern (lines 45, 66).
+
+### 4. `web/src/lib/generate/elevenlabsClient.ts`
+
+Same pattern for `generateSfx` (line 49) and `generateVoice` (line 87).
+
+### 5. `web/src/lib/generate/spriteClient.ts`
+
+Same pattern for `generateSprite` (68, 104), `generateSpriteSheet` (155), `generateTileset` (189), the `removeBackground` remove.bg call (214), and the internal Replicate polling fetch in `getReplicateStatus` (286) — an aborted job stops the in-client Replicate poll loop immediately rather than running to the poll cap, and an in-flight remove.bg request is cancelled like any other single fetch.
+
+### 6. `web/src/lib/generate/pixelArtClient.ts`
+
+Same pattern for the `PixelArtClient` class methods (class at line 43; both the OpenAI and Replicate paths).
+
+### 7. All 12 `web/src/app/api/generate/*/route.ts` — thread the signal
+
+Each `execute` passes the factory context's abort through: `execute: async (params, apiKey, ctx) => client.method({ ...args, signal: ctx.abortSignal })`. Routes whose `execute` currently omits the third param (`sprite-sheet/route.ts:62`, `tileset-gen/route.ts:49`) gain it. `localize/route.ts:138` and `pacing/route.ts:115` add `abortSignal: ctx.abortSignal` to their `generateText` options (supported in AI SDK v6 and v7 — no dependency on #8883). `ctx.abortSignal` is `undefined` on the inline (flag-off) path, so flag-off requests are unchanged end-to-end.
+
+### 8. `sprite-sheet/route.ts` + `tileset-gen/route.ts` — `usageId` fix (live bug)
+
+`TResult` gains `usageId: string | undefined` and the `execute` return gains `usageId: ctx.usageId`, exactly matching the established pattern (`model/route.ts:28,124`, `sprite/route.ts:30,108`). Additive JSON field; the poller reads it optionally (`useGenerationPolling.ts:460`), so no consumer breaks. This restores the client-side refund path for `sprite_sheet` and `tileset` job types (the QStash server-side path from #8867 remains an independent, idempotent second guard).
+
+**Abuse-resistance rationale (why exposing `usageId` to the client is safe):** the refund route scopes its lookup to the authenticated caller — `eq(tokenUsage.userId, userId)` — so a stolen or guessed `usageId` belonging to another user matches no row; `refundTokens` is idempotent via the CTE `INSERT … ON CONFLICT DO NOTHING` against `uq_token_usage_refund_idempotent`, so replaying one's own `usageId` cannot double-credit; and six async routes (`model`, `music`, `skybox`, `sprite`, `texture`, `pixel-art`) already return `usageId` today, so this adds no new exposure class — it brings two routes up to the existing, protected contract.
+
+### 9. `docs/api/openapi.json`
+
+`/api/generate/sprite-sheet` and `/api/generate/tileset-gen` are documented public paths (verified; only their `/status` sub-routes live in `openapi-internal-routes.json`). Their 201 responses — like five other async routes (`model`, `texture`, `music`, `skybox`, `sprite`) — are a `$ref` to the shared `components.schemas.GenerationJob` schema (`{ jobId, provider, status, estimatedSeconds }`, ~line 123), which today documents `usageId` for NO route. The edit: add `usageId: { type: "string" }` as an **optional** property to the shared `GenerationJob` schema (NOT to `required` — BYOK requests legitimately omit it; do NOT inline per-route schemas, which would diverge from the established `$ref` pattern). This is one additive property whose documentation reach is all seven referencing routes — and that reach is *correct*: the five factory routes above already return `usageId` today, and sprite-sheet/tileset-gen start returning it via Design §8, so after this PR every route referencing `GenerationJob` genuinely returns the field. Run `jq empty docs/api/openapi.json` after editing (a malformed spec 500s `/api-docs` in production).
+
+### 10. `web/src/app/api/__tests__/sentry-regressions.test.ts:77`
+
+`ASYNC_ROUTES` gains `'sprite-sheet'` and `'tileset-gen'` (written FIRST — fails until §8 lands; that failing state is the test-first proof of the bug).
+
+### 11. `docs/decisions/2026-06-23-generation-agent-spof.md`
+
+Update the Follow-ups section: abort forwarding delivered by this PR; durable-polling leg tracked as #8892; voice/batch remaining hardening tracked as #8893 (its error-message leak is closed by this PR, Design §13). Also post a clarifying comment on #8893 recording that split (orchestrator action at implementation time).
+
+### 12. Changeset
+
+`.changeset/<name>.md` — patch bump for the web app; user-visible fix line: "sprite-sheet and tileset-gen generation responses now include usageId so failed jobs refund from the client."
+
+### 13. `web/src/app/api/generate/voice/batch/route.ts:108` — provider-error-message hygiene (Boy Scout)
+
+Live leak found in review: the per-item catch does `error: err instanceof Error ? err.message : 'Generation failed'` (line 108), and `elevenlabsClient.generateVoice` throws `` `ElevenLabs TTS API error (${status}): ${body}` `` — so the raw provider response body lands in the user-visible `errors[].error`, violating the generic-error policy the factory enforces everywhere else. The full error is ALREADY captured server-side by the `captureException(err, { route, nodeId })` at line 105, so no detail is lost. Fix: line 108's user-visible string becomes the constant `'Voice generation failed for this item'`. One line; no control flow, billing, or response-shape changes. One existing test pins the old pass-through and must be updated in the same commit — `voice/batch/route.test.ts:222` (see test 20 for the exact substitution). The broader #8597-class hardening of this route stays in #8893.
+
+## Explicitly out of scope (each with an owning ticket)
+
+- **Durable completion path replacing `useGenerationPolling` + the 8 `*/status` routes** → **#8892 (PF-938)**. The 2026-06-27 grounding comment re-scoped the "durable" ambition of this ticket to the client side and directed choosing ONE backend — QStash (provisioned; server callbacks shipped in #8867), not AI SDK v7 `WorkflowAgent`/Vercel Workflows (new paid product, gated on #8883, would duplicate #8867). Building it here would balloon the PR past reviewable size and couple it to a backend decision that deserves its own spec.
+- **`voice/batch` #8597-class hardening** → **#8893 (PF-939)**. Not a factory route; folding the full migration in would widen blast radius for no shared code. Carve-out: its provider-error-message leak (`route.ts:108`) IS fixed in this PR (Design §13) per the Boy Scout Rule — a review-found live leak is never deferred; #8893 keeps the rest and gets a clarifying comment.
+- **Flipping `USE_GENERATION_AGENT`** — owner-only env action (runbook below), never a code change in this PR.
+- **`@ai-sdk/workflow` install** — rejected per above; also NOT part of #8883.
+- **Status routes, `pollProviderStatus.ts`, QStash webhook, `refund/route.ts`** — deliberately untouched (Constraints 6–7).
+
+## Test plan (test-first)
+
+Tests written before the implementation they guard; items marked *(regression pin)* pass against current code by design — their job is to lock behavior this PR must not change, not to fail first. Factory/route/client suites run under the node vitest config; the poller hook test under jsdom. All mocks via `@/lib/...` aliases. Local runs: `env -u UPSTASH_REDIS_REST_URL -u UPSTASH_REDIS_REST_TOKEN npx vitest run <file>`.
+
+**Dispatch 1 — factory contract pinning, part 1.**
+*Implements:* no Design section — test-only, pins EXISTING factory behavior. *Files touched:* `web/src/lib/api/__tests__/createGenerationHandler.test.ts` only.
+0. FIRST COMMIT: convert `vi.mock('../responseCache')` → `vi.mock('@/lib/api/responseCache')` (project mock rule; a relative mock silently un-mocks if the factory ever moves). No assertion changes.
+1. Filtered-prompt substitution: when `sanitizePrompt().safe === true` with `filtered !== input`, `execute` AND `billingMetadata` receive the FILTERED text — for the primary field and a `secondaryPromptFields` entry.
+2. Pricing guard: `tokenCost` fn returning `NaN` and `-5` → 500 `"Internal pricing error"` + `captureException`; a THROWING `tokenCost`/`provider`/`operation` config fn → 500 via the `resolve_billing_params` branch.
+3. Cached-path refund: `cachedGenerate` MISS whose inner `execute` throws → `refundTokens(userId, usageId)` called, 500 body is `GENERIC_500_MESSAGE`.
+4. Cache HIT is free: `resolveApiKey`, `deductTokens`, and the QStash publish are all NOT called; `X-Cache: HIT` header present.
+5. Refund-failure resilience: `refundTokens` itself throws → response is still the opaque 500 and `captureException` receives the refund-stage context (`usageId` attached).
+
+**Dispatch 2 — factory contract pinning, part 2.**
+*Implements:* no Design section — test-only, pins EXISTING factory behavior. *Files touched:* `web/src/lib/api/__tests__/createGenerationHandler.test.ts` only. Any Dispatch 1–2 test that comes up RED against current code is a real bug — fix the code in this PR (Boy Scout Rule), never adjust the test to match broken behavior.
+6. Auth-before-rate-limit: a 401 request consumes zero budget on both limiters (neither mock called).
+7. Dormant `after()`: for a non-async route and for an async route with QStash env unset, the captured `after` callback list stays empty.
+8. `billingMetadata` default: omitted config → metadata recorded equals validated `params`.
+9. `validate` returning `{ ok: false, status: 418 }` → response status 418 (pins `status ?? 422`).
+10. Non-string prompt-field value (e.g. numeric) → content-safety loop skips it without throwing (pins intended lenient behavior).
+
+**Dispatch 3 — usageId fix + poller refund.**
+*Implements:* Design §8 (`sprite-sheet/route.ts`, `tileset-gen/route.ts` — TResult + return gain `usageId`), §9 (`docs/api/openapi.json` — two response schemas), §10 (`sentry-regressions.test.ts` ASYNC_ROUTES). *Files touched:* those 4 + `route-integration.test.ts` + the poller hook test. 3 code items + 3 test items.
+11. `sentry-regressions.test.ts`: extend `ASYNC_ROUTES` per Design §10 (fails first).
+12. `route-integration.test.ts`: sprite-sheet + tileset-gen success payloads assert `usageId === ctx.usageId` in BOTH flag states (fails first); then Design §8 lands and both go green.
+13. `web/src/hooks/__tests__/useGenerationPolling` (jsdom): a job created WITH `usageId` that exhausts `MAX_POLL_COUNT` → the refund fetch fires with `{ usageId }`; a job WITHOUT `usageId` → no refund fetch (pins the `:460` guard both ways).
+
+**Dispatch 4 — abort composition + audio/3D clients.**
+*Implements:* Design §1 (`abortComposition.ts` NEW), §2 (`meshyClient.ts`), §3 (`sunoClient.ts`), §4 (`elevenlabsClient.ts`). *Files touched:* those 4 + 2 test files under `web/src/lib/generate/__tests__/`. 4 code items + 2 test items.
+14. `abortComposition.test.ts` (new; tests Design §1): undefined external → returned signal is timeout-driven only; pre-aborted external → result already aborted; external aborts before timeout → result aborts with the external reason.
+15. `meshyClient`/`sunoClient`/`elevenlabsClient` (tests Design §2–§4): with a params `signal` that aborts mid-flight, the underlying `fetch` receives a signal that aborts (assert via injected fetch mock capturing `init.signal`); without `signal`, captured signal still enforces the historical per-fetch timeout.
+
+**Dispatch 5 — remaining clients.**
+*Implements:* Design §5 (`spriteClient.ts`), §6 (`pixelArtClient.ts`) — the same `composeAbortSignal` pattern Dispatch 4 applied to Design §2–§4. *Files touched:* those 2 + their tests. 2 code items + 1 test item.
+16. `spriteClient`/`pixelArtClient` (tests Design §5–§6): same assertions as test 15, plus: aborting during the sprite client's internal Replicate poll loop (`getReplicateStatus`, Design §5 line 286) stops further poll fetches; `removeBackground` (line 214) is covered by the signal-capture assertion only (single fetch, no loop).
+
+**Dispatch 6 — route threading + end-to-end compose + docs + Boy-Scout leak fix.**
+*Implements:* Design §7 (ALL 12 `web/src/app/api/generate/*/route.ts` files — a uniform one-line `signal: ctx.abortSignal` pass-through per route, plus `abortSignal: ctx.abortSignal` at the 2 `generateText` call sites; sprite-sheet/tileset-gen also gain the `ctx` third param), §11 (ADR follow-ups update), §12 (changeset), §13 (`voice/batch/route.ts:108` error-message hygiene). *Files touched:* 12 route files + `voice/batch/route.ts` + ADR + changeset + `route-integration.test.ts` + 1 new factory-compose test + the voice/batch test file. The 14 signal pass-throughs are one mechanical pattern counted as one item, verified per-route by test 17 — the builder must still touch all 14 sites; logical items: route sweep + 4 tests + ADR + changeset + leak fix = 7.
+17. `route-integration.test.ts` (flag-on block; test-first for Design §7): assert each route's provider-client mock receives `ctx.abortSignal` (and the 2 LLM routes pass `abortSignal` to `generateText`). Implementation note: the provider clients are constructor mocks (`vi.fn(function (this) { this.method = vi.fn()... })`, `route-integration.test.ts:88–120`) — the method mocks live on constructed INSTANCES, not the module or prototype, so `vi.mocked(MeshyClient.prototype.createTextTo3D)` does not exist. Assert via the recorded instance: `vi.mocked(MeshyClient).mock.instances.at(-1)!.createTextTo3D.mock.calls[0]` and check the captured params carry the forwarded signal (use `.at(-1)` — the instance constructed by the request under test — since earlier tests in the file may also construct one). Do NOT restructure the existing mocks to prototype form; the 29 existing tests depend on the current shape.
+18. Timeout-parity test *(regression pin — model/music already carry `maxDurationSeconds: 180` and localize `120`, so this passes against current code)*: for every route, the `maxDurationSeconds` passed to the factory matches the route file's exported `maxDuration` (locks the 180s/120s special cases; closes the derive-plumbing gap).
+19. End-to-end compose *(regression pin — the timeout→`GenerationTimeoutError`→refund path shipped in #8833, so this passes against current code; its job is proving the path through the REAL factory, not the agent unit seam)*: flag-on route whose execute never resolves → `GenerationTimeoutError` fires at the derived deadline → `refundTokens` called → opaque 500. Implementation note: the factory's `runGenerationAgent` call (`createGenerationHandler.ts:278`) passes NO scheduler — the agent's injectable scheduler seam is unreachable from the factory, and the agent defaults to `globalThis.setTimeout` (`generationAgent.ts:143–145`). Fire the deadline with `vi.useFakeTimers()` + `await vi.advanceTimersByTimeAsync(stepTimeoutMs + 1)`; do NOT try to inject the scheduler through the factory (impossible without a code change this spec does not make) and do NOT use real wall-clock waits.
+20. Voice/batch error hygiene (test-first for Design §13): a provider failure whose body contains a sentinel string → the sentinel appears in NO user-visible field of the batch response (`errors[].error` is the generic message) AND `captureException` receives the status/body detail. In the SAME commit as the §13 code change, update the ONE existing assertion the fix invalidates — `voice/batch/route.test.ts:222` in `records errors for failed items while completing others`: `expect(data.errors[0].error).toBe('Voice generation failed')` becomes `.toBe('Voice generation failed for this item')`. The old expected string is the raw `err.message` pass-through itself (the mock rejects with `new Error('Voice generation failed')`), i.e. the assertion pins the leak §13 removes — updating it to the constant is a strengthening change, not a weakening.
+
+**Regression subsection — must pass unmodified (no weakening):** `route-integration.test.ts` (all 29 existing tests, both flag states), `createGenerationHandler.test.ts` (existing cases; only the Dispatch-1 mock-path line changes), `createGenerationHandler.qstash.test.ts` (run with QStash env unset), `generationAgent.test.ts`, `timeouts.test.ts`, `jobRecord.test.ts`, both `sentry-regressions.test.ts` files, `healthChecks` factory checks. `voice/batch/route.test.ts` is the ONE deliberate exception: exactly one expected-string assertion changes (line 222, per test 20 — it pins the leak §13 removes); every other assertion in that file must pass unmodified.
+
+**Gate (before push, Node 24):** `cd web && npx eslint --max-warnings 0 . && npx tsc --noEmit && env -u UPSTASH_REDIS_REST_URL -u UPSTASH_REDIS_REST_TOKEN npx vitest run` plus `jq empty docs/api/openapi.json`.
+
+## External prerequisites (owner-only — runbook, NOT set by this PR)
+
+ADR rollout steps 2–3, unblocked once this PR merges:
+1. Set `USE_GENERATION_AGENT=true` in Vercel **Preview** (scope `tnolan`, project `spawnforge`); exercise one generation per provider family on a preview deploy; watch Sentry (`tristan-nolan/spawnforge-ai`) for `GenerationTimeoutError` volume and generate-route 5xx rate.
+2. After a clean canary window, set the same var in **Production**.
+3. Revert path: unset the env var (exact-string semantics mean any other value is also OFF).
+
+## Acceptance criteria (mapped from ticket, corrected)
+
+1. *"Identical response contract incl. `usageId`"* — shipped by #8833 for 10 routes; COMPLETED here for all 12: sprite-sheet/tileset-gen return `usageId`, `route-integration.test.ts` green in both flag states, OpenAPI schemas updated.
+2. *"Step/timeout caps enforced; runaway terminates deterministically"* — shipped by #8833 (wall-clock deadline + `GenerationTimeoutError` → refund); COMPLETED here at the provider layer: the abort now cancels the in-flight provider HTTP request/poll loop, proven by client-level and end-to-end compose tests. (Scope note: for async job-submission providers, an already-accepted server-side job may still complete after abort — pre-existing, inherent to async generation, and refund-neutral; the abort guarantees OUR compute and connections stop.)
+3. *"Full integration tests across the generate routes pass"* — extended suite (Dispatches 1–6) green plus the unmodified regression set.
+4. Rollout runbook documented (above); flag flip remains an owner action.
+5. ADR follow-ups closed or ticketed: abort forwarding delivered; durable-polling leg → #8892; voice/batch remaining hardening → #8893 (with a clarifying comment posted); its error-message leak closed here with a pinning test (Design §13, test 20); ADR updated (Design §11).
+6. The PR closes #8826; taskboard PF-916 → done after the user merges.
+
+## Cross-spec coordination
+
+- **`specs/2026-07-02-posthog-deep-generator-attribution.md` (#8877, PR #8891 open):** neither depends on nor blocks this spec. That spec forbids `createGenerationHandler` control-flow changes on its side; this spec changes no factory control flow either (all edits are inside route `execute` bodies, provider clients, and tests). `captureAiGeneration` in localize/pacing is untouched — adding `abortSignal` to `generateText` options does not alter telemetry fields.
+- **`specs/PF-906-qstash-generation-callbacks.md` (#8816, shipped #8867):** dormancy invariants restated in Constraints §6 and pinned by Dispatch-2 test 7. The `usageId` addition feeds the same refund contract the QStash webhook uses; the webhook itself is untouched.
+- **#8883 (AI SDK v6→v7 bump, PR open):** fully independent. If #8883 merges first, nothing here changes (`abortSignal` on `generateText` is identical in v7); if this merges first, #8883 stays version-only. No file overlap except `package-lock.json` non-overlap (this PR touches no manifest).

--- a/web/src/app/api/__tests__/sentry-regressions.test.ts
+++ b/web/src/app/api/__tests__/sentry-regressions.test.ts
@@ -74,7 +74,7 @@ describe('Regression #2: refund endpoint idempotency', () => {
     // Async generation routes need usageId in success responses because
     // the client polls for job status and triggers refund via
     // useGenerationPolling.ts → triggerRefund() if the job fails after queuing.
-    const ASYNC_ROUTES = ['model', 'music', 'skybox', 'sprite', 'texture', 'pixel-art'];
+    const ASYNC_ROUTES = ['model', 'music', 'skybox', 'sprite', 'texture', 'pixel-art', 'sprite-sheet', 'tileset-gen'];
 
     const missing: string[] = [];
     for (const dir of ASYNC_ROUTES) {

--- a/web/src/app/api/generate/__tests__/route-integration.test.ts
+++ b/web/src/app/api/generate/__tests__/route-integration.test.ts
@@ -552,4 +552,252 @@ describe('generate route integration — generation agent path (USE_GENERATION_A
     const res = await POST(makeRequest('http://test/api/generate/sfx', { durationSeconds: 3 }));
     expect(res.status).toBe(422);
   });
+
+  // -------------------------------------------------------------------------
+  // Test 17: abort forwarding — each route's provider mock receives
+  // ctx.abortSignal (an AbortSignal) on the agent path (PF-916, Design §7).
+  //
+  // The mocks are constructor-shaped (vi.fn(function (this) { ... })), so
+  // method mocks live on instances, not the prototype. Access via
+  // vi.mocked(Ctor).mock.instances.at(-1) — the instance from this request,
+  // since vi.clearAllMocks() runs in beforeEach.
+  // -------------------------------------------------------------------------
+
+  it('test 17 — model route: MeshyClient.createTextTo3D receives ctx.abortSignal', async () => {
+    const { MeshyClient } = await import('@/lib/generate/meshyClient');
+    const { POST } = await import('@/app/api/generate/model/route');
+    const res = await POST(makeRequest('http://test/api/generate/model', { prompt: 'cube', mode: 'text-to-3d' }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(MeshyClient).mock.instances.at(-1) as any;
+    expect(instance.createTextTo3D.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — model route (image-to-3d): MeshyClient.createImageTo3D receives ctx.abortSignal', async () => {
+    const { MeshyClient } = await import('@/lib/generate/meshyClient');
+    const { POST } = await import('@/app/api/generate/model/route');
+    const res = await POST(makeRequest('http://test/api/generate/model', {
+      prompt: 'from image', mode: 'image-to-3d', imageBase64: 'abc123',
+    }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(MeshyClient).mock.instances.at(-1) as any;
+    expect(instance.createImageTo3D.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — texture route: MeshyClient.createTextToTexture receives ctx.abortSignal', async () => {
+    const { MeshyClient } = await import('@/lib/generate/meshyClient');
+    const { POST } = await import('@/app/api/generate/texture/route');
+    const res = await POST(makeRequest('http://test/api/generate/texture', { prompt: 'brick wall' }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(MeshyClient).mock.instances.at(-1) as any;
+    expect(instance.createTextToTexture.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — skybox route: MeshyClient.createTextToTexture receives ctx.abortSignal', async () => {
+    const { MeshyClient } = await import('@/lib/generate/meshyClient');
+    const { POST } = await import('@/app/api/generate/skybox/route');
+    const res = await POST(makeRequest('http://test/api/generate/skybox', { prompt: 'sunset clouds' }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(MeshyClient).mock.instances.at(-1) as any;
+    expect(instance.createTextToTexture.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — music route: SunoClient.createMusic receives ctx.abortSignal', async () => {
+    const { SunoClient } = await import('@/lib/generate/sunoClient');
+    const { POST } = await import('@/app/api/generate/music/route');
+    const res = await POST(makeRequest('http://test/api/generate/music', { prompt: 'epic battle', durationSeconds: 30 }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(SunoClient).mock.instances.at(-1) as any;
+    expect(instance.createMusic.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — sfx route: ElevenLabsClient.generateSfx receives ctx.abortSignal', async () => {
+    const { ElevenLabsClient } = await import('@/lib/generate/elevenlabsClient');
+    const { POST } = await import('@/app/api/generate/sfx/route');
+    const res = await POST(makeRequest('http://test/api/generate/sfx', { prompt: 'explosion', durationSeconds: 3 }));
+    expect(res.status).toBe(200);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(ElevenLabsClient).mock.instances.at(-1) as any;
+    expect(instance.generateSfx.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — voice route: ElevenLabsClient.generateVoice receives ctx.abortSignal', async () => {
+    const { ElevenLabsClient } = await import('@/lib/generate/elevenlabsClient');
+    const { POST } = await import('@/app/api/generate/voice/route');
+    const res = await POST(makeRequest('http://test/api/generate/voice', { text: 'Hello world' }));
+    expect(res.status).toBe(200);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(ElevenLabsClient).mock.instances.at(-1) as any;
+    expect(instance.generateVoice.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — sprite route: SpriteClient.generateSprite receives ctx.abortSignal', async () => {
+    const { SpriteClient } = await import('@/lib/generate/spriteClient');
+    const { POST } = await import('@/app/api/generate/sprite/route');
+    const res = await POST(makeRequest('http://test/api/generate/sprite', {
+      prompt: 'hero character', size: '64x64', removeBackground: true,
+    }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(SpriteClient).mock.instances.at(-1) as any;
+    expect(instance.generateSprite.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — sprite-sheet route: SpriteClient.generateSpriteSheet receives ctx.abortSignal', async () => {
+    const { SpriteClient } = await import('@/lib/generate/spriteClient');
+    const { POST } = await import('@/app/api/generate/sprite-sheet/route');
+    const res = await POST(makeRequest('http://test/api/generate/sprite-sheet', {
+      prompt: 'walk cycle', frameCount: 4, size: '64x64',
+    }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(SpriteClient).mock.instances.at(-1) as any;
+    expect(instance.generateSpriteSheet.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — pixel-art route: PixelArtClient.generate receives ctx.abortSignal', async () => {
+    const { PixelArtClient } = await import('@/lib/generate/pixelArtClient');
+    const { POST } = await import('@/app/api/generate/pixel-art/route');
+    const res = await POST(makeRequest('http://test/api/generate/pixel-art', {
+      prompt: 'wizard sprite', targetSize: 32, palette: 'nes',
+    }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(PixelArtClient).mock.instances.at(-1) as any;
+    expect(instance.generate.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — tileset-gen route: SpriteClient.generateTileset receives ctx.abortSignal', async () => {
+    const { SpriteClient } = await import('@/lib/generate/spriteClient');
+    const { POST } = await import('@/app/api/generate/tileset-gen/route');
+    const res = await POST(makeRequest('http://test/api/generate/tileset-gen', {
+      prompt: 'forest floor', tileSize: 32, gridSize: '8x8',
+    }));
+    expect(res.status).toBe(201);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instance = vi.mocked(SpriteClient).mock.instances.at(-1) as any;
+    expect(instance.generateTileset.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — localize route: generateText receives abortSignal option', async () => {
+    const { generateText } = await import('ai');
+    const { POST } = await import('@/app/api/generate/localize/route');
+    const res = await POST(makeRequest('http://test/api/generate/localize', {
+      strings: [{ id: 'greeting', text: 'Hello', context: 'Menu button' }],
+      sourceLocale: 'en',
+      targetLocales: ['es'],
+    }));
+    expect(res.status).toBe(200);
+    const calls = vi.mocked(generateText).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('test 17 — pacing route: generateText receives abortSignal option', async () => {
+    const { generateText } = await import('ai');
+    const { POST } = await import('@/app/api/generate/pacing/route');
+    const res = await POST(makeRequest('http://test/api/generate/pacing', {
+      report: {
+        score: 75,
+        curve: {
+          segments: [{ sceneIndex: 0, sceneName: 'Intro', intensity: 0.3, emotion: 'calm' }],
+          averageIntensity: 0.3,
+          variance: 0.01,
+        },
+        suggestions: [],
+      },
+    }));
+    expect(res.status).toBe(200);
+    const calls = vi.mocked(generateText).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0][0].abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 18: maxDuration parity regression pin.
+  //
+  // Pins the exported maxDuration for every route (model/music=180, localize=120,
+  // all others=60). This locks the relationship between each route's Vercel budget
+  // and the maxDurationSeconds config passed to createGenerationHandler, which
+  // drives deriveGenerationStepTimeoutMs. A drift here would make the agent abort
+  // either too late (outliving the function) or too early (spurious refunds).
+  // Passes against current code by design — its job is to prevent future drift.
+  // -------------------------------------------------------------------------
+
+  it('test 18 — all routes export maxDuration that matches factory maxDurationSeconds (regression pin)', async () => {
+    const [
+      model, music, localize,
+      sfx, voice, skybox, texture,
+      sprite, spriteSheet, pixelArt, tilesetGen, pacing,
+    ] = await Promise.all([
+      import('@/app/api/generate/model/route'),
+      import('@/app/api/generate/music/route'),
+      import('@/app/api/generate/localize/route'),
+      import('@/app/api/generate/sfx/route'),
+      import('@/app/api/generate/voice/route'),
+      import('@/app/api/generate/skybox/route'),
+      import('@/app/api/generate/texture/route'),
+      import('@/app/api/generate/sprite/route'),
+      import('@/app/api/generate/sprite-sheet/route'),
+      import('@/app/api/generate/pixel-art/route'),
+      import('@/app/api/generate/tileset-gen/route'),
+      import('@/app/api/generate/pacing/route'),
+    ]);
+
+    // Heavy provider routes: 180s budget (maxDurationSeconds: 180 in factory config)
+    expect(model.maxDuration).toBe(180);
+    expect(music.maxDuration).toBe(180);
+    // LLM batch route: 120s budget (maxDurationSeconds: 120 in factory config)
+    expect(localize.maxDuration).toBe(120);
+    // Standard routes: 60s budget (factory derives 55s step cap from this)
+    expect(sfx.maxDuration).toBe(60);
+    expect(voice.maxDuration).toBe(60);
+    expect(skybox.maxDuration).toBe(60);
+    expect(texture.maxDuration).toBe(60);
+    expect(sprite.maxDuration).toBe(60);
+    expect(spriteSheet.maxDuration).toBe(60);
+    expect(pixelArt.maxDuration).toBe(60);
+    expect(tilesetGen.maxDuration).toBe(60);
+    expect(pacing.maxDuration).toBe(60);
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 19: end-to-end timeout → GenerationTimeoutError → refund (regression pin).
+  //
+  // Proves the real factory drives the abort through the agent's timeout when
+  // a provider call never resolves. The agent defaults to globalThis.setTimeout
+  // (generationAgent.ts:143-145) so vi.useFakeTimers() fires the deadline.
+  // stepTimeoutMs for a 60s route = deriveGenerationStepTimeoutMs(60) = 55_000ms.
+  // Passes against current code (path shipped in #8833) — its job is to prove
+  // the composed path through the REAL factory, not the agent unit seam.
+  // -------------------------------------------------------------------------
+
+  it('test 19 — flag-on route timeout fires GenerationTimeoutError → refund → opaque 500 (regression pin)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { ElevenLabsClient } = await import('@/lib/generate/elevenlabsClient');
+      vi.mocked(ElevenLabsClient).mockImplementationOnce(function (this: Record<string, unknown>) {
+        this.generateSfx = vi.fn().mockReturnValue(new Promise<never>(() => {}));
+        this.generateVoice = vi.fn();
+      } as never);
+
+      const { refundTokens } = await import('@/lib/tokens/service');
+      const { POST } = await import('@/app/api/generate/sfx/route');
+
+      const responsePromise = POST(makeRequest('http://test/api/generate/sfx', { prompt: 'explosion', durationSeconds: 3 }));
+
+      // deriveGenerationStepTimeoutMs(60) = 60*1000 - 5000 = 55_000ms
+      await vi.advanceTimersByTimeAsync(55_001);
+
+      const res = await responsePromise;
+      expect(res.status).toBe(500);
+      expect(refundTokens).toHaveBeenCalledWith('user-int', 'usage-int');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/web/src/app/api/generate/__tests__/route-integration.test.ts
+++ b/web/src/app/api/generate/__tests__/route-integration.test.ts
@@ -269,7 +269,7 @@ describe('generate route integration (route → factory → provider)', () => {
     expect(data.usageId).toBe('usage-int');
   });
 
-  it('sprite-sheet: valid request → 201', async () => {
+  it('sprite-sheet: valid request → 201 with jobId and usageId', async () => {
     const { POST } = await import('@/app/api/generate/sprite-sheet/route');
     const res = await POST(makeRequest('http://test/api/generate/sprite-sheet', {
       prompt: 'walk cycle', frameCount: 4, size: '64x64',
@@ -277,9 +277,10 @@ describe('generate route integration (route → factory → provider)', () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.jobId).toBe('sheet-1');
+    expect(data.usageId).toBe('usage-int');
   });
 
-  it('tileset-gen: valid request → 201', async () => {
+  it('tileset-gen: valid request → 201 with jobId and usageId', async () => {
     const { POST } = await import('@/app/api/generate/tileset-gen/route');
     const res = await POST(makeRequest('http://test/api/generate/tileset-gen', {
       prompt: 'forest floor', tileSize: 32, gridSize: '8x8',
@@ -287,6 +288,7 @@ describe('generate route integration (route → factory → provider)', () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.jobId).toBe('tile-1');
+    expect(data.usageId).toBe('usage-int');
   });
 
   it('pixel-art: valid request → 201', async () => {
@@ -506,6 +508,28 @@ describe('generate route integration — generation agent path (USE_GENERATION_A
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.jobId).toBe('pxart-1');
+    expect(data.usageId).toBe('usage-int');
+  });
+
+  it('sprite-sheet: 201 with jobId AND usageId preserved through the agent', async () => {
+    const { POST } = await import('@/app/api/generate/sprite-sheet/route');
+    const res = await POST(makeRequest('http://test/api/generate/sprite-sheet', {
+      prompt: 'walk cycle', frameCount: 4, size: '64x64',
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.jobId).toBe('sheet-1');
+    expect(data.usageId).toBe('usage-int');
+  });
+
+  it('tileset-gen: 201 with jobId AND usageId preserved through the agent', async () => {
+    const { POST } = await import('@/app/api/generate/tileset-gen/route');
+    const res = await POST(makeRequest('http://test/api/generate/tileset-gen', {
+      prompt: 'forest floor', tileSize: 32, gridSize: '8x8',
+    }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.jobId).toBe('tile-1');
     expect(data.usageId).toBe('usage-int');
   });
 

--- a/web/src/app/api/generate/localize/route.ts
+++ b/web/src/app/api/generate/localize/route.ts
@@ -119,7 +119,7 @@ export const POST = createGenerationHandler<
     sourceLocale: params.sourceLocale,
     targetLocales: params.targetLocales,
   }),
-  execute: async (params, apiKey, { userId, usageId }) => {
+  execute: async (params, apiKey, { userId, usageId, abortSignal }) => {
     const anthropicProvider = createAnthropic({ apiKey });
     const result: Record<string, LocaleBundle> = {};
 
@@ -141,6 +141,7 @@ export const POST = createGenerationHandler<
           prompt,
           maxOutputTokens: 4096,
           experimental_telemetry: { isEnabled: true },
+          abortSignal,
         });
 
         captureAiGeneration({

--- a/web/src/app/api/generate/model/route.ts
+++ b/web/src/app/api/generate/model/route.ts
@@ -106,6 +106,7 @@ export const POST = createGenerationHandler<
       result = await client.createImageTo3D({
         imageBase64: params.imageBase64!,
         prompt: params.prompt,
+        signal: ctx.abortSignal,
       });
     } else {
       result = await client.createTextTo3D({
@@ -113,6 +114,7 @@ export const POST = createGenerationHandler<
         artStyle: params.artStyle,
         negativePrompt: params.negativePrompt,
         quality: params.quality,
+        signal: ctx.abortSignal,
       });
     }
 

--- a/web/src/app/api/generate/music/route.ts
+++ b/web/src/app/api/generate/music/route.ts
@@ -46,6 +46,7 @@ export const POST = createGenerationHandler<
       prompt: params.prompt,
       durationSeconds: params.durationSeconds,
       instrumental: params.instrumental,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/pacing/route.ts
+++ b/web/src/app/api/generate/pacing/route.ts
@@ -84,7 +84,7 @@ export const POST = createGenerationHandler<
 
     return { ok: true, params: { report: r } };
   },
-  execute: async (params, apiKey, { userId, usageId }) => {
+  execute: async (params, apiKey, { userId, usageId, abortSignal }) => {
     const { report } = params;
     const consented = await hasAnalyticsConsent();
 
@@ -120,6 +120,7 @@ Generate 2–4 additional AI suggestions to improve the emotional pacing.`;
       temperature: 0.4,
       output: Output.object({ schema: PacingSuggestionSchema }),
       experimental_telemetry: { isEnabled: true },
+      abortSignal,
     });
 
     captureAiGeneration({

--- a/web/src/app/api/generate/pixel-art/route.ts
+++ b/web/src/app/api/generate/pixel-art/route.ts
@@ -121,6 +121,7 @@ export const POST = createGenerationHandler<
       prompt: params.prompt,
       style: params.style as PixelArtStyle,
       size: providerSize,
+      signal: ctx.abortSignal,
     });
 
     const jobId = result.predictionId ?? `pxart-openai-${Date.now()}`;

--- a/web/src/app/api/generate/sfx/route.ts
+++ b/web/src/app/api/generate/sfx/route.ts
@@ -32,11 +32,12 @@ export const POST = createGenerationHandler<
     prompt: params.prompt,
     durationSeconds: params.durationSeconds,
   }),
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, ctx) => {
     const client = new ElevenLabsClient({ apiKey });
     const result = await client.generateSfx({
       prompt: params.prompt,
       durationSeconds: params.durationSeconds,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/skybox/route.ts
+++ b/web/src/app/api/generate/skybox/route.ts
@@ -38,6 +38,7 @@ export const POST = createGenerationHandler<
       resolution: '2048',
       style: params.style,
       tiling: false,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/sprite-sheet/route.ts
+++ b/web/src/app/api/generate/sprite-sheet/route.ts
@@ -66,6 +66,7 @@ export const POST = createGenerationHandler<
       frameCount: params.frameCount,
       style: params.style,
       size: params.size,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/sprite-sheet/route.ts
+++ b/web/src/app/api/generate/sprite-sheet/route.ts
@@ -15,7 +15,7 @@ export const POST = createGenerationHandler<
     style?: SpriteStyle;
     size: SpriteSize;
   },
-  { jobId: string; provider: string; status: string; estimatedSeconds: number }
+  { jobId: string; provider: string; status: string; estimatedSeconds: number; usageId: string | undefined }
 >({
   route: '/api/generate/sprite-sheet',
   provider: DB_PROVIDER.sprite,
@@ -59,7 +59,7 @@ export const POST = createGenerationHandler<
       },
     };
   },
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, ctx) => {
     const client = new SpriteClient(apiKey, 'sdxl');
     const result = await client.generateSpriteSheet({
       prompt: params.prompt,
@@ -73,6 +73,7 @@ export const POST = createGenerationHandler<
       provider: DB_PROVIDER.sprite,
       status: result.status,
       estimatedSeconds: params.frameCount * 10,
+      usageId: ctx.usageId,
     };
   },
   // Durable server-side completion + refund (PF-906). Dormant unless QStash set.

--- a/web/src/app/api/generate/sprite/route.ts
+++ b/web/src/app/api/generate/sprite/route.ts
@@ -93,6 +93,7 @@ export const POST = createGenerationHandler<
       size: params.size,
       provider: params.provider,
       removeBackground: params.removeBackground,
+      signal: ctx.abortSignal,
     });
 
     let finalJobId = result.taskId;

--- a/web/src/app/api/generate/texture/route.ts
+++ b/web/src/app/api/generate/texture/route.ts
@@ -81,6 +81,7 @@ export const POST = createGenerationHandler<
       style: params.style,
       tiling: params.tiling,
       generateMaps: params.generateMaps,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/tileset-gen/route.ts
+++ b/web/src/app/api/generate/tileset-gen/route.ts
@@ -52,6 +52,7 @@ export const POST = createGenerationHandler<
       prompt: params.prompt,
       tileSize: params.tileSize,
       gridSize: params.gridSize,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/app/api/generate/tileset-gen/route.ts
+++ b/web/src/app/api/generate/tileset-gen/route.ts
@@ -9,7 +9,7 @@ type GridSize = '4x4' | '8x8' | '16x16';
 
 export const POST = createGenerationHandler<
   { prompt: string; tileSize: TileSize; gridSize: GridSize },
-  { jobId: string; provider: string; status: string; estimatedSeconds: number }
+  { jobId: string; provider: string; status: string; estimatedSeconds: number; usageId: string | undefined }
 >({
   route: '/api/generate/tileset-gen',
   provider: DB_PROVIDER.sprite,
@@ -46,7 +46,7 @@ export const POST = createGenerationHandler<
       },
     };
   },
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, ctx) => {
     const client = new SpriteClient(apiKey, 'sdxl');
     const result = await client.generateTileset({
       prompt: params.prompt,
@@ -59,6 +59,7 @@ export const POST = createGenerationHandler<
       provider: DB_PROVIDER.sprite,
       status: result.status,
       estimatedSeconds: 60,
+      usageId: ctx.usageId,
     };
   },
   // Durable server-side completion + refund (PF-906). Dormant unless QStash set.

--- a/web/src/app/api/generate/voice/batch/route.test.ts
+++ b/web/src/app/api/generate/voice/batch/route.test.ts
@@ -219,7 +219,34 @@ describe('POST /api/generate/voice/batch', () => {
     expect(data.totalGenerated).toBe(1);
     expect(data.totalFailed).toBe(1);
     expect(data.errors[0].nodeId).toBe('node_2');
-    expect(data.errors[0].error).toBe('Voice generation failed');
+    expect(data.errors[0].error).toBe('Voice generation failed for this item');
+  });
+
+  // Test 20: provider error body must reach captureException and NOT the user response.
+  // The old code passed err.message through, leaking raw provider details (status
+  // codes, response bodies). Design §13 replaces it with a constant generic string.
+  it('test 20 — provider error detail reaches captureException only, not user-visible response', async () => {
+    const { captureException } = await import('@/lib/monitoring/sentry-server');
+    const user = makeUser();
+    vi.mocked(authenticateRequest).mockResolvedValue({ ok: true, ctx: { clerkId: '123', user } });
+    vi.mocked(resolveApiKey).mockResolvedValue({ type: 'platform', key: 'el_key', metered: true });
+
+    const sentinel = 'ElevenLabs TTS API error (503): {"error":"upstream_failure","detail":"SENTINEL_xz99"}';
+    mockGenerateVoice.mockRejectedValueOnce(new Error(sentinel));
+
+    const singleItem = [{ nodeId: 'node_t20', text: 'Test sentence', speaker: 'narrator' }];
+    const res = await POST(makeRequest({ items: singleItem, voiceSettings: defaultVoiceSettings }));
+    const data = await res.json();
+
+    // Sentinel must not appear in any user-visible field
+    expect(data.errors[0].error).toBe('Voice generation failed for this item');
+    expect(JSON.stringify(data)).not.toContain('SENTINEL_xz99');
+
+    // Full error detail is captured server-side for debugging
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: sentinel }),
+      expect.anything(),
+    );
   });
 
   it('rethrows non-ApiKeyError during key resolution', async () => {

--- a/web/src/app/api/generate/voice/batch/route.ts
+++ b/web/src/app/api/generate/voice/batch/route.ts
@@ -105,7 +105,7 @@ export async function POST(request: NextRequest) {
       captureException(err, { route: '/api/generate/voice/batch', nodeId: item.nodeId });
       errors.push({
         nodeId: item.nodeId,
-        error: err instanceof Error ? err.message : 'Generation failed',
+        error: 'Voice generation failed for this item',
       });
     }
   }

--- a/web/src/app/api/generate/voice/route.ts
+++ b/web/src/app/api/generate/voice/route.ts
@@ -94,7 +94,7 @@ export const POST = createGenerationHandler<
     similarityBoost: params.similarityBoost,
     style: params.style,
   }),
-  execute: async (params, apiKey) => {
+  execute: async (params, apiKey, ctx) => {
     const client = new ElevenLabsClient({ apiKey });
     const result = await client.generateVoice({
       text: params.text,
@@ -102,6 +102,7 @@ export const POST = createGenerationHandler<
       stability: params.stability,
       similarityBoost: params.similarityBoost,
       style: params.style,
+      signal: ctx.abortSignal,
     });
 
     return {

--- a/web/src/hooks/__tests__/useGenerationPolling.test.ts
+++ b/web/src/hooks/__tests__/useGenerationPolling.test.ts
@@ -464,6 +464,57 @@ describe('useGenerationPolling', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // triggerRefund :460 guard — pins both sides of `if (!job?.usageId) return`
+  // ---------------------------------------------------------------------------
+  it('triggers refund with usageId when a job exhausts MAX_POLL_COUNT', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      if (typeof url === 'string' && url.includes('refund')) {
+        return new Response('{}', { status: 200 });
+      }
+      return {
+        ok: true,
+        json: () => Promise.resolve({ jobId: 'job-rg1', status: 'processing', progress: 50 }),
+      } as Response;
+    });
+
+    mockJobs['rg1'] = makeJob('rg1', { usageId: 'usage-rg1' });
+    renderHook(() => useGenerationPolling());
+
+    for (let i = 0; i < 101; i++) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    }
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/generate/refund',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('usage-rg1'),
+      }),
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it('does not trigger refund when a job without usageId exhausts MAX_POLL_COUNT', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve({ jobId: 'job-rg2', status: 'processing', progress: 50 }),
+    } as Response));
+
+    mockJobs['rg2'] = makeJob('rg2'); // no usageId
+    renderHook(() => useGenerationPolling());
+
+    for (let i = 0; i < 101; i++) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    }
+
+    const refundCalls = fetchSpy.mock.calls.filter(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('refund'),
+    );
+    expect(refundCalls).toHaveLength(0);
+    fetchSpy.mockRestore();
+  });
+
+  // ---------------------------------------------------------------------------
   // Timeout (max polls)
   // ---------------------------------------------------------------------------
   it('times out after MAX_POLL_COUNT (100) polls', async () => {

--- a/web/src/lib/api/__tests__/createGenerationHandler.test.ts
+++ b/web/src/lib/api/__tests__/createGenerationHandler.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest, NextResponse } from 'next/server';
 
+// Capture every after() callback so tests can assert the deferred-publish gate
+// is dormant (no callbacks registered) without triggering real Next.js after().
+// Pattern mirrors createGenerationHandler.qstash.test.ts.
+const { afterCallbacks } = vi.hoisted(() => ({ afterCallbacks: [] as Array<() => unknown> }));
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return { ...actual, after: (cb: () => unknown) => { afterCallbacks.push(cb); } };
+});
+
 vi.mock('server-only', () => ({}));
 
 // Mock all dependencies
@@ -54,6 +63,12 @@ vi.mock('@/lib/api/responseCache', () => ({
     cached: false,
   })),
 }));
+// QStash client: default dormant (isQstashConfigured → false) so existing tests
+// are unaffected. Tests that need it active set mockConfigured.mockReturnValue(true).
+vi.mock('@/lib/qstash/client', () => ({
+  isQstashConfigured: vi.fn(() => false),
+  publishGenerationCallback: vi.fn(async () => {}),
+}));
 
 // Client-facing message for every 500 (#8597). Raw err.message can leak server
 // internals (env var names, DB DSNs, provider request IDs), so the client gets
@@ -67,6 +82,7 @@ import { sanitizePrompt } from '@/lib/ai/contentSafety';
 import { refundTokens } from '@/lib/tokens/service';
 import { captureException } from '@/lib/monitoring/sentry-server';
 import { cachedGenerate } from '@/lib/api/responseCache';
+import { isQstashConfigured } from '@/lib/qstash/client';
 import { createGenerationHandler } from '../createGenerationHandler';
 
 const mockAuth = vi.mocked(authenticateRequest);
@@ -77,6 +93,7 @@ const mockSanitize = vi.mocked(sanitizePrompt);
 const mockRefund = vi.mocked(refundTokens);
 const mockCapture = vi.mocked(captureException);
 const mockCachedGenerate = vi.mocked(cachedGenerate);
+const mockConfigured = vi.mocked(isQstashConfigured);
 
 function makeRequest(body: Record<string, unknown>): NextRequest {
   return new NextRequest('http://localhost:3000/api/generate/test', {
@@ -107,6 +124,7 @@ describe('createGenerationHandler', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    afterCallbacks.length = 0;
     mockAuth.mockResolvedValue({
       ok: true,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -116,6 +134,9 @@ describe('createGenerationHandler', () => {
     mockRateLimit.mockResolvedValue({ allowed: true, remaining: 9, resetAt: Date.now() + 300000 });
     mockResolve.mockResolvedValue({ type: 'platform', key: 'test-key', metered: true, usageId: 'usage-1' });
     mockSanitize.mockReturnValue({ safe: true, filtered: 'test prompt' });
+    // QStash dormant by default — handlers in this file that omit asyncJob never
+    // reach isQstashConfigured() (short-circuit), so this is safe for all existing tests.
+    mockConfigured.mockReturnValue(false);
   });
 
   it('returns 401 when unauthenticated', async () => {
@@ -563,5 +584,123 @@ describe('createGenerationHandler', () => {
       expect.any(Error),
       expect.objectContaining({ action: 'refund', usageId: 'usage-1' }),
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // PF-916 / #8826 — Dispatch 2: factory contract pins (tests 6–10)
+  // -------------------------------------------------------------------------
+
+  it('returns 401 without calling either rate limiter (auth before rate limit) (#8826 pin)', async () => {
+    // The factory returns from auth (step 1) before reaching the aggregate or
+    // per-route rate limiters (step 2a/2b). A 401 must consume zero budget.
+    mockAuth.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const res = await testHandler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(401);
+    expect(mockAggRateLimit).not.toHaveBeenCalled();
+    expect(mockRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('registers no after() callbacks for a non-async route (dormant after, part 1 of 2) (#8826 pin)', async () => {
+    // testHandler has no asyncJob — the `if (asyncJob && isQstashConfigured())`
+    // gate short-circuits on asyncJob === undefined, so after() is never reached.
+    const res = await testHandler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(200);
+    expect(afterCallbacks).toHaveLength(0);
+  });
+
+  it('registers no after() callbacks for an async route when QStash is unconfigured (dormant after, part 2 of 2) (#8826 pin)', async () => {
+    // mockConfigured.mockReturnValue(false) is set by beforeEach: QStash env unset.
+    // Even with asyncJob declared, isQstashConfigured() returning false means the
+    // gate `asyncJob && isQstashConfigured()` evaluates to false → after() is never called.
+    const asyncHandler = createGenerationHandler<{ prompt: string }, { jobId: string; status: string }>({
+      route: '/api/generate/model',
+      provider: 'elevenlabs',
+      operation: 'model_generation',
+      rateLimitKey: 'gen-model',
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => ({ jobId: 'task-1', status: 'pending' }),
+      asyncJob: {
+        type: 'model',
+        providerJobId: (r) => r.jobId,
+      },
+    });
+    const res = await asyncHandler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(200);
+    expect(afterCallbacks).toHaveLength(0);
+  });
+
+  it('passes validated params directly as billingMetadata when billingMetadata config is omitted (#8826 pin)', async () => {
+    // Factory lines 384 and 437: `const metadata = billingMetadataFn
+    //   ? billingMetadataFn(params) : (params as Record<string, unknown>)`.
+    // Omitting billingMetadata → resolveApiKey receives the full params object.
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      // No billingMetadata — params is passed through unchanged.
+      validate: (body) => ({
+        ok: true,
+        params: { prompt: body.prompt as string, count: body.count as number },
+      }),
+      execute: async () => ({ ok: true }),
+    });
+
+    await handler(makeRequest({ prompt: 'test prompt', count: 3 }));
+
+    // Content safety replaces prompt with the filtered value ('test prompt' → 'test prompt'
+    // per the mock, same value). count is a number; the type guard skips it unchanged.
+    expect(mockResolve).toHaveBeenCalledWith(
+      'user-1',
+      'elevenlabs',
+      10,
+      'test_generation',
+      { prompt: 'test prompt', count: 3 },
+    );
+  });
+
+  it('uses custom status code from validate failure and falls back to 422 (pins status ?? 422) (#8826 pin)', async () => {
+    // Factory line 320: `{ status: validation.status ?? 422 }`.
+    // A validate result carrying status: 418 must produce a 418 response.
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      validate: () => ({ ok: false as const, error: 'I am a teapot', status: 418 }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(418);
+    const data = await res.json();
+    expect(data.error).toBe('I am a teapot');
+  });
+
+  it('skips non-string secondaryPromptField values without throwing (pins lenient safety loop) (#8826 pin)', async () => {
+    // Factory line 338: `if (typeof value === 'string' && value.length > 0)`.
+    // A numeric value (e.g. count: 5) in a secondaryPromptFields entry must be
+    // silently skipped — no TypeError, no 422, no call to sanitizePrompt.
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      secondaryPromptFields: ['count'],
+      validate: (body) => ({
+        ok: true,
+        params: { prompt: body.prompt as string, count: body.count as number },
+      }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt', count: 5 }));
+    expect(res.status).toBe(200);
+    // sanitizePrompt called once (primary prompt only); numeric count is bypassed.
+    expect(mockSanitize).toHaveBeenCalledTimes(1);
+    expect(mockSanitize).toHaveBeenCalledWith('test prompt');
   });
 });

--- a/web/src/lib/api/__tests__/createGenerationHandler.test.ts
+++ b/web/src/lib/api/__tests__/createGenerationHandler.test.ts
@@ -48,7 +48,7 @@ vi.mock('@/lib/db/client', () => ({
 // Drive the cached path deterministically: run the miss factory and surface any
 // thrown error to the handler's cached-path catch site (so its 500 behaviour,
 // including the #8597 message-leak guard, is exercised without real Redis).
-vi.mock('../responseCache', () => ({
+vi.mock('@/lib/api/responseCache', () => ({
   cachedGenerate: vi.fn(async (_op: string, _params: unknown, factory: () => Promise<unknown>) => ({
     result: await factory(),
     cached: false,

--- a/web/src/lib/api/__tests__/createGenerationHandler.test.ts
+++ b/web/src/lib/api/__tests__/createGenerationHandler.test.ts
@@ -66,6 +66,7 @@ import { distributedRateLimit, aggregateGenerationRateLimit } from '@/lib/rateLi
 import { sanitizePrompt } from '@/lib/ai/contentSafety';
 import { refundTokens } from '@/lib/tokens/service';
 import { captureException } from '@/lib/monitoring/sentry-server';
+import { cachedGenerate } from '@/lib/api/responseCache';
 import { createGenerationHandler } from '../createGenerationHandler';
 
 const mockAuth = vi.mocked(authenticateRequest);
@@ -75,6 +76,7 @@ const mockAggRateLimit = vi.mocked(aggregateGenerationRateLimit);
 const mockSanitize = vi.mocked(sanitizePrompt);
 const mockRefund = vi.mocked(refundTokens);
 const mockCapture = vi.mocked(captureException);
+const mockCachedGenerate = vi.mocked(cachedGenerate);
 
 function makeRequest(body: Record<string, unknown>): NextRequest {
   return new NextRequest('http://localhost:3000/api/generate/test', {
@@ -397,5 +399,169 @@ describe('createGenerationHandler', () => {
     // Absent secondary fields are not screened.
     expect(mockSanitize).toHaveBeenCalledWith('a friendly robot');
     expect(mockSanitize).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // PF-916 / #8826 — factory contract pins (regression guards)
+  //
+  // These tests pin EXISTING behavior: they pass against current code by
+  // design. Their job is to lock behavior this PR must not change, not to
+  // fail first. Any RED result is a real bug — fix the code, never the test.
+  // -------------------------------------------------------------------------
+
+  it('passes filtered prompt text to both execute and billingMetadata (primary + secondary fields) (#8826 pin)', async () => {
+    const executeSpy = vi.fn().mockResolvedValue({ ok: true });
+    const billingMetadataSpy = vi.fn().mockImplementation((p: unknown) => p as Record<string, unknown>);
+
+    mockSanitize.mockImplementation((p: string) => ({ safe: true, filtered: `filtered(${p})` }));
+
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      secondaryPromptFields: ['negativePrompt'],
+      billingMetadata: billingMetadataSpy,
+      validate: (body) => ({
+        ok: true,
+        params: { prompt: body.prompt as string, negativePrompt: body.negativePrompt as string },
+      }),
+      execute: executeSpy,
+    });
+
+    await handler(makeRequest({ prompt: 'raw prompt', negativePrompt: 'raw negative' }));
+
+    // params is mutated in-place by the content-safety loop before execute and
+    // billingMetadata are called, so both receive the filtered versions.
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'filtered(raw prompt)',
+        negativePrompt: 'filtered(raw negative)',
+      }),
+      expect.any(String),
+      expect.anything(),
+    );
+    expect(billingMetadataSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'filtered(raw prompt)',
+        negativePrompt: 'filtered(raw negative)',
+      }),
+    );
+  });
+
+  it('returns 500 "Internal pricing error" and captures when tokenCost fn returns NaN (#8826 pin)', async () => {
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      tokenCost: () => NaN,
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Internal pricing error');
+    expect(mockCapture).toHaveBeenCalled();
+  });
+
+  it('returns 500 "Internal pricing error" and captures when tokenCost fn returns a negative value (#8826 pin)', async () => {
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      tokenCost: () => -5,
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Internal pricing error');
+    expect(mockCapture).toHaveBeenCalled();
+  });
+
+  it('returns 500 "Internal pricing error" via resolve_billing_params branch when tokenCost fn throws (#8826 pin)', async () => {
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      tokenCost: () => { throw new Error('pricing service unavailable'); },
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => ({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe('Internal pricing error');
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ action: 'resolve_billing_params' }),
+    );
+  });
+
+  it('calls refundTokens and returns GENERIC_500 on cached-path execute failure (#8826 pin)', async () => {
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      cacheKeyParams: (p) => ({ prompt: (p as { prompt: string }).prompt }),
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => { throw new Error('cached provider failure'); },
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(500);
+    expect(mockRefund).toHaveBeenCalledWith('user-1', 'usage-1');
+    const data = await res.json();
+    expect(data.error).toBe(GENERIC_500);
+  });
+
+  it('skips resolveApiKey, deductTokens and QStash publish on a cache HIT; sets X-Cache: HIT header (#8826 pin)', async () => {
+    mockCachedGenerate.mockResolvedValueOnce({ result: { ok: true }, cached: true });
+
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      cacheKeyParams: (p) => ({ prompt: (p as { prompt: string }).prompt }),
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: vi.fn().mockResolvedValue({ ok: true }),
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Cache')).toBe('HIT');
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it('returns opaque 500 and captures with refund context even when refundTokens itself throws (#8826 pin)', async () => {
+    mockRefund.mockRejectedValue(new Error('refund service unavailable'));
+
+    const handler = createGenerationHandler({
+      route: '/api/generate/test',
+      provider: 'elevenlabs',
+      operation: 'test_generation',
+      rateLimitKey: 'gen-test',
+      validate: (body) => ({ ok: true, params: { prompt: body.prompt as string } }),
+      execute: async () => { throw new Error('provider failure triggering refund'); },
+    });
+
+    const res = await handler(makeRequest({ prompt: 'test prompt' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toBe(GENERIC_500);
+    expect(mockCapture).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ action: 'refund', usageId: 'usage-1' }),
+    );
   });
 });

--- a/web/src/lib/generate/__tests__/abortComposition.test.ts
+++ b/web/src/lib/generate/__tests__/abortComposition.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { composeAbortSignal } from '../abortComposition';
+
+describe('composeAbortSignal', () => {
+  it('returns a timeout-only signal when external is undefined', () => {
+    const signal = composeAbortSignal(undefined, 5000);
+    expect(signal).toBeInstanceOf(AbortSignal);
+    // A fresh timeout signal should not be immediately aborted
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('returns an already-aborted signal when external is pre-aborted', () => {
+    const controller = new AbortController();
+    controller.abort(new Error('already done'));
+    const signal = composeAbortSignal(controller.signal, 5000);
+    expect(signal.aborted).toBe(true);
+  });
+
+  it('aborts with the external reason when external fires before the timeout', () => {
+    const controller = new AbortController();
+    const reason = new Error('deadline exceeded');
+    const signal = composeAbortSignal(controller.signal, 60_000);
+
+    expect(signal.aborted).toBe(false);
+    controller.abort(reason);
+    // AbortSignal.any propagates the reason of the first signal to fire
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(reason);
+  });
+});

--- a/web/src/lib/generate/__tests__/elevenlabsClient.test.ts
+++ b/web/src/lib/generate/__tests__/elevenlabsClient.test.ts
@@ -107,6 +107,70 @@ describe('ElevenLabsClient', () => {
     });
   });
 
+  describe('abort signal composition', () => {
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (generateSfx)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([]).buffer),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new ElevenLabsClient({ apiKey: mockApiKey });
+      await client.generateSfx({ prompt: 'wind', signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (generateSfx)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([]).buffer),
+      } as Response);
+
+      const client = new ElevenLabsClient({ apiKey: mockApiKey });
+      await client.generateSfx({ prompt: 'rain' });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (generateVoice)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([]).buffer),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new ElevenLabsClient({ apiKey: mockApiKey });
+      await client.generateVoice({ text: 'Hello', signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (generateVoice)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new Uint8Array([]).buffer),
+      } as Response);
+
+      const client = new ElevenLabsClient({ apiKey: mockApiKey });
+      await client.generateVoice({ text: 'Hello world' });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+  });
+
   describe('generateVoice', () => {
     it('sends correct request with default voiceId and returns audio', async () => {
       const fakeBuffer = new Uint8Array([10, 20]).buffer;

--- a/web/src/lib/generate/__tests__/meshyClient.test.ts
+++ b/web/src/lib/generate/__tests__/meshyClient.test.ts
@@ -294,6 +294,68 @@ describe('MeshyClient', () => {
       // A fresh timeout signal must not be immediately aborted
       expect(capturedSignal.aborted).toBe(false);
     });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal is provided (getTaskStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'pending' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.getTaskStatus('valid-task-id', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal is provided (getTaskStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'pending' }),
+      } as Response);
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.getTaskStatus('valid-task-id');
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal is provided (getTextureStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'pending', progress: 10 }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.getTextureStatus('valid-tex-id', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal is provided (getTextureStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'pending', progress: 10 }),
+      } as Response);
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.getTextureStatus('valid-tex-id');
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
   });
 
   describe('getTextureStatus', () => {

--- a/web/src/lib/generate/__tests__/meshyClient.test.ts
+++ b/web/src/lib/generate/__tests__/meshyClient.test.ts
@@ -261,6 +261,41 @@ describe('MeshyClient', () => {
     });
   });
 
+  describe('abort signal composition', () => {
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ result: 'task-signal-test' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.createTextTo3D({ prompt: 'dragon', signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      // The composed signal must be aborted because the external was pre-aborted
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ result: 'task-no-signal' }),
+      } as Response);
+
+      const client = new MeshyClient({ apiKey: mockApiKey });
+      await client.createTextTo3D({ prompt: 'castle' });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      // A fresh timeout signal must not be immediately aborted
+      expect(capturedSignal.aborted).toBe(false);
+    });
+  });
+
   describe('getTextureStatus', () => {
     it('returns texture status with maps', async () => {
       vi.mocked(fetch).mockResolvedValue({

--- a/web/src/lib/generate/__tests__/pixelArtClient.test.ts
+++ b/web/src/lib/generate/__tests__/pixelArtClient.test.ts
@@ -172,4 +172,85 @@ describe('pixelArtClient', () => {
         .rejects.toThrow('Replicate status error 404');
     });
   });
+
+  describe('abort signal composition', () => {
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (openai provider)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ b64_json: 'base64data' }] }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new PixelArtClient('test-key', 'openai');
+      await client.generate({ prompt: 'knight', style: 'character', size: 1024, signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (openai provider)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ b64_json: 'base64data' }] }),
+      } as Response);
+
+      const client = new PixelArtClient('test-key', 'openai');
+      await client.generate({ prompt: 'knight', style: 'character', size: 1024 });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (replicate provider)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'pred-123', status: 'starting' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new PixelArtClient('test-key', 'replicate');
+      await client.generate({ prompt: 'sword', style: 'prop', size: 1024, signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (getReplicateStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'succeeded', output: [] }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new PixelArtClient('test-key', 'replicate');
+      await client.getReplicateStatus('pred-sig', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (getReplicateStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'starting' }),
+      } as Response);
+
+      const client = new PixelArtClient('test-key', 'replicate');
+      await client.getReplicateStatus('pred-no-sig');
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+  });
 });

--- a/web/src/lib/generate/__tests__/spriteClient.test.ts
+++ b/web/src/lib/generate/__tests__/spriteClient.test.ts
@@ -305,4 +305,162 @@ describe('SpriteClient', () => {
         .rejects.toThrow('Replicate API error (500)');
     });
   });
+
+  describe('abort signal composition', () => {
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (generateSprite DALL-E)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ url: 'https://image.url' }] }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SpriteClient(mockApiKey, 'dalle3');
+      await client.generateSprite({ prompt: 'cat', size: '512x512', signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (generateSprite DALL-E)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ url: 'https://image.url' }] }),
+      } as Response);
+
+      const client = new SpriteClient(mockApiKey, 'dalle3');
+      await client.generateSprite({ prompt: 'cat', size: '512x512' });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (generateSpriteSheet)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'sheet_sig', status: 'starting' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SpriteClient(mockApiKey, 'sdxl');
+      await client.generateSpriteSheet({
+        prompt: 'walk', frameCount: 4, size: '64x64', signal: controller.signal,
+      });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (generateTileset)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'tile_sig', status: 'starting' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SpriteClient(mockApiKey, 'sdxl');
+      await client.generateTileset({
+        prompt: 'grass', tileSize: 32, gridSize: '8x8', signal: controller.signal,
+      });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (removeBackground)', async () => {
+      const mockBlob = new Blob(['png-data'], { type: 'image/png' });
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(mockBlob),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SpriteClient(mockApiKey, 'removebg');
+      await client.removeBackground('https://example.com/image.png', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided (getReplicateStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'succeeded', output: [] }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SpriteClient(mockApiKey, 'sdxl');
+      await client.getReplicateStatus('pred-sig', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided (getReplicateStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'starting' }),
+      } as Response);
+
+      const client = new SpriteClient(mockApiKey, 'sdxl');
+      await client.getReplicateStatus('pred-no-sig');
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+
+    it('poll loop: aborting during getReplicateStatus stops further poll fetches', async () => {
+      const controller = new AbortController();
+      const client = new SpriteClient(mockApiKey, 'sdxl');
+
+      // Simulate real fetch behavior: throw AbortError when signal is already aborted
+      vi.mocked(fetch).mockImplementation(async (_url, init) => {
+        if (init?.signal?.aborted) {
+          throw Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' });
+        }
+        return {
+          ok: true,
+          json: () => Promise.resolve({ status: 'processing' }),
+        } as Response;
+      });
+
+      const MAX_POLLS = 5;
+      let successfulPolls = 0;
+
+      for (let i = 0; i < MAX_POLLS; i++) {
+        try {
+          await client.getReplicateStatus('pred-loop', { signal: controller.signal });
+          successfulPolls++;
+          // Abort after the first successful poll
+          if (successfulPolls === 1) {
+            controller.abort();
+          }
+        } catch {
+          // AbortError thrown by the second poll stops the loop
+          break;
+        }
+      }
+
+      // Only one poll completed before abort interrupted the loop
+      expect(successfulPolls).toBe(1);
+      // Fetch-call count stopped growing well before MAX_POLLS
+      expect(vi.mocked(fetch).mock.calls.length).toBeLessThan(MAX_POLLS);
+    });
+  });
 });

--- a/web/src/lib/generate/__tests__/sunoClient.test.ts
+++ b/web/src/lib/generate/__tests__/sunoClient.test.ts
@@ -137,6 +137,39 @@ describe('SunoClient', () => {
     });
   });
 
+  describe('abort signal composition', () => {
+    it('passes a composed (pre-aborted) signal to fetch when signal param is provided', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ task_id: 'suno-signal-test' }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SunoClient({ apiKey: mockApiKey });
+      await client.createMusic({ prompt: 'ambient', signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal param is provided', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ task_id: 'suno-no-signal' }),
+      } as Response);
+
+      const client = new SunoClient({ apiKey: mockApiKey });
+      await client.createMusic({ prompt: 'jazz' });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
+  });
+
   describe('getStatus', () => {
     it('returns completed status with audioUrl', async () => {
       vi.mocked(fetch).mockResolvedValue({

--- a/web/src/lib/generate/__tests__/sunoClient.test.ts
+++ b/web/src/lib/generate/__tests__/sunoClient.test.ts
@@ -168,6 +168,37 @@ describe('SunoClient', () => {
       expect(capturedSignal).toBeInstanceOf(AbortSignal);
       expect(capturedSignal.aborted).toBe(false);
     });
+
+    it('passes a composed (pre-aborted) signal to fetch when signal is provided (getStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'processing', progress: 45 }),
+      } as Response);
+
+      const controller = new AbortController();
+      controller.abort(new Error('deadline exceeded'));
+
+      const client = new SunoClient({ apiKey: mockApiKey });
+      await client.getStatus('valid-task-id', { signal: controller.signal });
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    it('passes a timeout signal to fetch when no signal is provided (getStatus)', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 'processing', progress: 45 }),
+      } as Response);
+
+      const client = new SunoClient({ apiKey: mockApiKey });
+      await client.getStatus('valid-task-id');
+
+      const capturedSignal = vi.mocked(fetch).mock.calls[0][1]?.signal as AbortSignal;
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal.aborted).toBe(false);
+    });
   });
 
   describe('getStatus', () => {

--- a/web/src/lib/generate/abortComposition.ts
+++ b/web/src/lib/generate/abortComposition.ts
@@ -1,0 +1,19 @@
+/**
+ * Combine an optional external abort (the generation agent's per-route
+ * deadline) with a client's own per-fetch timeout. When no external signal
+ * is supplied (flag off, or the inline execute path), this returns exactly
+ * AbortSignal.timeout(timeoutMs) — byte-identical to today's behavior.
+ *
+ * Why safe: AbortSignal.any fires on the FIRST of its inputs, so per-fetch
+ * timeouts still bound each request exactly as today; the external deadline
+ * can only make cancellation earlier, never later.
+ *
+ * Requires Node ≥ 20.3 (AbortSignal.any built-in). Repo runs Node 24.
+ */
+export function composeAbortSignal(
+  external: AbortSignal | undefined,
+  timeoutMs: number,
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return external ? AbortSignal.any([external, timeout]) : timeout;
+}

--- a/web/src/lib/generate/elevenlabsClient.ts
+++ b/web/src/lib/generate/elevenlabsClient.ts
@@ -7,6 +7,7 @@
  */
 
 import { validateResourceId } from '@/lib/validation/resourceId';
+import { composeAbortSignal } from '@/lib/generate/abortComposition';
 
 export interface ElevenLabsConfig {
   apiKey: string;
@@ -15,6 +16,7 @@ export interface ElevenLabsConfig {
 export interface GenerateSfxParams {
   prompt: string;
   durationSeconds?: number;
+  signal?: AbortSignal;
 }
 
 export interface GenerateVoiceParams {
@@ -23,6 +25,7 @@ export interface GenerateVoiceParams {
   stability?: number;
   similarityBoost?: number;
   style?: number;
+  signal?: AbortSignal;
 }
 
 export interface AudioResult {
@@ -46,7 +49,7 @@ export class ElevenLabsClient {
         text: params.prompt,
         duration_seconds: params.durationSeconds || 5,
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -84,7 +87,7 @@ export class ElevenLabsClient {
           style: params.style ?? 0,
         },
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {

--- a/web/src/lib/generate/meshyClient.ts
+++ b/web/src/lib/generate/meshyClient.ts
@@ -7,6 +7,7 @@
  */
 
 import { validateResourceId } from '@/lib/validation/resourceId';
+import { composeAbortSignal } from '@/lib/generate/abortComposition';
 
 export interface MeshyConfig {
   apiKey: string;
@@ -17,11 +18,13 @@ export interface TextTo3DParams {
   artStyle?: string;
   negativePrompt?: string;
   quality?: 'standard' | 'high';
+  signal?: AbortSignal;
 }
 
 export interface ImageTo3DParams {
   imageBase64: string;
   prompt?: string;
+  signal?: AbortSignal;
 }
 
 export interface TextToTextureParams {
@@ -30,6 +33,7 @@ export interface TextToTextureParams {
   style?: string;
   tiling?: boolean;
   generateMaps?: Record<string, boolean>;
+  signal?: AbortSignal;
 }
 
 export interface TaskStatus {
@@ -67,7 +71,7 @@ export class MeshyClient {
         topology: 'triangle',
         should_remesh: true,
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -94,7 +98,7 @@ export class MeshyClient {
         topology: 'triangle',
         should_remesh: true,
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -106,7 +110,7 @@ export class MeshyClient {
     return { taskId: data.result };
   }
 
-  async getTaskStatus(taskId: string): Promise<TaskStatus> {
+  async getTaskStatus(taskId: string, opts?: { signal?: AbortSignal }): Promise<TaskStatus> {
     validateResourceId(taskId);
     const safeTaskId = encodeURIComponent(taskId);
     const url = new URL(`/openapi/v2/text-to-3d/${safeTaskId}`, 'https://api.meshy.ai');
@@ -115,7 +119,7 @@ export class MeshyClient {
       headers: {
         'Authorization': `Bearer ${this.config.apiKey}`,
       },
-      signal: AbortSignal.timeout(10000),
+      signal: composeAbortSignal(opts?.signal, 10000),
     });
 
     if (!response.ok) {
@@ -146,7 +150,7 @@ export class MeshyClient {
         tiling: params.tiling ?? true,
         ...(params.generateMaps && { generate_maps: params.generateMaps }),
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -158,7 +162,7 @@ export class MeshyClient {
     return { taskId: data.result };
   }
 
-  async getTextureStatus(taskId: string): Promise<TextureStatus> {
+  async getTextureStatus(taskId: string, opts?: { signal?: AbortSignal }): Promise<TextureStatus> {
     validateResourceId(taskId);
     const safeTaskId = encodeURIComponent(taskId);
     const url = new URL(`/openapi/v2/text-to-texture/${safeTaskId}`, 'https://api.meshy.ai');
@@ -167,7 +171,7 @@ export class MeshyClient {
       headers: {
         'Authorization': `Bearer ${this.config.apiKey}`,
       },
-      signal: AbortSignal.timeout(10000),
+      signal: composeAbortSignal(opts?.signal, 10000),
     });
 
     if (!response.ok) {

--- a/web/src/lib/generate/pixelArtClient.ts
+++ b/web/src/lib/generate/pixelArtClient.ts
@@ -4,6 +4,7 @@ import 'server-only';
 
 import { REPLICATE_MODEL_SDXL } from '@/lib/ai/models';
 import { validateResourceId } from '@/lib/validation/resourceId';
+import { composeAbortSignal } from '@/lib/generate/abortComposition';
 export type { PixelArtStyle } from '@/lib/config/providers';
 import type { PixelArtStyle } from '@/lib/config/providers';
 export type PixelArtProvider = 'openai' | 'replicate';
@@ -13,6 +14,7 @@ interface GenerateParams {
   style: PixelArtStyle;
   size: 512 | 1024;
   referenceImage?: string; // base64
+  signal?: AbortSignal;
 }
 
 interface OpenAIResult {
@@ -50,12 +52,12 @@ export class PixelArtClient {
     const enhancedPrompt = buildPixelArtPrompt(params.prompt, params.style);
 
     if (this.provider === 'openai') {
-      return this.generateDalle(enhancedPrompt, params.size);
+      return this.generateDalle(enhancedPrompt, params.size, params.signal);
     }
-    return this.generateReplicate(enhancedPrompt, params.size);
+    return this.generateReplicate(enhancedPrompt, params.size, params.signal);
   }
 
-  private async generateDalle(prompt: string, _size: 512 | 1024): Promise<OpenAIResult> {
+  private async generateDalle(prompt: string, _size: 512 | 1024, signal?: AbortSignal): Promise<OpenAIResult> {
     // DALL-E 3 only supports 1024x1024, 1024x1792, and 1792x1024.
     // Always request 1024x1024 and let the caller downscale if needed.
     const response = await fetch('https://api.openai.com/v1/images/generations', {
@@ -71,7 +73,7 @@ export class PixelArtClient {
         size: '1024x1024',
         response_format: 'b64_json',
       }),
-      signal: AbortSignal.timeout(60_000),
+      signal: composeAbortSignal(signal, 60_000),
     });
 
     if (!response.ok) {
@@ -83,7 +85,7 @@ export class PixelArtClient {
     return { base64: data.data[0].b64_json };
   }
 
-  private async generateReplicate(prompt: string, _size: 512 | 1024): Promise<ReplicateResult> {
+  private async generateReplicate(prompt: string, _size: 512 | 1024, signal?: AbortSignal): Promise<ReplicateResult> {
     const response = await fetch('https://api.replicate.com/v1/predictions', {
       method: 'POST',
       headers: {
@@ -100,7 +102,7 @@ export class PixelArtClient {
           height: 1024,
         },
       }),
-      signal: AbortSignal.timeout(30_000),
+      signal: composeAbortSignal(signal, 30_000),
     });
 
     if (!response.ok) {
@@ -112,7 +114,7 @@ export class PixelArtClient {
     return { predictionId: data.id, status: data.status };
   }
 
-  async getReplicateStatus(predictionId: string): Promise<{ status: string; output?: string[] }> {
+  async getReplicateStatus(predictionId: string, opts?: { signal?: AbortSignal }): Promise<{ status: string; output?: string[] }> {
     // predictionId is interpolated into the Replicate prediction URL. Validate it
     // against the safe-id allowlist and percent-encode before building the URL so a
     // crafted jobId (path traversal / SSRF — e.g. `../models/foo`) can't redirect the
@@ -125,7 +127,7 @@ export class PixelArtClient {
     const response = await fetch(url, {
       method: 'GET',
       headers: { 'Authorization': `Bearer ${this.apiKey}` },
-      signal: AbortSignal.timeout(15_000),
+      signal: composeAbortSignal(opts?.signal, 15_000),
     });
     if (!response.ok) throw new Error(`Replicate status error ${response.status}`);
     const data = await response.json();

--- a/web/src/lib/generate/spriteClient.ts
+++ b/web/src/lib/generate/spriteClient.ts
@@ -6,6 +6,7 @@
 
 import { validateResourceId } from '@/lib/validation/resourceId';
 import { REPLICATE_MODEL_SDXL } from '@/lib/ai/models';
+import { composeAbortSignal } from '@/lib/generate/abortComposition';
 
 export interface SpriteGenerateParams {
   prompt: string;
@@ -13,6 +14,7 @@ export interface SpriteGenerateParams {
   size: '32x32' | '64x64' | '128x128' | '256x256' | '512x512' | '1024x1024';
   provider?: 'auto' | 'dalle3' | 'sdxl';
   removeBackground?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface SpriteSheetParams {
@@ -20,12 +22,14 @@ export interface SpriteSheetParams {
   frameCount: number;
   style?: 'pixel-art' | 'hand-drawn' | 'vector' | 'realistic';
   size: '32x32' | '64x64' | '128x128' | '256x256';
+  signal?: AbortSignal;
 }
 
 export interface TilesetParams {
   prompt: string;
   tileSize: 16 | 32 | 48 | 64;
   gridSize: '4x4' | '8x8' | '16x16';
+  signal?: AbortSignal;
 }
 
 export interface GenerationResult {
@@ -65,7 +69,7 @@ export class SpriteClient {
           : params.size,
         quality: 'standard',
       }),
-      signal: AbortSignal.timeout(60000),
+      signal: composeAbortSignal(params.signal, 60000),
     });
 
     if (!response.ok) {
@@ -101,7 +105,7 @@ export class SpriteClient {
           guidance_scale: 7.5,
         },
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -152,7 +156,7 @@ export class SpriteClient {
           guidance_scale: 8,
         },
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -186,7 +190,7 @@ export class SpriteClient {
           guidance_scale: 9,
         },
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -201,7 +205,7 @@ export class SpriteClient {
     };
   }
 
-  async removeBackground(imageUrl: string): Promise<{ resultUrl: string }> {
+  async removeBackground(imageUrl: string, opts?: { signal?: AbortSignal }): Promise<{ resultUrl: string }> {
     const response = await fetch('https://api.remove.bg/v1.0/removebg', {
       method: 'POST',
       headers: {
@@ -211,7 +215,7 @@ export class SpriteClient {
         image_url: imageUrl,
         size: 'auto',
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(opts?.signal, 30000),
     });
 
     if (!response.ok) {
@@ -274,7 +278,7 @@ export class SpriteClient {
     });
   }
 
-  async getReplicateStatus(predictionId: string): Promise<{ status: string; output?: string[] }> {
+  async getReplicateStatus(predictionId: string, opts?: { signal?: AbortSignal }): Promise<{ status: string; output?: string[] }> {
     validateResourceId(predictionId);
     const safePredictionId = encodeURIComponent(predictionId);
     const url = new URL(`/v1/predictions/${safePredictionId}`, 'https://api.replicate.com');
@@ -283,7 +287,7 @@ export class SpriteClient {
       headers: {
         'Authorization': `Bearer ${this.apiKey}`,
       },
-      signal: AbortSignal.timeout(10000),
+      signal: composeAbortSignal(opts?.signal, 10000),
     });
 
     if (!response.ok) {

--- a/web/src/lib/generate/sunoClient.ts
+++ b/web/src/lib/generate/sunoClient.ts
@@ -7,6 +7,7 @@
  */
 
 import { validateResourceId } from '@/lib/validation/resourceId';
+import { composeAbortSignal } from '@/lib/generate/abortComposition';
 
 export interface SunoConfig {
   apiKey: string;
@@ -16,6 +17,7 @@ export interface CreateMusicParams {
   prompt: string;
   durationSeconds?: number;
   instrumental?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface MusicStatus {
@@ -42,7 +44,7 @@ export class SunoClient {
         duration_seconds: params.durationSeconds || 30,
         instrumental: params.instrumental ?? true,
       }),
-      signal: AbortSignal.timeout(30000),
+      signal: composeAbortSignal(params.signal, 30000),
     });
 
     if (!response.ok) {
@@ -54,7 +56,7 @@ export class SunoClient {
     return { taskId: data.task_id || data.id };
   }
 
-  async getStatus(taskId: string): Promise<MusicStatus> {
+  async getStatus(taskId: string, opts?: { signal?: AbortSignal }): Promise<MusicStatus> {
     validateResourceId(taskId);
     const safeTaskId = encodeURIComponent(taskId);
     const url = new URL(`/v1/generation/${safeTaskId}`, 'https://api.suno.ai');
@@ -63,7 +65,7 @@ export class SunoClient {
       headers: {
         'Authorization': `Bearer ${this.config.apiKey}`,
       },
-      signal: AbortSignal.timeout(10000),
+      signal: composeAbortSignal(opts?.signal, 10000),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Adds `composeAbortSignal(external, timeoutMs)` (`web/src/lib/generate/abortComposition.ts`) — combines the generation agent's per-route deadline with each client's historical per-fetch timeout via `AbortSignal.any`; flag-off is byte-identical to today's `AbortSignal.timeout(N)` literals. Node built-in, no new dependencies.
- Threads abort signals end-to-end: all 5 provider clients (meshy, suno, elevenlabs, sprite, pixel-art — every fetch site, including status methods and the sprite client's internal Replicate poll loop) accept an optional external signal, and all 12 `/api/generate/*` routes forward `ctx.abortSignal` (plus `abortSignal` at the two `generateText` sites in localize/pacing). A flag-on timeout now cancels in-flight provider work instead of orphaning it, and `GenerationTimeoutError` surfaces as a provider failure so the refund path runs.
- Fixes a live product bug: `sprite-sheet` and `tileset-gen` responses now return `usageId`, restoring client-side refunds (`useGenerationPolling`'s `triggerRefund` silently no-op'd without it). Additive optional field, documented in `docs/api/openapi.json`; both routes added to the `sentry-regressions` ASYNC_ROUTES pin.
- Closes every factory contract-test gap from the spec (tests 1–20): filtered-prompt substitution, pricing NaN guard, cache-HIT-is-free, refund-failure resilience, auth-before-rate-limit, dormant `after()`, `maxDuration` parity pin, end-to-end flag-on timeout → refund → opaque 500, per-route signal forwarding, and the `vi.mock` relative-path landmine (`@/lib/api/responseCache` alias).
- Boy Scout: `voice/batch` per-item errors no longer echo raw provider `err.message` to clients (Sentry still gets the full error); follow-ups tracked in #8892 (durable execution) and #8893 (voice/batch hardening). ADR + changeset included.

Spec: `specs/2026-07-03-generation-agent-spof-completion.md`. Flag `USE_GENERATION_AGENT` remains default OFF; no behavior change until enabled.

Closes #8826 (PF-916)

## Test plan
- [x] `npx eslint --max-warnings 0 .` clean
- [x] `npx tsc --noEmit` clean
- [x] Full vitest: 16,222 passed / 1 pre-existing skip; +93-line status-method signal pins re-run green after
- [x] `route-integration.test.ts` green in BOTH flag states (agent-path re-run block)
- [x] `jq empty docs/api/openapi.json` + `scripts/check-openapi-route-sync.sh` — all 98 routes documented/allowlisted
- [x] 5-reviewer board (architect, security, dx, ux, test): all PASS on final tree