### PR TITLE
ci(deps): ignore eslint semver-major until plugin ecosystem supports ESLint 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,21 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # eslint 10 is un-mergeable until the plugin ecosystem catches up.
+      # eslint-plugin-react 7.37.5 (latest, 2025-04, peer eslint ^3..^9.7) still
+      # calls the removed context.getFilename() and crashes every rule under
+      # ESLint 10 — reproduced on #8914's Lint job (TypeError at
+      # eslint-plugin-react/lib/util/version.js:31). eslint-config-next 16.2.10
+      # hard-depends on eslint-plugin-react ^7.37.0, so no config change on our
+      # side avoids it; eslint-plugin-jsx-a11y 6.10.2 and eslint-plugin-import
+      # 2.32.0 (both latest) also cap peers at eslint ^9. 9.x patch/minor
+      # updates still flow (9.39.4 is npm's `maintenance` dist-tag). Remove
+      # when jsx-eslint/eslint-plugin-react#3977 ships an eslint-10 release AND
+      # eslint-config-next adopts it (vercel/next.js#89764). Tracking: #8917
+      # (PF-945).
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   # Rust/Cargo dependencies (engine)
   - package-ecosystem: cargo


### PR DESCRIPTION
## Summary
- Add `eslint` semver-major to the npm Dependabot ignore list — ESLint 10 is un-mergeable today and #8914 would otherwise churn on every 10.x release
- `eslint-plugin-react` 7.37.5 (latest, published 2025-04) still calls the removed `context.getFilename()` and crashes every rule under ESLint 10 — reproduced in #8914's own Lint job (`TypeError` at `eslint-plugin-react/lib/util/version.js:31`, exit 2 before any findings)
- `eslint-config-next` 16.2.10 hard-depends on `eslint-plugin-react ^7.37.0`, so no config or code change on our side avoids it; `eslint-plugin-jsx-a11y` 6.10.2 and `eslint-plugin-import` 2.32.0 (both latest) also cap peers at eslint ^9
- 9.x patch/minor updates still flow via the minor-and-patch group; eslint 9.39.4 is npm's `maintenance` dist-tag and remains supported
- Removal path documented in the rule comment: remove when jsx-eslint/eslint-plugin-react#3977 ships an eslint-10-compatible release AND eslint-config-next adopts it (vercel/next.js#89764)

Closes #8917 (PF-945)

## Test plan
- [x] `yaml.safe_load` parses; npm block ignore list = `[('eslint', ['version-update:semver-major'])]`
- [x] Same ignore-rule shape as the merged egui-family rule (#8912) — exact-match `dependency-name: "eslint"` does not glob-match eslint-config-next / eslint-plugin-* (those still update)
- [ ] After merge: close #8914 unmerged; verify Dependabot's next npm run opens no new eslint 10.x PR