### PR TITLE
ci(dependabot): ignore piecemeal bevy* minor/major bumps until coordinated 0.19 migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,19 @@ updates:
     labels:
       - dependencies
       - rust
+    ignore:
+      # Bevy releases (0.18 → 0.19) must land as ONE coordinated migration across
+      # bevy + every bevy_* ecosystem crate (#8887). A piecemeal per-crate bump
+      # (e.g. bevy_math 0.19.0 alone while the workspace pins bevy 0.18.1) leaves
+      # BOTH versions in engine/Cargo.lock → type mismatches at the
+      # transform-gizmo-fork/engine boundary → Quality Gates / WASM Build fails.
+      # Shipped live as #8897/#8898/#8899 (all red). Bevy is 0.x, so 0.18 → 0.19
+      # is `semver-minor`; patch updates (0.18.1 → 0.18.2) still flow. Remove
+      # this rule as part of the coordinated 0.19 migration (#8887).
+      - dependency-name: "bevy*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   # GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Adds an `ignore` rule to the cargo ecosystem block in `.github/dependabot.yml`: `bevy*` at `version-update:semver-minor` and `version-update:semver-major`. Patch updates (0.18.1 → 0.18.2) still flow.
- Why: Dependabot opened three per-crate Bevy 0.19 bumps (#8897 bevy_math, #8898 bevy_image, #8899 bevy_reflect) while the engine workspace pins bevy 0.18.1. Each leaves BOTH 0.18.x and 0.19.0 in `engine/Cargo.lock` → type mismatches at the transform-gizmo-fork/engine boundary → Quality Gates / WASM Build red on all three. Without an ignore rule the weekly cargo run recreates them on every future 0.19.x release.
- Bevy is 0.x, so 0.18 → 0.19 maps to `semver-minor` — the rule blocks exactly the piecemeal-hazard class and nothing else. Security-update PRs are NOT suppressed (`update-types` ignores only affect version updates, per GitHub docs).
- Removal path: lift the rule as part of the coordinated Bevy 0.19 migration (#8887), which is blocked on bevy_rapier 0.19 support.

## Merge prerequisite (from infra-devops review)
Dependabot does **not** auto-close open PRs when an ignore rule lands. **Close #8897 and #8898 manually** (#8899 is already closed) — until then an accidental merge of either reproduces the exact WASM-build breakage this rule prevents.

Closes #8905 (PF-942)

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — valid YAML, ignore block parses as expected
- [x] Rule scoped to the cargo ecosystem only — npm and github-actions blocks untouched
- [x] Security review: security-update PRs unaffected by `update-types` ignore (verified against current GitHub docs)
- [x] Infra review: enum strings valid v2 schema; `bevy*` glob covers bare `bevy` + all `bevy_*` (no gh-aw-style bare-name pitfall — crate names have no path separators)
- [ ] After merge: next weekly cargo run opens no bevy* 0.19 PRs; patch-level bevy* PRs still appear when available