### PR TITLE
ci(dependabot): ignore piecemeal egui-family minor/major bumps in /engine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,31 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-major"
+      # egui-family crates (egui/emath/epaint/ecolor) are pinned as a matched
+      # set by the local transform-gizmo fork (.transform-gizmo-fork/Cargo.toml,
+      # reached via engine's path dependency — Dependabot edits it when relocking
+      # /engine). A piecemeal bump (emath 0.35 alone in #8908; ecolor in #8869)
+      # leaves two versions in engine/Cargo.lock → E0308 `expected epaint::Pos2,
+      # found emath::Pos2` at the fork boundary → WASM Build red. Like bevy*,
+      # they are 0.x crates, so 0.34 → 0.35 is `semver-minor`; patch updates
+      # still flow. The set moves together when the fork moves — as part of the
+      # coordinated Bevy 0.19 migration (#8887). Tracking: #8911 (PF-944).
+      - dependency-name: "egui*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "emath"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "epaint"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
+      - dependency-name: "ecolor"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   # GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary
- Extends the #8906 pattern to the egui family: `egui*`, `emath`, `epaint`, `ecolor` are now ignored for `semver-minor`/`semver-major` cargo updates (patch updates still flow).
- The transform-gizmo fork (`.transform-gizmo-fork/Cargo.toml`) pins these four as a matched 0.34 set. Dependabot's `/engine` updater follows the path dependency into the fork's manifest and bumps them piecemeal — emath 0.34→0.35 in #8908 (red: `E0308: expected epaint::Pos2, found emath::Pos2`), ecolor previously in #8869 — leaving two versions in `engine/Cargo.lock` and failing WASM Build + E2E Engine Smoke Gate.
- The set moves together when the fork moves, as part of the coordinated Bevy 0.19 migration (#8887). The rule documents its own removal path.
- Config-only change: `skip changeset`.

Closes #8911 (PF-944)

## Test plan
- [x] `dependabot.yml` parses (yaml.safe_load) — cargo ignores now `['bevy*', 'egui*', 'emath', 'epaint', 'ecolor']`
- [ ] After merge: #8908 is closeable and Dependabot's next cargo run opens no egui-family minor/major PRs